### PR TITLE
Add runtime error logging and loading indicator for debugging

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,30 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'core/theme/flit_theme.dart';
 import 'features/auth/login_screen.dart';
 
+/// Collected runtime errors for the debug overlay.
+final List<String> _errorLog = [];
+
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Capture Flutter framework errors (widget build failures, etc.)
+  FlutterError.onError = (details) {
+    FlutterError.presentError(details);
+    _errorLog.add('[FlutterError] ${details.exceptionAsString()}');
+  };
+
+  // Capture async / platform errors that escape the framework.
+  PlatformDispatcher.instance.onError = (error, stack) {
+    _errorLog.add('[PlatformError] $error');
+    return true; // prevent crash, keep app alive
+  };
+
   runApp(
     const ProviderScope(
       child: FlitApp(),
@@ -22,7 +41,91 @@ class FlitApp extends StatelessWidget {
       title: 'Flit',
       debugShowCheckedModeBanner: false,
       theme: FlitTheme.dark,
+      builder: (context, child) {
+        // Wrap the entire app in an error boundary with debug overlay.
+        return Stack(
+          children: [
+            child ?? const SizedBox.shrink(),
+            if (kDebugMode) const _DebugErrorOverlay(),
+          ],
+        );
+      },
       home: const LoginScreen(),
+    );
+  }
+}
+
+/// Floating debug overlay that shows runtime errors on screen.
+/// Only visible in debug mode and when errors have been captured.
+class _DebugErrorOverlay extends StatefulWidget {
+  const _DebugErrorOverlay();
+
+  @override
+  State<_DebugErrorOverlay> createState() => _DebugErrorOverlayState();
+}
+
+class _DebugErrorOverlayState extends State<_DebugErrorOverlay> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_errorLog.isEmpty) return const SizedBox.shrink();
+
+    return Positioned(
+      bottom: 16,
+      left: 16,
+      right: 16,
+      child: SafeArea(
+        child: Material(
+          color: Colors.red.shade900.withAlpha(230),
+          borderRadius: BorderRadius.circular(8),
+          child: InkWell(
+            onTap: () => setState(() => _expanded = !_expanded),
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.error, color: Colors.white, size: 18),
+                      const SizedBox(width: 8),
+                      Text(
+                        '${_errorLog.length} error(s) — tap to ${_expanded ? 'collapse' : 'expand'}',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 13,
+                          fontWeight: FontWeight.bold,
+                          decoration: TextDecoration.none,
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (_expanded) ...[
+                    const SizedBox(height: 8),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxHeight: 200),
+                      child: SingleChildScrollView(
+                        child: Text(
+                          _errorLog.join('\n\n'),
+                          style: const TextStyle(
+                            color: Colors.white70,
+                            fontSize: 11,
+                            fontFamily: 'monospace',
+                            decoration: TextDecoration.none,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -36,9 +36,90 @@
       overflow: hidden;
       background-color: #1A2A32;
     }
+    #loading {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100%;
+      flex-direction: column;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      color: #F0E8DC;
+    }
+    #loading .spinner {
+      width: 36px;
+      height: 36px;
+      border: 3px solid #264050;
+      border-top-color: #D4654A;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    #loading .label {
+      margin-top: 14px;
+      font-size: 13px;
+      opacity: 0.6;
+      letter-spacing: 2px;
+    }
+    #error-box {
+      display: none;
+      position: fixed;
+      bottom: 16px;
+      left: 16px;
+      right: 16px;
+      max-height: 40vh;
+      overflow-y: auto;
+      background: #7a1616ee;
+      color: #fff;
+      font-family: monospace;
+      font-size: 12px;
+      padding: 14px;
+      border-radius: 8px;
+      white-space: pre-wrap;
+      word-break: break-word;
+      z-index: 99999;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
   </style>
 </head>
 <body>
+  <!-- Loading indicator (hidden once Flutter renders) -->
+  <div id="loading">
+    <div class="spinner"></div>
+    <div class="label">LOADING FLIT...</div>
+  </div>
+
+  <!-- Error display for JS-level errors (before Flutter loads) -->
+  <div id="error-box"></div>
+
+  <script>
+    // Capture JS-level errors and display them visually.
+    var errorBox = document.getElementById('error-box');
+    var errors = [];
+    function showError(msg) {
+      errors.push(msg);
+      errorBox.style.display = 'block';
+      errorBox.textContent = errors.join('\n\n');
+    }
+
+    window.addEventListener('error', function(e) {
+      showError('[JS Error] ' + e.message + ' (' + e.filename + ':' + e.lineno + ')');
+    });
+    window.addEventListener('unhandledrejection', function(e) {
+      showError('[Promise Rejection] ' + (e.reason || e));
+    });
+
+    // After 10 seconds, if loading is still visible, show a hint.
+    setTimeout(function() {
+      var loading = document.getElementById('loading');
+      if (loading && loading.style.display !== 'none') {
+        var label = loading.querySelector('.label');
+        if (label) {
+          label.textContent = 'Still loading... check console for errors.';
+          label.style.color = '#D4A944';
+        }
+      }
+    }, 10000);
+  </script>
+
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
`Two` layers of error capture to diagnose the blue screen:

1. web/index.html: Loading spinner with 10s timeout warning, JS-level error/rejection handlers that display errors visually in a red overlay at the bottom of the screen.

2. lib/main.dart: FlutterError.onError and PlatformDispatcher.onError handlers that catch Dart-side crashes and display them in a debug overlay (debug mode only). Errors are kept alive instead of crashing the app, so the error messages remain readable.

Next launch should show either the login screen (working) or visible error messages explaining what's failing.

https://claude.ai/code/session_01CPLAGkWQEHxXeTB7QjiXtm