### PR TITLE
Fix flutter.js API: use loadEntrypoint() for Flutter 3.16

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -122,7 +122,18 @@
       fl.src = 'flutter.js';
       fl.defer = true;
       fl.onload = function() {
-        _flutter.loader.load();
+        // Flutter 3.22+ uses load(), 3.16-3.21 uses loadEntrypoint().
+        if (_flutter.loader.load) {
+          _flutter.loader.load();
+        } else {
+          _flutter.loader.loadEntrypoint({
+            onEntrypointLoaded: function(engineInitializer) {
+              engineInitializer.initializeEngine().then(function(appRunner) {
+                appRunner.runApp();
+              });
+            }
+          });
+        }
       };
       fl.onerror = function() {
         showError('Could not load Flutter engine (neither flutter_bootstrap.js nor flutter.js found).');


### PR DESCRIPTION
Error was: _flutter.loader.load is not a function
Flutter 3.16 exposes loadEntrypoint(), not load(). Now detects which API is available and uses the correct one.

https://claude.ai/code/session_01CPLAGkWQEHxXeTB7QjiXtm