### PR TITLE
Fix HomeScreen crash: replace Size.infinite with SizedBox.expand

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -228,15 +228,18 @@ class _StaticMapBackground extends StatelessWidget {
   const _StaticMapBackground();
 
   @override
-  Widget build(BuildContext context) => CustomPaint(
-        painter: _MapBackgroundPainter(),
-        size: Size.infinite,
+  Widget build(BuildContext context) => SizedBox.expand(
+        child: CustomPaint(
+          painter: _MapBackgroundPainter(),
+        ),
       );
 }
 
 class _MapBackgroundPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
+    if (size.isEmpty || !size.isFinite) return;
+
     // Ocean gradient
     final oceanGradient = Paint()
       ..shader = const LinearGradient(


### PR DESCRIPTION
The _StaticMapBackground used CustomPaint with size: Size.infinite, which crashes shader creation on web when createShader receives infinite Rect dimensions. Replaced with SizedBox.expand so the widget fills its Stack parent with actual screen dimensions.

Also added a size guard in the painter to bail early if it ever receives empty or non-finite dimensions.

https://claude.ai/code/session_01CPLAGkWQEHxXeTB7QjiXtm