### PR TITLE
Fix game startup crash: white flash then revert to login

### DIFF
--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as developer;
 import 'dart:math';
 
 import 'package:flame/events.dart';
@@ -89,7 +90,15 @@ class FlitGame extends FlameGame
     _worldPosition = Vector2(0, 0); // Center of map
     _heading = -pi / 2; // Facing north
 
-    onGameReady?.call();
+    // Notify the host widget that the engine is ready.  Wrapped in try/catch
+    // so a failure in the callback doesn't break the Flame loading future
+    // (which would leave the GameWidget in an unrecoverable error state and
+    // produce the white‑flash-then-crash behaviour).
+    try {
+      onGameReady?.call();
+    } catch (e, st) {
+      developer.log('onGameReady callback failed', error: e, stackTrace: st);
+    }
   }
 
   @override
@@ -146,7 +155,7 @@ class FlitGame extends FlameGame
 
   @override
   KeyEventResult onKeyEvent(
-    RawKeyEvent event,
+    KeyEvent event,
     Set<LogicalKeyboardKey> keysPressed,
   ) {
     final superResult = super.onKeyEvent(event, keysPressed);
@@ -164,7 +173,7 @@ class FlitGame extends FlameGame
 
     _plane.setTurnDirection(direction);
 
-    if (event is RawKeyDownEvent) {
+    if (event is KeyDownEvent) {
       if (event.logicalKey == LogicalKeyboardKey.space ||
           event.logicalKey == LogicalKeyboardKey.arrowUp ||
           event.logicalKey == LogicalKeyboardKey.arrowDown) {


### PR DESCRIPTION
Three root causes identified and fixed:

1. FlitGame.onLoad() called onGameReady synchronously – any exception in the callback (e.g. during GameSession.random or setState) propagated through the Flame loading future, putting the GameWidget in an unrecoverable error state that flashed white. Now wrapped in try/catch and the game session start is deferred via addPostFrameCallback to decouple it from the engine loading lifecycle.

2. Navigator double-pop used the dialog's BuildContext for both pops. After the first pop dismissed the dialog, Navigator.of(dialogContext) operated on a deactivated context, corrupting the navigation stack on subsequent game starts. Fixed to use the PlayScreen's own context for the second pop.

3. GameWidget had no loadingBuilder or errorBuilder, so before the Flame engine finished onLoad the widget rendered its default blank/white canvas (the visible "white flash"). Added dark-themed builders matching the app aesthetic and a user-facing error screen with a back button.

Also fixed: onKeyEvent used deprecated RawKeyEvent/RawKeyDownEvent instead of KeyEvent/KeyDownEvent (required for Flame ^1.14.0 + Flutter 3.16+).

https://claude.ai/code/session_01RCGfmkZSAytbzhWirQxKSa