### PR TITLE
Fix keyboard event type mismatch in FlitGame.onKeyEvent

### DIFF
--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -155,7 +155,7 @@ class FlitGame extends FlameGame
 
   @override
   KeyEventResult onKeyEvent(
-    KeyEvent event,
+    RawKeyEvent event,
     Set<LogicalKeyboardKey> keysPressed,
   ) {
     final superResult = super.onKeyEvent(event, keysPressed);
@@ -173,7 +173,7 @@ class FlitGame extends FlameGame
 
     _plane.setTurnDirection(direction);
 
-    if (event is KeyDownEvent) {
+    if (event is RawKeyDownEvent) {
       if (event.logicalKey == LogicalKeyboardKey.space ||
           event.logicalKey == LogicalKeyboardKey.arrowUp ||
           event.logicalKey == LogicalKeyboardKey.arrowDown) {


### PR DESCRIPTION
Flame 1.14.x's HasKeyboardHandlerComponents expects RawKeyEvent, not the newer KeyEvent API. Changed parameter type from KeyEvent to RawKeyEvent and the type check from KeyDownEvent to RawKeyDownEvent.

https://claude.ai/code/session_01JrhpH6HVMizmJMgD2p9QCG