### PR TITLE
Fix license/avatar UX issues and add new features

### DIFF
--- a/lib/data/models/avatar_config.dart
+++ b/lib/data/models/avatar_config.dart
@@ -1,3 +1,10 @@
+/// Avatar body type. Affects build proportions and facial features.
+/// All options are free.
+enum AvatarBodyType {
+  masculine,
+  feminine,
+}
+
 /// Avatar face shapes. All free.
 enum AvatarFace {
   round,
@@ -100,6 +107,7 @@ enum AvatarCompanion {
 /// chosen so every new player has a complete look out of the box.
 class AvatarConfig {
   const AvatarConfig({
+    this.bodyType = AvatarBodyType.masculine,
     this.face = AvatarFace.round,
     this.skin = AvatarSkin.medium,
     this.eyes = AvatarEyes.round,
@@ -111,6 +119,7 @@ class AvatarConfig {
     this.companion = AvatarCompanion.none,
   });
 
+  final AvatarBodyType bodyType;
   final AvatarFace face;
   final AvatarSkin skin;
   final AvatarEyes eyes;
@@ -126,6 +135,7 @@ class AvatarConfig {
   // ---------------------------------------------------------------------------
 
   AvatarConfig copyWith({
+    AvatarBodyType? bodyType,
     AvatarFace? face,
     AvatarSkin? skin,
     AvatarEyes? eyes,
@@ -137,6 +147,7 @@ class AvatarConfig {
     AvatarCompanion? companion,
   }) =>
       AvatarConfig(
+        bodyType: bodyType ?? this.bodyType,
         face: face ?? this.face,
         skin: skin ?? this.skin,
         eyes: eyes ?? this.eyes,
@@ -222,11 +233,39 @@ class AvatarConfig {
       accessoryPrice(accessory) +
       companionPrice(companion);
 
+  /// Rarity tier based on [totalCost].
+  ///
+  ///   0         → Common   (luck bonus 0)
+  ///   1-999     → Uncommon (luck bonus 1)
+  ///   1000-4999 → Rare     (luck bonus 2)
+  ///   5000-14999→ Epic     (luck bonus 3)
+  ///   15000+    → Legendary(luck bonus 5)
+  String get rarityTier {
+    final cost = totalCost;
+    if (cost >= 15000) return 'Legendary';
+    if (cost >= 5000) return 'Epic';
+    if (cost >= 1000) return 'Rare';
+    if (cost >= 1) return 'Uncommon';
+    return 'Common';
+  }
+
+  /// Luck bonus for licence rerolls based on avatar rarity.
+  /// Higher values give better odds when rolling licence stats.
+  int get luckBonus {
+    final cost = totalCost;
+    if (cost >= 15000) return 5;
+    if (cost >= 5000) return 3;
+    if (cost >= 1000) return 2;
+    if (cost >= 1) return 1;
+    return 0;
+  }
+
   // ---------------------------------------------------------------------------
   // Serialisation
   // ---------------------------------------------------------------------------
 
   Map<String, dynamic> toJson() => {
+        'body_type': bodyType.name,
         'face': face.name,
         'skin': skin.name,
         'eyes': eyes.name,
@@ -239,6 +278,10 @@ class AvatarConfig {
       };
 
   factory AvatarConfig.fromJson(Map<String, dynamic> json) => AvatarConfig(
+        bodyType: AvatarBodyType.values.firstWhere(
+          (v) => v.name == json['body_type'],
+          orElse: () => AvatarBodyType.masculine,
+        ),
         face: AvatarFace.values.firstWhere(
           (v) => v.name == json['face'],
           orElse: () => AvatarFace.round,
@@ -281,6 +324,7 @@ class AvatarConfig {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is AvatarConfig &&
+          bodyType == other.bodyType &&
           face == other.face &&
           skin == other.skin &&
           eyes == other.eyes &&
@@ -293,6 +337,7 @@ class AvatarConfig {
 
   @override
   int get hashCode => Object.hash(
+        bodyType,
         face,
         skin,
         eyes,

--- a/lib/data/providers/account_provider.dart
+++ b/lib/data/providers/account_provider.dart
@@ -197,6 +197,9 @@ class AccountNotifier extends StateNotifier<AccountState> {
   // --- Pilot License ---
 
   /// Reroll the pilot license. Returns true if affordable.
+  ///
+  /// The avatar's [luckBonus] is automatically applied — rarer avatars
+  /// grant advantage rolls for better licence stats.
   bool rerollLicense({Set<String> lockedStats = const {}, bool lockType = false}) {
     // Calculate cost
     var cost = PilotLicense.rerollAllCost;
@@ -211,6 +214,7 @@ class AccountNotifier extends StateNotifier<AccountState> {
         state.license,
         lockedStats: lockedStats,
         lockType: lockType,
+        luckBonus: state.avatar.luckBonus,
       ),
     );
     return true;

--- a/lib/features/avatar/avatar_editor_screen.dart
+++ b/lib/features/avatar/avatar_editor_screen.dart
@@ -61,6 +61,17 @@ class _AvatarCategory {
 }
 
 const List<_AvatarCategory> _categories = [
+  // -- Body Type --
+  _AvatarCategory(
+    label: 'Body',
+    icon: Icons.accessibility_new,
+    configKey: 'bodyType',
+    parts: [
+      _AvatarPart(id: 'body_masculine', name: 'Boy', icon: Icons.male),
+      _AvatarPart(id: 'body_feminine', name: 'Girl', icon: Icons.female),
+    ],
+  ),
+
   // -- Face --
   _AvatarCategory(
     label: 'Face',
@@ -388,6 +399,8 @@ class _AvatarEditorScreenState extends ConsumerState<AvatarEditorScreen> {
   /// Returns the currently selected part id for the given [categoryKey].
   String _selectedPartForCategory(String categoryKey) {
     switch (categoryKey) {
+      case 'bodyType':
+        return 'body_${_config.bodyType.name}';
       case 'face':
         return 'face_${_config.face.name}';
       case 'skin':
@@ -421,6 +434,11 @@ class _AvatarEditorScreenState extends ConsumerState<AvatarEditorScreen> {
   void _selectPart(String categoryKey, String partId) {
     setState(() {
       switch (categoryKey) {
+        case 'bodyType':
+          final name = _enumName('body', partId);
+          _config = _config.copyWith(
+            bodyType: AvatarBodyType.values.firstWhere((v) => v.name == name),
+          );
         case 'face':
           final name = _enumName('face', partId);
           _config = _config.copyWith(
@@ -598,14 +616,44 @@ class _AvatarEditorScreenState extends ConsumerState<AvatarEditorScreen> {
                     ),
                   ],
                   const SizedBox(height: 4),
-                  const Row(
+                  Row(
                     children: [
-                      Icon(Icons.info_outline, color: FlitColors.textMuted, size: 16),
-                      SizedBox(width: 6),
+                      const Icon(Icons.info_outline, color: FlitColors.textMuted, size: 16),
+                      const SizedBox(width: 6),
                       Expanded(
-                        child: Text(
-                          'Play games to earn coins or buy from shop',
-                          style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
+                        child: Text.rich(
+                          TextSpan(
+                            children: [
+                              const TextSpan(
+                                text: 'Play games to earn coins or ',
+                                style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
+                              ),
+                              WidgetSpan(
+                                alignment: PlaceholderAlignment.baseline,
+                                baseline: TextBaseline.alphabetic,
+                                child: GestureDetector(
+                                  onTap: () {
+                                    Navigator.of(dialogContext).pop();
+                                    Navigator.of(context).push(
+                                      MaterialPageRoute<void>(
+                                        builder: (_) => const ShopScreen(initialTabIndex: 2),
+                                      ),
+                                    );
+                                  },
+                                  child: const Text(
+                                    'buy',
+                                    style: TextStyle(
+                                      color: FlitColors.accent,
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w600,
+                                      decoration: TextDecoration.underline,
+                                      decorationColor: FlitColors.accent,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ],
@@ -737,7 +785,9 @@ class _AvatarEditorScreenState extends ConsumerState<AvatarEditorScreen> {
             // Coin balance pill
             GestureDetector(
               onTap: () => Navigator.of(context).push(
-                MaterialPageRoute<void>(builder: (_) => const ShopScreen()),
+                MaterialPageRoute<void>(
+                  builder: (_) => const ShopScreen(initialTabIndex: 2),
+                ),
               ),
               child: Container(
                 padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),

--- a/lib/features/avatar/avatar_widget.dart
+++ b/lib/features/avatar/avatar_widget.dart
@@ -325,12 +325,21 @@ class _AvatarPainter extends CustomPainter {
 
   void _drawEyebrows(Canvas canvas, double s, double p) {
     final dark = _skinShadow[config.skin]!;
-    // Left brow
-    _hline(canvas, p, 23, 26, 7, dark);
-    _px(canvas, p, 22, 27, dark);
-    // Right brow
-    _hline(canvas, p, 34, 26, 7, dark);
-    _px(canvas, p, 41, 27, dark);
+    final isFeminine = config.bodyType == AvatarBodyType.feminine;
+
+    if (isFeminine) {
+      // Thinner, arched brows
+      _hline(canvas, p, 24, 26, 5, dark);
+      _px(canvas, p, 23, 27, dark);
+      _hline(canvas, p, 35, 26, 5, dark);
+      _px(canvas, p, 40, 27, dark);
+    } else {
+      // Standard brows
+      _hline(canvas, p, 23, 26, 7, dark);
+      _px(canvas, p, 22, 27, dark);
+      _hline(canvas, p, 34, 26, 7, dark);
+      _px(canvas, p, 41, 27, dark);
+    }
   }
 
   // ---------- Eyes ----------
@@ -476,6 +485,15 @@ class _AvatarPainter extends CustomPainter {
         _px(canvas, p, 39, 30, outline);
         _px(canvas, p, 40, 31, outline);
     }
+
+    // Feminine eyelashes
+    if (config.bodyType == AvatarBodyType.feminine) {
+      // Upper lash extensions
+      _px(canvas, p, 23, 27, outline);
+      _px(canvas, p, 29, 27, outline);
+      _px(canvas, p, 34, 27, outline);
+      _px(canvas, p, 40, 27, outline);
+    }
   }
 
   // ---------- Nose ----------
@@ -502,14 +520,27 @@ class _AvatarPainter extends CustomPainter {
     const lip = Color(0xFFBB5555);
     const lipHl = Color(0xFFCC7777);
     const lipDark = Color(0xFF994444);
-    // Upper lip line
-    _hline(canvas, p, 28, 38, 8, shd);
-    // Lips
-    _hline(canvas, p, 29, 39, 6, lip);
-    _hline(canvas, p, 30, 40, 4, lipDark);
-    // Lip highlight
-    _px(canvas, p, 31, 39, lipHl);
-    _px(canvas, p, 32, 39, lipHl);
+
+    if (config.bodyType == AvatarBodyType.feminine) {
+      // Fuller, more defined lips
+      _hline(canvas, p, 28, 37, 8, shd);
+      _hline(canvas, p, 28, 38, 8, lip);
+      _hline(canvas, p, 29, 39, 6, lip);
+      _hline(canvas, p, 29, 40, 6, lipDark);
+      _hline(canvas, p, 30, 41, 4, lipDark);
+      // Highlight (cupid's bow)
+      _px(canvas, p, 30, 38, lipHl);
+      _px(canvas, p, 33, 38, lipHl);
+      _px(canvas, p, 31, 39, lipHl);
+      _px(canvas, p, 32, 39, lipHl);
+    } else {
+      // Standard lips
+      _hline(canvas, p, 28, 38, 8, shd);
+      _hline(canvas, p, 29, 39, 6, lip);
+      _hline(canvas, p, 30, 40, 4, lipDark);
+      _px(canvas, p, 31, 39, lipHl);
+      _px(canvas, p, 32, 39, lipHl);
+    }
   }
 
   // ---------- Hair ----------
@@ -664,22 +695,39 @@ class _AvatarPainter extends CustomPainter {
     final base = _outfitBase[config.outfit]!;
     final light = _outfitLight[config.outfit]!;
     final dark = _outfitDark[config.outfit]!;
+    final isFeminine = config.bodyType == AvatarBodyType.feminine;
 
-    // Torso/shoulders
-    _rect(canvas, p, 12, 48, 40, 16, base);
-    // Shoulder curve
-    _rect(canvas, p, 8, 50, 4, 14, base);
-    _rect(canvas, p, 52, 50, 4, 14, base);
-    _rect(canvas, p, 6, 52, 2, 12, base);
-    _rect(canvas, p, 56, 52, 2, 12, base);
-    // Collar area highlight
-    _hline(canvas, p, 26, 48, 12, light);
-    _hline(canvas, p, 27, 47, 10, light);
-    // Shoulder highlights
-    _rect(canvas, p, 12, 48, 6, 2, light);
-    _rect(canvas, p, 46, 48, 6, 2, light);
-    // Lower shadow
-    _rect(canvas, p, 12, 58, 40, 6, dark);
+    if (isFeminine) {
+      // Narrower shoulders, tapered waist
+      _rect(canvas, p, 14, 48, 36, 16, base);
+      _rect(canvas, p, 10, 50, 4, 14, base);
+      _rect(canvas, p, 50, 50, 4, 14, base);
+      _rect(canvas, p, 8, 52, 2, 12, base);
+      _rect(canvas, p, 54, 52, 2, 12, base);
+      // Collar area highlight
+      _hline(canvas, p, 26, 48, 12, light);
+      _hline(canvas, p, 27, 47, 10, light);
+      // Shoulder highlights
+      _rect(canvas, p, 14, 48, 6, 2, light);
+      _rect(canvas, p, 44, 48, 6, 2, light);
+      // Lower shadow
+      _rect(canvas, p, 14, 58, 36, 6, dark);
+    } else {
+      // Standard broader shoulders
+      _rect(canvas, p, 12, 48, 40, 16, base);
+      _rect(canvas, p, 8, 50, 4, 14, base);
+      _rect(canvas, p, 52, 50, 4, 14, base);
+      _rect(canvas, p, 6, 52, 2, 12, base);
+      _rect(canvas, p, 56, 52, 2, 12, base);
+      // Collar area highlight
+      _hline(canvas, p, 26, 48, 12, light);
+      _hline(canvas, p, 27, 47, 10, light);
+      // Shoulder highlights
+      _rect(canvas, p, 12, 48, 6, 2, light);
+      _rect(canvas, p, 46, 48, 6, 2, light);
+      // Lower shadow
+      _rect(canvas, p, 12, 58, 40, 6, dark);
+    }
 
     switch (config.outfit) {
       case AvatarOutfit.tshirt:

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -136,6 +136,23 @@ class HomeScreen extends StatelessWidget {
         ],
       );
 
+  /// Close the bottom sheet and navigate to [destination] after the sheet
+  /// animation completes, preventing a white-flash / blank-frame artefact.
+  void _closeSheetAndNavigate(
+    BuildContext sheetContext,
+    BuildContext homeContext,
+    Widget destination,
+  ) {
+    Navigator.of(sheetContext).pop();
+    // Wait for the bottom-sheet dismiss animation to finish before pushing
+    // the new route. This eliminates a white flash on some devices.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Navigator.of(homeContext).push(
+        MaterialPageRoute<void>(builder: (_) => destination),
+      );
+    });
+  }
+
   void _showGameModes(BuildContext context) {
     showModalBottomSheet<void>(
       context: context,
@@ -162,28 +179,18 @@ class HomeScreen extends StatelessWidget {
               title: 'Free Flight',
               subtitle: 'Explore the world at your own pace',
               icon: Icons.flight_takeoff,
-              onTap: () {
-                Navigator.of(ctx).pop();
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const RegionSelectScreen(),
-                  ),
-                );
-              },
+              onTap: () => _closeSheetAndNavigate(
+                ctx, context, const RegionSelectScreen(),
+              ),
             ),
             const SizedBox(height: 10),
             _GameModeCard(
               title: 'Training Sortie',
               subtitle: 'Practice without rank pressure',
               icon: Icons.school_rounded,
-              onTap: () {
-                Navigator.of(ctx).pop();
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const PracticeScreen(),
-                  ),
-                );
-              },
+              onTap: () => _closeSheetAndNavigate(
+                ctx, context, const PracticeScreen(),
+              ),
             ),
             const SizedBox(height: 10),
             _GameModeCard(
@@ -191,28 +198,18 @@ class HomeScreen extends StatelessWidget {
               subtitle: 'Today\'s challenge — compete for glory',
               icon: Icons.today_rounded,
               isHighlighted: true,
-              onTap: () {
-                Navigator.of(ctx).pop();
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const DailyChallengeScreen(),
-                  ),
-                );
-              },
+              onTap: () => _closeSheetAndNavigate(
+                ctx, context, const DailyChallengeScreen(),
+              ),
             ),
             const SizedBox(height: 10),
             _GameModeCard(
               title: 'Dogfight',
               subtitle: 'Challenge your friends head-to-head',
               icon: Icons.people_rounded,
-              onTap: () {
-                Navigator.of(ctx).pop();
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const FriendsScreen(),
-                  ),
-                );
-              },
+              onTap: () => _closeSheetAndNavigate(
+                ctx, context, const FriendsScreen(),
+              ),
             ),
             const SizedBox(height: 16),
           ],

--- a/lib/features/shop/shop_screen.dart
+++ b/lib/features/shop/shop_screen.dart
@@ -9,7 +9,10 @@ import '../../data/providers/account_provider.dart';
 
 /// Shop screen for purchasing cosmetics and gold.
 class ShopScreen extends ConsumerStatefulWidget {
-  const ShopScreen({super.key});
+  const ShopScreen({super.key, this.initialTabIndex = 0});
+
+  /// Which tab to show initially: 0 = Planes, 1 = Contrails, 2 = Gold.
+  final int initialTabIndex;
 
   @override
   ConsumerState<ShopScreen> createState() => _ShopScreenState();
@@ -27,7 +30,11 @@ class _ShopScreenState extends ConsumerState<ShopScreen>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
+    _tabController = TabController(
+      length: 3,
+      vsync: this,
+      initialIndex: widget.initialTabIndex.clamp(0, 2),
+    );
   }
 
   @override


### PR DESCRIPTION
- Make 'buy' a tappable link instead of underlined full text in license and avatar editor screens
- Gold icon taps now navigate to shop Gold tab (initialTabIndex: 2)
- Add clue type locking to licence reroll (was stat-only before)
- Add body type (masculine/feminine) to avatar system with distinct pixel art proportions (brows, lashes, lips, shoulders)
- Fix white screen on game mode launch by deferring route push until after bottom sheet dismiss animation completes
- Implement avatar rarity luck bonus: rarer (costlier) avatars grant advantage rolls on licence stat rerolls, shown on licence screen

https://claude.ai/code/session_01DtTZtbSbzj221y7QCUPwch