### PR TITLE
Fix game engine, licence UX, multi-round play, and coin rewards

### DIFF
--- a/lib/data/models/pilot_license.dart
+++ b/lib/data/models/pilot_license.dart
@@ -172,21 +172,21 @@ class PilotLicense {
   // Display helpers
   // ---------------------------------------------------------------------------
 
-  /// Human-readable coin boost, e.g. "+5% Coins".
-  String get coinBoostLabel => '+$coinBoost% Coins';
+  /// Human-readable coin boost, e.g. "+5% Extra Coins".
+  String get coinBoostLabel => '+$coinBoost% Extra Coins';
 
-  /// Human-readable clue boost including the type.
+  /// Human-readable clue type, e.g. "Clue Type: Flag".
   String get clueBoostLabel {
     final typeLabel =
         '${preferredClueType[0].toUpperCase()}${preferredClueType.substring(1)}';
-    return '$typeLabel Clue Type';
+    return 'Clue Type: $typeLabel';
   }
 
   /// Human-readable clue chance, e.g. "+5% Clue Chance".
   String get clueChanceLabel => '+$clueChance% Clue Chance';
 
-  /// Human-readable fuel boost, e.g. "+7% Fuel".
-  String get fuelBoostLabel => '+$fuelBoost% Fuel';
+  /// Human-readable fuel boost, e.g. "+7% Fuel Efficiency".
+  String get fuelBoostLabel => '+$fuelBoost% Fuel Efficiency';
 
   /// Sum of all four boosts (useful for ranking / comparison).
   int get totalBoost => coinBoost + clueBoost + clueChance + fuelBoost;

--- a/lib/features/daily/daily_challenge_screen.dart
+++ b/lib/features/daily/daily_challenge_screen.dart
@@ -1,21 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../data/models/cosmetic.dart';
 import '../../data/models/daily_challenge.dart';
 import '../../data/models/seasonal_theme.dart';
+import '../../data/providers/account_provider.dart';
 import '../../game/map/region.dart';
 import '../play/play_screen.dart';
 
 /// Daily challenge screen showing today's challenge details, seasonal events,
 /// rewards, and leaderboards with licensed/unlicensed toggle.
-class DailyChallengeScreen extends StatefulWidget {
+class DailyChallengeScreen extends ConsumerStatefulWidget {
   const DailyChallengeScreen({super.key});
 
   @override
-  State<DailyChallengeScreen> createState() => _DailyChallengeScreenState();
+  ConsumerState<DailyChallengeScreen> createState() => _DailyChallengeScreenState();
 }
 
-class _DailyChallengeScreenState extends State<DailyChallengeScreen> {
+class _DailyChallengeScreenState extends ConsumerState<DailyChallengeScreen> {
   late final DailyChallenge _challenge;
   final SeasonalTheme? _seasonalTheme = SeasonalTheme.current();
 
@@ -78,9 +81,19 @@ class _DailyChallengeScreenState extends State<DailyChallengeScreen> {
       );
 
   void _onPlay() {
+    final reward = _challenge.coinReward;
+    final planeId = ref.read(equippedPlaneIdProvider);
+    final planeColors = CosmeticCatalog.getById(planeId)?.colorScheme;
     Navigator.of(context).push(
       MaterialPageRoute<void>(
-        builder: (_) => const PlayScreen(region: GameRegion.world),
+        builder: (_) => PlayScreen(
+          region: GameRegion.world,
+          coinReward: reward,
+          planeColorScheme: planeColors,
+          onComplete: (totalScore) {
+            ref.read(accountProvider.notifier).addCoins(reward);
+          },
+        ),
       ),
     );
   }

--- a/lib/features/friends/friends_screen.dart
+++ b/lib/features/friends/friends_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../data/models/cosmetic.dart';
 import '../../data/models/friend.dart';
 import '../../data/providers/account_provider.dart';
 import '../play/play_screen.dart';
@@ -119,11 +120,14 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
   }
 
   void _challengeFriend(Friend friend) {
+    final planeId = ref.read(equippedPlaneIdProvider);
+    final planeColors = CosmeticCatalog.getById(planeId)?.colorScheme;
     // Navigate directly to play screen for round 1
     Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (context) => PlayScreen(
           challengeFriendName: friend.name,
+          planeColorScheme: planeColors,
         ),
       ),
     ).then((_) {

--- a/lib/features/license/license_screen.dart
+++ b/lib/features/license/license_screen.dart
@@ -418,14 +418,14 @@ class _LicenseScreenState extends ConsumerState<LicenseScreen>
         ),
         const Spacer(flex: 1),
 
-        // --- Stat bars: coins, fuel, clue type, clue chance ---
+        // --- Stat bars: coins, fuel, clue chance, clue type ---
         _CompactStatBar(
           label: _license.coinBoostLabel,
           icon: Icons.monetization_on,
           value: _license.coinBoost,
           shimmer: _shimmerController,
           onTap: () => _showEffectPopup(
-            'Coin Boost',
+            'Extra Coins',
             'Earn ${_license.coinBoost}% more coins from every game you play. Stacks with daily bonuses.',
             Icons.monetization_on,
           ),
@@ -437,22 +437,9 @@ class _LicenseScreenState extends ConsumerState<LicenseScreen>
           value: _license.fuelBoost,
           shimmer: _shimmerController,
           onTap: () => _showEffectPopup(
-            'Fuel Boost',
+            'Fuel Efficiency',
             'Extends your fuel/speed-boost duration in solo play by ${_license.fuelBoost}%. More fuel means more time to guess.',
             Icons.local_gas_station,
-          ),
-        ),
-        const SizedBox(height: 4),
-        _CompactStatBar(
-          label: '${_license.preferredClueType[0].toUpperCase()}${_license.preferredClueType.substring(1)}',
-          icon: Icons.lightbulb_outline,
-          value: _license.clueBoost,
-          shimmer: _shimmerController,
-          showPercentage: false,
-          onTap: () => _showEffectPopup(
-            'Clue Type',
-            'Your preferred clue type is "${_license.preferredClueType}". You\'ll receive this type of clue more often when playing.',
-            Icons.lightbulb_outline,
           ),
         ),
         const SizedBox(height: 4),
@@ -465,6 +452,19 @@ class _LicenseScreenState extends ConsumerState<LicenseScreen>
             'Clue Chance',
             'Increases the chance of receiving additional clues by ${_license.clueChance}%. More clues means more information to help you guess.',
             Icons.casino,
+          ),
+        ),
+        const SizedBox(height: 4),
+        _CompactStatBar(
+          label: _license.clueBoostLabel,
+          icon: Icons.lightbulb_outline,
+          value: _license.clueBoost,
+          shimmer: _shimmerController,
+          showPercentage: false,
+          onTap: () => _showEffectPopup(
+            'Clue Type',
+            'Your preferred clue type is "${_license.preferredClueType}". You\'ll receive this type of clue ${_license.clueBoost}% more often when playing.',
+            Icons.lightbulb_outline,
           ),
         ),
 
@@ -846,7 +846,7 @@ class _LicenseScreenState extends ConsumerState<LicenseScreen>
               TextSpan(
                 children: [
                   const TextSpan(
-                    text: 'Not enough coins. Play to earn more or ',
+                    text: 'Not enough coins. Play or ',
                     style: TextStyle(color: FlitColors.error, fontSize: 12),
                   ),
                   WidgetSpan(
@@ -869,6 +869,10 @@ class _LicenseScreenState extends ConsumerState<LicenseScreen>
                         ),
                       ),
                     ),
+                  ),
+                  const TextSpan(
+                    text: ' more coins.',
+                    style: TextStyle(color: FlitColors.error, fontSize: 12),
                   ),
                 ],
               ),
@@ -1000,22 +1004,24 @@ class _CompactStatBar extends StatelessWidget {
         height: 16,
         child: Row(
           children: [
-            Icon(icon, color: color, size: 13),
-            const SizedBox(width: 4),
-            SizedBox(
-              width: 80,
+            Icon(icon, color: color, size: 12),
+            const SizedBox(width: 3),
+            Flexible(
+              flex: 0,
               child: Text(
                 label,
                 style: const TextStyle(
                   color: FlitColors.textSecondary,
-                  fontSize: 10,
+                  fontSize: 9,
                   fontWeight: FontWeight.w500,
                 ),
                 maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+                overflow: TextOverflow.clip,
               ),
             ),
-            Expanded(
+            const SizedBox(width: 4),
+            SizedBox(
+              width: 50,
               child: isMax
                   ? _AnimBuilder(
                       animation: shimmer,
@@ -1023,18 +1029,15 @@ class _CompactStatBar extends StatelessWidget {
                     )
                   : _buildSegments(color, isMax),
             ),
-            const SizedBox(width: 4),
+            const SizedBox(width: 3),
             if (showPercentage)
-              SizedBox(
-                width: 22,
-                child: Text(
-                  '$value',
-                  textAlign: TextAlign.right,
-                  style: TextStyle(
-                    color: color,
-                    fontSize: 10,
-                    fontWeight: FontWeight.bold,
-                  ),
+              Text(
+                '$value',
+                textAlign: TextAlign.right,
+                style: TextStyle(
+                  color: color,
+                  fontSize: 9,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
           ],

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -14,11 +14,19 @@ import '../../game/ui/game_hud.dart';
 final _log = GameLog.instance;
 
 /// Main play screen with game canvas and HUD overlay.
+///
+/// Supports multi-round play: when [totalRounds] > 1, the player
+/// automatically advances through rounds without landing until the
+/// final round.
 class PlayScreen extends StatefulWidget {
   const PlayScreen({
     super.key,
     this.region = GameRegion.world,
     this.challengeFriendName,
+    this.totalRounds = 1,
+    this.coinReward = 0,
+    this.onComplete,
+    this.planeColorScheme,
   });
 
   /// The region to play in.
@@ -26,6 +34,19 @@ class PlayScreen extends StatefulWidget {
 
   /// When non-null, the game is played as a challenge round against this friend.
   final String? challengeFriendName;
+
+  /// Number of rounds to play back-to-back. 1 = single round.
+  /// For Training Sortie this is 10.
+  final int totalRounds;
+
+  /// Coins awarded on completion.
+  final int coinReward;
+
+  /// Called when the full session completes with the total score.
+  final void Function(int totalScore)? onComplete;
+
+  /// Color scheme for the equipped plane cosmetic.
+  final Map<String, int>? planeColorScheme;
 
   @override
   State<PlayScreen> createState() => _PlayScreenState();
@@ -40,16 +61,24 @@ class _PlayScreenState extends State<PlayScreen> {
   bool _gameReady = false;
   String? _error;
 
+  /// Current round (1-indexed).
+  int _currentRound = 1;
+
+  /// Accumulated score across all rounds.
+  int _totalScore = 0;
+
   @override
   void initState() {
     super.initState();
     _log.info('screen', 'PlayScreen.initState', data: {
       'region': widget.region.name,
       'challenge': widget.challengeFriendName,
+      'totalRounds': widget.totalRounds,
     });
     _game = FlitGame(
       onGameReady: _onGameReady,
       onAltitudeChanged: _onAltitudeChanged,
+      planeColorScheme: widget.planeColorScheme,
     );
   }
 
@@ -82,8 +111,11 @@ class _PlayScreenState extends State<PlayScreen> {
     }
   }
 
+  bool get _isMultiRound => widget.totalRounds > 1;
+  bool get _isFinalRound => _currentRound >= widget.totalRounds;
+
   void _startNewGame() {
-    _log.info('session', 'Starting new game');
+    _log.info('session', 'Starting round $_currentRound/${widget.totalRounds}');
     try {
       _session = GameSession.random(region: widget.region);
       _elapsed = Duration.zero;
@@ -91,6 +123,7 @@ class _PlayScreenState extends State<PlayScreen> {
       _log.info('session', 'Session created', data: {
         'target': _session!.targetName,
         'clue': _session!.clue.type.name,
+        'round': _currentRound,
       });
 
       // Start the game with the session data
@@ -113,8 +146,8 @@ class _PlayScreenState extends State<PlayScreen> {
             _session!.recordPosition(_game.worldPosition);
           }
 
-          // Check for landing
-          _checkLanding();
+          // Check for proximity to target
+          _checkProximity();
         }
       });
 
@@ -131,24 +164,58 @@ class _PlayScreenState extends State<PlayScreen> {
     }
   }
 
-  void _checkLanding() {
+  void _checkProximity() {
     if (_session == null || _session!.isCompleted) return;
 
-    // Landing detection: low altitude + near target
-    if (!_isHighAltitude && _game.isNearTarget(threshold: 80)) {
-      _completeLanding();
+    // Proximity detection: near target
+    if (_game.isNearTarget(threshold: 80)) {
+      if (_isMultiRound && !_isFinalRound) {
+        // Not the final round: auto-advance when near target (any altitude)
+        _advanceRound();
+      } else if (!_isHighAltitude) {
+        // Final round or single round: require low altitude to land
+        _completeLanding();
+      }
     }
+  }
+
+  /// Advance to the next round without showing a dialog.
+  void _advanceRound() {
+    _timer?.cancel();
+    _session?.complete();
+    _totalScore += _session?.score ?? 0;
+
+    _log.info('session', 'Round $_currentRound complete, advancing', data: {
+      'target': _session?.targetName,
+      'roundScore': _session?.score,
+      'totalScore': _totalScore,
+    });
+
+    setState(() {
+      _currentRound++;
+    });
+
+    // Brief delay so the player sees they arrived, then start next round
+    Future<void>.delayed(const Duration(milliseconds: 300), () {
+      if (mounted) _startNewGame();
+    });
   }
 
   void _completeLanding() {
     _timer?.cancel();
     _session?.complete();
+    _totalScore += _session?.score ?? 0;
 
     _log.info('session', 'Landing complete', data: {
       'target': _session?.targetName,
       'elapsed': _session?.elapsed.inMilliseconds,
       'score': _session?.score,
+      'totalScore': _totalScore,
+      'round': _currentRound,
     });
+
+    // Notify completion callback
+    widget.onComplete?.call(_totalScore);
 
     final friendName = widget.challengeFriendName;
 
@@ -159,9 +226,16 @@ class _PlayScreenState extends State<PlayScreen> {
       builder: (dialogContext) => _ResultDialog(
         session: _session!,
         challengeFriendName: friendName,
+        totalScore: _totalScore,
+        totalRounds: widget.totalRounds,
+        coinReward: widget.coinReward,
         onPlayAgain: friendName == null
             ? () {
                 Navigator.of(dialogContext).pop();
+                setState(() {
+                  _currentRound = 1;
+                  _totalScore = 0;
+                });
                 _startNewGame();
               }
             : null,
@@ -371,6 +445,38 @@ class _PlayScreenState extends State<PlayScreen> {
                 onExit: _requestExit,
               ),
 
+            // Round indicator for multi-round play
+            if (_gameReady && _isMultiRound)
+              Positioned(
+                top: MediaQuery.of(context).padding.top + 8,
+                left: 0,
+                right: 0,
+                child: Center(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 6,
+                    ),
+                    decoration: BoxDecoration(
+                      color: FlitColors.cardBackground.withOpacity(0.85),
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                        color: FlitColors.accent.withOpacity(0.5),
+                      ),
+                    ),
+                    child: Text(
+                      'Round $_currentRound / ${widget.totalRounds}',
+                      style: const TextStyle(
+                        color: FlitColors.accent,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: 1,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+
             // Error overlay
             if (_error != null)
               Container(
@@ -425,6 +531,9 @@ class _ResultDialog extends StatelessWidget {
     required this.onExit,
     this.challengeFriendName,
     this.onSendChallenge,
+    this.totalScore = 0,
+    this.totalRounds = 1,
+    this.coinReward = 0,
   });
 
   final GameSession session;
@@ -432,6 +541,9 @@ class _ResultDialog extends StatelessWidget {
   final VoidCallback onExit;
   final String? challengeFriendName;
   final VoidCallback? onSendChallenge;
+  final int totalScore;
+  final int totalRounds;
+  final int coinReward;
 
   @override
   Widget build(BuildContext context) {
@@ -440,6 +552,7 @@ class _ResultDialog extends StatelessWidget {
     final minutes = session.elapsed.inMinutes;
     final seconds = session.elapsed.inSeconds % 60;
     final millis = (session.elapsed.inMilliseconds % 1000) ~/ 10;
+    final isMultiRound = totalRounds > 1;
 
     return Dialog(
       backgroundColor: FlitColors.cardBackground,
@@ -500,12 +613,59 @@ class _ResultDialog extends StatelessWidget {
             ],
             const SizedBox(height: 6),
             Text(
-              'Score: ${session.score}',
+              isMultiRound
+                  ? 'Total Score: $totalScore'
+                  : 'Score: ${session.score}',
               style: const TextStyle(
                 color: FlitColors.textSecondary,
                 fontSize: 14,
               ),
             ),
+            if (isMultiRound) ...[
+              const SizedBox(height: 4),
+              Text(
+                '$totalRounds rounds completed',
+                style: const TextStyle(
+                  color: FlitColors.textMuted,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+            if (coinReward > 0) ...[
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
+                decoration: BoxDecoration(
+                  color: FlitColors.gold.withOpacity(0.15),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: FlitColors.gold.withOpacity(0.4),
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.monetization_on,
+                      color: FlitColors.gold,
+                      size: 18,
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      '+$coinReward coins',
+                      style: const TextStyle(
+                        color: FlitColors.gold,
+                        fontSize: 14,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
             const SizedBox(height: 24),
             // Buttons
             Row(

--- a/lib/features/play/practice_screen.dart
+++ b/lib/features/play/practice_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../data/models/cosmetic.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/clues/clue_types.dart';
 import '../../game/map/region.dart';
@@ -205,9 +206,15 @@ class _PracticeScreenState extends ConsumerState<PracticeScreen> {
     if (cost > 0) {
       ref.read(accountProvider.notifier).spendCoins(cost);
     }
+    final planeId = ref.read(equippedPlaneIdProvider);
+    final planeColors = CosmeticCatalog.getById(planeId)?.colorScheme;
     Navigator.of(context).push(
       MaterialPageRoute<void>(
-        builder: (_) => const PlayScreen(region: GameRegion.world),
+        builder: (_) => PlayScreen(
+          region: GameRegion.world,
+          totalRounds: 10,
+          planeColorScheme: planeColors,
+        ),
       ),
     );
   }

--- a/lib/features/play/region_select_screen.dart
+++ b/lib/features/play/region_select_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../data/models/cosmetic.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/map/region.dart';
 import 'play_screen.dart';
@@ -88,11 +89,18 @@ class RegionSelectScreen extends ConsumerWidget {
             unlockCost: cost,
             canBuy: !isUnlocked && canAfford,
             onTap: isUnlocked
-                ? () => Navigator.of(context).pushReplacement(
+                ? () {
+                    final planeId = ref.read(equippedPlaneIdProvider);
+                    final planeColors = CosmeticCatalog.getById(planeId)?.colorScheme;
+                    Navigator.of(context).pushReplacement(
                       MaterialPageRoute<void>(
-                        builder: (context) => PlayScreen(region: region),
+                        builder: (context) => PlayScreen(
+                          region: region,
+                          planeColorScheme: planeColors,
+                        ),
                       ),
-                    )
+                    );
+                  }
                 : null,
             onBuy: (!isUnlocked && canAfford)
                 ? () => _showUnlockDialog(context, ref, region, cost)

--- a/lib/game/map/world_map.dart
+++ b/lib/game/map/world_map.dart
@@ -31,8 +31,9 @@ class WorldMap extends Component with HasGameRef<FlitGame> {
   static const double mapHeight = 1800;
 
   /// Angular radius of the visible globe in radians.
-  static const double _highAltitudeRadius = 1.1; // ~63°
-  static const double _lowAltitudeRadius = 0.4; // ~23°
+  /// Lower values = closer to the surface. Earth curvature just off screen.
+  static const double _highAltitudeRadius = 0.55; // ~31° — closer view
+  static const double _lowAltitudeRadius = 0.2; // ~11° — near surface
 
   /// Current interpolated angular radius.
   double _angularRadius = _highAltitudeRadius;


### PR DESCRIPTION
- License card: reorder stats (coins, fuel, clue chance, clue type), rename labels to "Extra Coins", "Fuel Efficiency", "Clue Type: X", squash stat bars to show full label text
- Fix "not enough coins" text: "Play or buy more coins."
- Polar coordinate fix: clamp latitude to ±85° to avoid singularity
- Steering: dt-based turn decay (prevents infinite spinning), higher drag sensitivity, dead zone for micro-drags
- Zoom: reduce angular radius (0.55/0.2 rad) for closer surface view
- Contrails: increase trail lifetime from 1s to 4s
- Multi-round play: PlayScreen supports totalRounds param (10 for Training Sortie), auto-advances through rounds, only lands on final
- Daily challenge: award coinReward on completion via account provider
- Equipped plane: pass color scheme through to PlaneComponent renderer
- All PlayScreen callers updated to pass planeColorScheme

https://claude.ai/code/session_01DtTZtbSbzj221y7QCUPwch