### PR TITLE
fix: downgrade audioplayers to ^5.2.1 for Dart SDK 3.2 compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,8 @@ dependencies:
   http: ^1.1.0
 
   # Audio (cross-platform: iOS, Android, Web)
-  audioplayers: ^6.1.0
+  # Pinned to v5 for Dart SDK 3.2 compatibility (Flutter 3.16)
+  audioplayers: ^5.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
audioplayers ^6.1.0 requires audioplayers_web ^5.0.1 which needs Dart SDK >=3.3.0, but Flutter 3.16.0 ships with Dart 3.2.0. Downgraded to ^5.2.1 which has the same API surface we use (play, stop, setVolume, setReleaseMode, AssetSource).

https://claude.ai/code/session_01Emysg4tU5NJsGmWanyjebT