### PR TITLE
fix: add const to TextStyle in _SeasonalBanner vehicleDescription

### DIFF
--- a/lib/features/daily/daily_challenge_screen.dart
+++ b/lib/features/daily/daily_challenge_screen.dart
@@ -405,7 +405,7 @@ class _SeasonalBanner extends StatelessWidget {
                 const SizedBox(height: 2),
                 Text(
                   theme.vehicleDescription,
-                  style: TextStyle(
+                  style: const TextStyle(
                     color: FlitColors.textSecondary,
                     fontSize: 12,
                     height: 1.3,


### PR DESCRIPTION
The TextStyle constructor has only const arguments (FlitColors.textSecondary, 12, 1.3) but was missing the const keyword. The parent Text widget can't be const (runtime theme.vehicleDescription), so the TextStyle needs explicit const.

This resolves the prefer_const_constructors lint at line 427:26 (post-format).

https://claude.ai/code/session_01Emysg4tU5NJsGmWanyjebT