### PR TITLE
feat: chase camera, contrail overlay, and dogfight fix

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -83,6 +83,7 @@ class _PlayScreenState extends State<PlayScreen> {
     _game = FlitGame(
       onGameReady: _onGameReady,
       onAltitudeChanged: _onAltitudeChanged,
+      isChallenge: widget.challengeFriendName != null,
       planeColorScheme: widget.planeColorScheme,
       equippedPlaneId: widget.equippedPlaneId,
     );

--- a/lib/game/components/contrail_renderer.dart
+++ b/lib/game/components/contrail_renderer.dart
@@ -1,0 +1,31 @@
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../flit_game.dart';
+import 'plane_component.dart';
+
+/// Renders contrail particles as a Flame overlay component.
+///
+/// This component draws contrails independently of the globe renderer,
+/// ensuring they appear regardless of whether the shader or canvas
+/// world map is active. Contrails trail from the plane's wing tips
+/// and fade over their lifetime.
+class ContrailRenderer extends Component with HasGameRef<FlitGame> {
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+
+    final plane = gameRef.plane;
+    final planePos = plane.position;
+
+    for (final particle in plane.contrails) {
+      final opacity = (particle.life / particle.maxLife).clamp(0.0, 1.0);
+      final paint = Paint()
+        ..color = FlitColors.contrail.withOpacity(opacity * 0.5);
+
+      final pos = planePos.toOffset() + particle.screenOffset.toOffset();
+      canvas.drawCircle(pos, particle.size * (0.3 + opacity * 0.7), paint);
+    }
+  }
+}

--- a/lib/game/map/world_map.dart
+++ b/lib/game/map/world_map.dart
@@ -94,8 +94,7 @@ class WorldMap extends Component with HasGameRef<FlitGame> {
       _renderCities(canvas, screenSize, globeRadius);
     }
 
-    // 7. Contrails
-    _renderContrails(canvas, screenSize, center);
+    // Contrails are rendered by ContrailRenderer (separate component).
 
     canvas.restore(); // un-clip
 
@@ -335,19 +334,6 @@ class WorldMap extends Component with HasGameRef<FlitGame> {
         Offset(
             projected.dx + dotSize + 3, projected.dy - textPainter.height / 2),
       );
-    }
-  }
-
-  void _renderContrails(Canvas canvas, Vector2 screenSize, Offset center) {
-    final plane = gameRef.plane;
-
-    for (final particle in plane.contrails) {
-      final opacity = (particle.life / particle.maxLife).clamp(0.0, 1.0);
-      final paint = Paint()
-        ..color = FlitColors.contrail.withOpacity(opacity * 0.5);
-
-      final pos = center + particle.screenOffset.toOffset();
-      canvas.drawCircle(pos, particle.size * (0.3 + opacity * 0.7), paint);
     }
   }
 

--- a/lib/game/rendering/globe_renderer.dart
+++ b/lib/game/rendering/globe_renderer.dart
@@ -73,8 +73,8 @@ class GlobeRenderer extends Component with HasGameRef<FlitGame> {
 
     _time += dt;
 
-    // -- Update camera from the game's plane position --
-    final worldPos = gameRef.worldPosition;
+    // -- Update camera from the chase camera offset position --
+    final camPos = gameRef.cameraPosition;
     final plane = gameRef.plane;
 
     // speedFraction: ratio of current speed to max speed.
@@ -83,8 +83,8 @@ class GlobeRenderer extends Component with HasGameRef<FlitGame> {
 
     _camera.update(
       dt,
-      planeLatDeg: worldPos.y,
-      planeLngDeg: worldPos.x,
+      planeLatDeg: camPos.y,
+      planeLngDeg: camPos.x,
       isHighAltitude: plane.isHighAltitude,
       speedFraction: speedFraction.clamp(0.0, 1.0),
     );


### PR DESCRIPTION
- Add chase camera that follows behind the plane with delayed heading catch-up on turns. Camera heading smoothly interpolates toward plane heading using exponential ease-out (rate 2.0). Camera center is offset ahead of plane along heading direction (4-8 degrees depending on altitude), so more world is visible in the direction of travel.

- Move plane screen position from center (0.5) to lower (0.6) so the player sees more of the world ahead.

- Extract contrail rendering into standalone ContrailRenderer component that works with both the shader globe renderer and the canvas WorldMap. Previously contrails only rendered in the legacy Canvas path.

- Fix dogfight crash: pass isChallenge flag from PlayScreen to FlitGame when challengeFriendName is set. This ensures license bonuses (fuel boost) are correctly disabled in head-to-head challenges, only applying in solo/free flight mode.

- Clean up WorldMap: remove orphaned _renderContrails method.

https://claude.ai/code/session_01DS8vta8DEzTgtDhSX7Vg91