### PR TITLE
feat: 3D plane banking with perspective shading, invert swipe controls

### DIFF
--- a/lib/game/components/contrail_renderer.dart
+++ b/lib/game/components/contrail_renderer.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
 import '../flit_game.dart';
-import 'plane_component.dart';
 
 /// Renders contrail particles as a Flame overlay component.
 ///

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -349,8 +349,8 @@ class FlitGame extends FlameGame
       // In dead zone - don't change direction, let it coast
       return;
     }
-    // Map the drag to -1..+1 with higher sensitivity
-    _plane.setTurnDirection((dx * _dragSensitivity).clamp(-1, 1));
+    // Map the drag to -1..+1 — inverted so dragging right banks left
+    _plane.setTurnDirection((-dx * _dragSensitivity).clamp(-1, 1));
   }
 
   @override


### PR DESCRIPTION
Plane rendering rewritten for 3D look:
- Wings foreshorten with cos(bank) for perspective effect
- Asymmetric wing spans: near wing grows, far wing shrinks during bank
- Directional shading: lit side vs shadowed side based on bank direction
- Underside strip visible when significantly banked (>15% bank)
- Fuselage, cockpit, engine shift laterally with bank
- Tail stabiliser and vertical fin tilt with roll
- Navigation lights track actual wing tip positions
- Bank angle increased from 0.35 to 0.7 rad (~40 degrees) for drama
- Shadow foreshortens to match wing banking perspective

Swipe controls inverted: drag right now banks left (feels like pulling the world, not pushing the plane).

Fix unused import lint warning in contrail_renderer.dart.

https://claude.ai/code/session_01DS8vta8DEzTgtDhSX7Vg91