### PR TITLE
feat: 45-deg chase camera, world-space contrails, shader fallback, co…

### DIFF
--- a/lib/core/services/game_settings.dart
+++ b/lib/core/services/game_settings.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+
+/// Singleton that holds user-configurable game settings.
+///
+/// All settings are stored in memory. Persistence (SharedPreferences)
+/// will be added in a future update. The singleton is accessed from
+/// both the settings UI and from the Flame game loop.
+class GameSettings extends ChangeNotifier {
+  GameSettings._();
+
+  /// Singleton instance.
+  static final GameSettings instance = GameSettings._();
+
+  // ─── Turn Sensitivity ──────────────────────────────────────────────
+
+  /// Turn sensitivity multiplier applied to drag input.
+  /// Range: 0.2 (very sluggish) to 1.5 (very twitchy).
+  /// Default: 0.5.
+  double _turnSensitivity = 0.5;
+
+  double get turnSensitivity => _turnSensitivity;
+
+  set turnSensitivity(double value) {
+    _turnSensitivity = value.clamp(0.2, 1.5);
+    notifyListeners();
+  }
+
+  /// Human-readable label for the current sensitivity level.
+  String get sensitivityLabel {
+    if (_turnSensitivity <= 0.3) return 'Low';
+    if (_turnSensitivity <= 0.6) return 'Medium';
+    if (_turnSensitivity <= 1.0) return 'High';
+    return 'Very High';
+  }
+
+  // ─── Invert Controls ──────────────────────────────────────────────
+
+  /// When true, dragging right banks the plane left (and vice versa).
+  /// This is the default "natural" feel for a behind-the-plane camera.
+  bool _invertControls = true;
+
+  bool get invertControls => _invertControls;
+
+  set invertControls(bool value) {
+    _invertControls = value;
+    notifyListeners();
+  }
+}

--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/services/audio_manager.dart';
+import '../../core/services/game_settings.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../core/utils/profanity_filter.dart';
 import '../../data/models/avatar_config.dart';
@@ -107,6 +108,30 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                 onChanged: (value) {
                   setSheetState(() => _hapticEnabled = value);
                   setState(() {});
+                },
+              ),
+              const Divider(color: FlitColors.cardBorder, height: 1),
+              _SettingsToggle(
+                label: 'Invert Controls',
+                icon: Icons.swap_horiz,
+                value: GameSettings.instance.invertControls,
+                onChanged: (value) {
+                  GameSettings.instance.invertControls = value;
+                  setSheetState(() {});
+                  setState(() {});
+                },
+              ),
+              const Divider(color: FlitColors.cardBorder, height: 1),
+              _SettingsSlider(
+                label: 'Turn Sensitivity',
+                icon: Icons.speed,
+                value: GameSettings.instance.turnSensitivity,
+                min: 0.2,
+                max: 1.5,
+                valueLabel: GameSettings.instance.sensitivityLabel,
+                onChanged: (value) {
+                  GameSettings.instance.turnSensitivity = value;
+                  setSheetState(() {});
                 },
               ),
               const Divider(color: FlitColors.cardBorder, height: 1),
@@ -806,6 +831,77 @@ class _SettingsToggle extends StatelessWidget {
               onChanged: onChanged,
               activeColor: FlitColors.accent,
               inactiveTrackColor: FlitColors.backgroundMid,
+            ),
+          ],
+        ),
+      );
+}
+
+// ---------------------------------------------------------------------------
+// Settings slider row used inside the settings bottom sheet
+// ---------------------------------------------------------------------------
+
+class _SettingsSlider extends StatelessWidget {
+  const _SettingsSlider({
+    required this.label,
+    required this.icon,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.valueLabel,
+    required this.onChanged,
+  });
+
+  final String label;
+  final IconData icon;
+  final double value;
+  final double min;
+  final double max;
+  final String valueLabel;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, color: FlitColors.textSecondary, size: 22),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    label,
+                    style: const TextStyle(
+                      color: FlitColors.textPrimary,
+                      fontSize: 16,
+                    ),
+                  ),
+                ),
+                Text(
+                  valueLabel,
+                  style: const TextStyle(
+                    color: FlitColors.textSecondary,
+                    fontSize: 14,
+                  ),
+                ),
+              ],
+            ),
+            SliderTheme(
+              data: SliderThemeData(
+                activeTrackColor: FlitColors.accent,
+                inactiveTrackColor: FlitColors.backgroundMid,
+                thumbColor: FlitColors.accent,
+                overlayColor: FlitColors.accent.withOpacity(0.15),
+                trackHeight: 4,
+              ),
+              child: Slider(
+                value: value,
+                min: min,
+                max: max,
+                onChanged: onChanged,
+              ),
             ),
           ],
         ),

--- a/lib/game/components/contrail_renderer.dart
+++ b/lib/game/components/contrail_renderer.dart
@@ -6,25 +6,32 @@ import '../flit_game.dart';
 
 /// Renders contrail particles as a Flame overlay component.
 ///
-/// This component draws contrails independently of the globe renderer,
-/// ensuring they appear regardless of whether the shader or canvas
-/// world map is active. Contrails trail from the plane's wing tips
-/// and fade over their lifetime.
+/// Contrails are anchored to world positions (lat/lng). Each frame,
+/// particles are projected from world space onto the screen so they
+/// stay fixed on the map as the plane flies away — creating a trailing
+/// ribbon effect.
 class ContrailRenderer extends Component with HasGameRef<FlitGame> {
   @override
   void render(Canvas canvas) {
     super.render(canvas);
 
     final plane = gameRef.plane;
-    final planePos = plane.position;
 
     for (final particle in plane.contrails) {
       final opacity = (particle.life / particle.maxLife).clamp(0.0, 1.0);
+      if (opacity < 0.01) continue;
+
+      // Project world position to screen.
+      final screenPos = gameRef.worldToScreen(particle.worldPosition);
+
       final paint = Paint()
         ..color = FlitColors.contrail.withOpacity(opacity * 0.5);
 
-      final pos = planePos.toOffset() + particle.screenOffset.toOffset();
-      canvas.drawCircle(pos, particle.size * (0.3 + opacity * 0.7), paint);
+      canvas.drawCircle(
+        Offset(screenPos.x, screenPos.y),
+        particle.size * (0.3 + opacity * 0.7),
+        paint,
+      );
     }
   }
 }

--- a/lib/game/map/world_map.dart
+++ b/lib/game/map/world_map.dart
@@ -64,8 +64,8 @@ class WorldMap extends Component with HasGameRef<FlitGame> {
 
     final screenSize = gameRef.size;
     final center = Offset(
-      screenSize.x * FlitGame.planeScreenX,
-      screenSize.y * FlitGame.planeScreenY,
+      screenSize.x * FlitGame.projectionCenterX,
+      screenSize.y * FlitGame.projectionCenterY,
     );
     final globeRadius = _globeScreenRadius(screenSize);
 
@@ -374,8 +374,8 @@ class WorldMap extends Component with HasGameRef<FlitGame> {
 
     if (c < 0.0001) {
       return Offset(
-        screenSize.x * FlitGame.planeScreenX,
-        screenSize.y * FlitGame.planeScreenY,
+        screenSize.x * FlitGame.projectionCenterX,
+        screenSize.y * FlitGame.projectionCenterY,
       );
     }
 
@@ -387,8 +387,8 @@ class WorldMap extends Component with HasGameRef<FlitGame> {
     final scale = globeRadius / _angularRadius;
 
     return Offset(
-      screenSize.x * FlitGame.planeScreenX + px * c * scale,
-      screenSize.y * FlitGame.planeScreenY - py * c * scale,
+      screenSize.x * FlitGame.projectionCenterX + px * c * scale,
+      screenSize.y * FlitGame.projectionCenterY - py * c * scale,
     );
   }
 
@@ -407,8 +407,8 @@ class WorldMap extends Component with HasGameRef<FlitGame> {
 
     if (c < 0.0001) {
       return Offset(
-        screenSize.x * FlitGame.planeScreenX,
-        screenSize.y * FlitGame.planeScreenY,
+        screenSize.x * FlitGame.projectionCenterX,
+        screenSize.y * FlitGame.projectionCenterY,
       );
     }
 
@@ -422,15 +422,15 @@ class WorldMap extends Component with HasGameRef<FlitGame> {
     final scale = globeRadius / _angularRadius;
 
     return Offset(
-      screenSize.x * FlitGame.planeScreenX + px * c * scale,
-      screenSize.y * FlitGame.planeScreenY - py * c * scale,
+      screenSize.x * FlitGame.projectionCenterX + px * c * scale,
+      screenSize.y * FlitGame.projectionCenterY - py * c * scale,
     );
   }
 
   /// Inverse projection: screen → (lng, lat) degrees.
   Vector2 screenToLatLng(Vector2 screenPos, Vector2 screenSize) {
-    final cx = screenSize.x * FlitGame.planeScreenX;
-    final cy = screenSize.y * FlitGame.planeScreenY;
+    final cx = screenSize.x * FlitGame.projectionCenterX;
+    final cy = screenSize.y * FlitGame.projectionCenterY;
     final globeRadius = _globeScreenRadius(screenSize);
     final scale = globeRadius / _angularRadius;
 


### PR DESCRIPTION
…ntrol settings

- Camera: projection center decoupled from plane sprite position. Map projects 18° ahead along heading (at high alt), plane renders at 72% screen height, camera heading lags with ease rate 1.5 for slow recovery on turns — creates a genuine behind-the-plane view.

- Contrails: particles now store world coordinates (lat/lng) instead of screen offsets. Wing-tip positions computed via great-circle math. ContrailRenderer projects world positions to screen each frame so contrails stay fixed on the map as the plane flies away.

- Shader fallback: FlitGame.onLoad now checks shaderManager.isReady after initialize() (which swallows errors internally). Falls back to Canvas WorldMap renderer for all game modes when shader fails.

- Settings: GameSettings singleton with turnSensitivity (slider 0.2–1.5) and invertControls (toggle). Added to profile settings bottom sheet. FlitGame drag handler reads from GameSettings instead of hardcoded values.

https://claude.ai/code/session_01DS8vta8DEzTgtDhSX7Vg91