### PR TITLE
fix: prevent white screen on game errors, show plain text error details

### DIFF
--- a/lib/core/utils/game_log.dart
+++ b/lib/core/utils/game_log.dart
@@ -1,7 +1,5 @@
 import 'dart:developer' as developer;
 
-import 'package:flutter/foundation.dart';
-
 import '../services/error_service.dart';
 
 /// Log severity levels.
@@ -103,9 +101,8 @@ class GameLog {
       stackTrace: entry.stackTrace,
     );
 
-    // Bridge errors/warnings to ErrorService so they appear in DevOverlay.
-    // Only in debug/profile builds — no overhead in release.
-    if (!kReleaseMode && !_bridging) {
+    // Bridge errors/warnings to ErrorService for telemetry and DevOverlay.
+    if (!_bridging) {
       _bridging = true;
       try {
         if (entry.level == LogLevel.error) {

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../core/services/audio_manager.dart';
+import '../core/services/error_service.dart';
 import '../core/services/game_settings.dart';
 import '../core/theme/flit_colors.dart';
 import '../core/utils/game_log.dart';
@@ -225,9 +226,19 @@ class FlitGame extends FlameGame
       } catch (e, st) {
         _log.error('game', 'onGameReady callback failed',
             error: e, stackTrace: st);
+        ErrorService.instance.reportCritical(
+          e,
+          st,
+          context: {'source': 'FlitGame', 'action': 'onGameReady'},
+        );
       }
     } catch (e, st) {
       _log.error('game', 'FlitGame.onLoad FAILED', error: e, stackTrace: st);
+      ErrorService.instance.reportCritical(
+        e,
+        st,
+        context: {'source': 'FlitGame', 'action': 'onLoad'},
+      );
       rethrow;
     }
   }


### PR DESCRIPTION
Three root causes fixed:

1. Loading overlay covered GameWidget errorBuilder — when FlitGame.onLoad() failed, the errorBuilder fired but _gameReady stayed false and _error stayed null, so the loading spinner rendered on top of the error UI. Fix: errorBuilder now schedules setState to set _error, and when _error is set the build method renders ONLY the error screen (no GameWidget).

2. Errors not reported to ErrorService — _startNewGame, GameWidget errorBuilder, and FlitGame.onLoad catch blocks only logged locally. Fix: all catch blocks now call ErrorService.instance.reportCritical().

3. Error messages were generic ("Something went wrong") with no details. Fix: error overlay now shows full error + stack trace as selectable monospace text. GameLog bridges to ErrorService in all build modes.

https://claude.ai/code/session_01PC3a3WdFBKDtUMSS6i7rHK