### PR TITLE
fix: Vercel deploy, iOS error handler, and map camera Y-inversion

### DIFF
--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -117,11 +117,9 @@ class FlitGame extends FlameGame
   /// Sensitivity: how many radians of camera rotation per pixel of drag.
   static const double _cameraDragSensitivity = 0.004;
 
-  /// How far ahead (in degrees) the projection center looks along heading.
-  /// Must be ~56% of angular radius (in degrees) so the plane's world
-  /// position projects to its fixed screen position (y=72%, center=45%).
-  /// High: 0.55 rad = 31.5° → 31.5 × 0.56 = 17.6°
-  /// Low:  0.10 rad = 5.73° → 5.73 × 0.56 = 3.2°
+  /// How far ahead (in degrees) the camera looks along heading.
+  /// The shader Y-flip + these offsets naturally project the plane
+  /// to approximately its fixed screen position (y ≈ 72%).
   static const double _cameraOffsetHigh = 17.6;
   static const double _cameraOffsetLow = 3.2;
 
@@ -224,10 +222,12 @@ class FlitGame extends FlameGame
     final uvX = localX / (localZ * halfFov);
     final uvY = localY / (localZ * halfFov);
 
-    // Convert to screen coords — use projection center, not screen center,
-    // so worldToScreen(planeWorldPos) aligns with the plane's fixed screen pos.
-    final screenX = uvX * size.y + size.x * projectionCenterX;
-    final screenY = uvY * size.y + size.y * projectionCenterY;
+    // Convert to screen coords. Must match the shader's cameraRayDir:
+    //   uv = (fragCoord - 0.5 * resolution) / resolution.y
+    //   uv.y = -uv.y   (Flutter y-down flip)
+    // Inverse: fragCoord = (uvX * res.y + 0.5 * res.x, -uvY * res.y + 0.5 * res.y)
+    final screenX = uvX * size.y + size.x * 0.5;
+    final screenY = -uvY * size.y + size.y * 0.5;
 
     return Vector2(screenX, screenY);
   }
@@ -237,8 +237,8 @@ class FlitGame extends FlameGame
   static const double planeScreenY = 0.72;
   static const double planeScreenX = 0.50;
 
-  /// Where the map projection is centered on screen.
-  /// This is higher up than the plane, so the map shows more world ahead.
+  /// Where the Canvas (WorldMap) renderer centers its projection on screen.
+  /// The shader renderer uses screen center (0.5, 0.5) with a Y-flip instead.
   static const double projectionCenterY = 0.45;
   static const double projectionCenterX = 0.50;
 

--- a/shaders/globe.frag
+++ b/shaders/globe.frag
@@ -210,6 +210,10 @@ vec2 equirectangularUV(vec3 p) {
 // to prevent rolling at non-equatorial latitudes.
 vec3 cameraRayDir(vec2 fragCoord, vec2 resolution, vec3 camPos, vec3 camUp, float fov) {
     vec2 uv = (fragCoord - 0.5 * resolution) / resolution.y;
+    // Flutter fragCoord is y-down; flip Y so camera up maps to screen top.
+    // Without this, the heading direction (camera up) renders at the bottom
+    // of the screen, giving an inverted chase-camera view.
+    uv.y = -uv.y;
     float halfFov = tan(fov * 0.5);
     uv *= halfFov;
 

--- a/vercel.json
+++ b/vercel.json
@@ -3,12 +3,6 @@
   "buildCommand": "",
   "outputDirectory": "",
   "framework": null,
-  "routes": [
-    {
-      "src": "/api/(.*)",
-      "dest": "/api/$1"
-    }
-  ],
   "functions": {
     "api/errors/index.js": {
       "memory": 256,

--- a/web/index.html
+++ b/web/index.html
@@ -102,15 +102,25 @@
     // freezes the screen with the full error text. On iOS PWA this is
     // the only way to see errors — Dart ErrorWidget never renders
     // because the WebView reloads the page on unhandled exceptions.
+    //
+    // PERSISTENCE: On iOS Safari PWA, uncaught errors can force a page
+    // reload before the error overlay is visible. We persist errors in
+    // localStorage so they survive reloads and display on next page load.
 
     var errorBox = document.getElementById('error-box');
     var errors = [];
     var frozen = false;
+    var STORAGE_KEY = 'flit_crash_errors';
 
-    function freezeWithError(msg) {
-      errors.push(msg);
+    // Restore errors from a previous page load (iOS PWA reload recovery).
+    try {
+      var stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        errors = JSON.parse(stored);
+      }
+    } catch (_) {}
 
-      // Build full-screen error display
+    function renderErrorOverlay() {
       errorBox.innerHTML = '';
       var title = document.createElement('div');
       title.className = 'error-title';
@@ -120,6 +130,19 @@
       var body = document.createElement('div');
       body.textContent = errors.join('\n\n---\n\n');
       errorBox.appendChild(body);
+
+      // Dismiss button so the user can clear errors and retry
+      var btn = document.createElement('div');
+      btn.textContent = '[TAP TO DISMISS & RETRY]';
+      btn.style.cssText = 'color:#4A90B8;margin-top:24px;font-size:14px;cursor:pointer;text-align:center;';
+      btn.onclick = function() {
+        errors = [];
+        try { localStorage.removeItem(STORAGE_KEY); } catch (_) {}
+        errorBox.style.display = 'none';
+        frozen = false;
+        location.reload();
+      };
+      errorBox.appendChild(btn);
 
       errorBox.style.display = 'block';
 
@@ -133,6 +156,20 @@
       }
 
       frozen = true;
+    }
+
+    // If we restored errors from a previous crash, show them immediately.
+    if (errors.length > 0) {
+      renderErrorOverlay();
+    }
+
+    function freezeWithError(msg) {
+      errors.push(msg);
+
+      // Persist to localStorage so errors survive iOS PWA page reloads.
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(errors)); } catch (_) {}
+
+      renderErrorOverlay();
     }
 
     // Catch synchronous JS errors
@@ -193,7 +230,7 @@
         }
       };
       fl.onerror = function() {
-        showError('Could not load Flutter engine (neither flutter_bootstrap.js nor flutter.js found).');
+        freezeWithError('Could not load Flutter engine (neither flutter_bootstrap.js nor flutter.js found).');
       };
       document.body.appendChild(fl);
     };


### PR DESCRIPTION
Three fixes:

1. Vercel config: Remove `routes` array that conflicted with `headers` (Vercel v2 doesn't allow both). API routing is automatic for /api/*.

2. iOS Safari error handler: Persist errors in localStorage so they survive PWA page reloads. Add dismiss-and-retry button. Fix broken `showError` reference (was undefined, now `freezeWithError`).

3. Map/camera alignment: Fix Y-axis inversion in the shader's cameraRayDir — Flutter uses y-down coordinates but the UV math assumed y-up, causing the heading direction to render at the bottom of the screen instead of the top. Fix _shaderWorldToScreen to match with -uvY and center at 0.5. This aligns the plane sprite, contrails, and globe rendering correctly for a behind-the-plane chase camera.

https://claude.ai/code/session_015q8vaS4QBKYwB8UaQBHx5t