### PR TITLE
fix: JS errors to Vercel telemetry, open POST auth, early-frame guard

### DIFF
--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -379,6 +379,8 @@ class FlitGame extends FlameGame
   }
 
   void _updateInner(double dt) {
+    // Don't run game logic until a session is active and the game has a size.
+    if (!_isPlaying || size.x < 1 || size.y < 1) return;
 
     // --- Great-circle movement ---
     final speed = _plane.currentSpeed;

--- a/web/index.html
+++ b/web/index.html
@@ -111,6 +111,7 @@
     var errors = [];
     var frozen = false;
     var STORAGE_KEY = 'flit_crash_errors';
+    var ERROR_ENDPOINT = 'https://flit-errors.vercel.app/api/errors';
 
     // Restore errors from a previous page load (iOS PWA reload recovery).
     try {
@@ -119,6 +120,25 @@
         errors = JSON.parse(stored);
       }
     } catch (_) {}
+
+    // POST error to Vercel telemetry (fire-and-forget, never blocks UI).
+    function sendToVercel(msg) {
+      try {
+        var payload = JSON.stringify({
+          error: msg,
+          source: 'js_error_handler',
+          url: location.href,
+          userAgent: navigator.userAgent,
+          timestamp: new Date().toISOString(),
+        });
+        fetch(ERROR_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: payload,
+          keepalive: true,  // survives page unload on iOS
+        }).catch(function() {}); // swallow network failures
+      } catch (_) {}
+    }
 
     function renderErrorOverlay() {
       errorBox.innerHTML = '';
@@ -168,6 +188,9 @@
 
       // Persist to localStorage so errors survive iOS PWA page reloads.
       try { localStorage.setItem(STORAGE_KEY, JSON.stringify(errors)); } catch (_) {}
+
+      // Send to Vercel telemetry (fire-and-forget).
+      sendToVercel(msg);
 
       renderErrorOverlay();
     }


### PR DESCRIPTION
Three fixes:

1. JS error handler now POSTs to Vercel telemetry (fire-and-forget with keepalive for iOS page unloads). Previously only showed an overlay but never sent errors to the backend.

2. API endpoint: POST (error ingestion) is now unauthenticated so the JS client can report errors without exposing the API key. GET (reading errors) still requires X-API-Key auth. The POST handler also accepts lightweight JS payloads (just {error, source, url, userAgent}) by auto-normalizing them to the full schema.

3. Added _isPlaying guard in _updateInner to prevent game logic from running before a session starts or before the widget has a valid size. This prevents NaN/zero-division crashes during early frames.

https://claude.ai/code/session_015q8vaS4QBKYwB8UaQBHx5t