### PR TITLE
fix: error reporting chain — WebErrorBridge, keyless flush, critical …

### DIFF
--- a/lib/core/services/error_sender_http.dart
+++ b/lib/core/services/error_sender_http.dart
@@ -17,12 +17,17 @@ Future<bool> errorSenderHttp({
   required String jsonBody,
 }) async {
   try {
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+    };
+    // Only include the API key if one was configured. The Vercel POST
+    // endpoint is unauthenticated, so this header is optional.
+    if (apiKey.isNotEmpty) {
+      headers['X-API-Key'] = apiKey;
+    }
     final response = await http.post(
       Uri.parse(url),
-      headers: {
-        'Content-Type': 'application/json',
-        'X-API-Key': apiKey,
-      },
+      headers: headers,
       body: jsonBody,
     );
     // 2xx means the server accepted the batch.

--- a/lib/core/services/error_service.dart
+++ b/lib/core/services/error_service.dart
@@ -242,7 +242,11 @@ class ErrorService {
     );
   }
 
-  /// Convenience: report with [ErrorSeverity.critical].
+  /// Report with [ErrorSeverity.critical] and flush immediately.
+  ///
+  /// Critical errors also trigger an immediate flush (fire-and-forget)
+  /// because the app may be about to crash/reload — we can't wait for
+  /// the periodic flush timer.
   void reportCritical(
     Object error,
     StackTrace? stackTrace, {
@@ -254,6 +258,8 @@ class ErrorService {
       severity: ErrorSeverity.critical,
       context: context,
     );
+    // Fire-and-forget immediate flush — don't await.
+    flush();
   }
 
   // ---------------------------------------------------------------------------
@@ -297,7 +303,7 @@ class ErrorService {
     if (_queue.isEmpty) return true;
 
     // Guard: no endpoint or sender configured.
-    if (_apiEndpoint == null || _apiKey == null || _sender == null) {
+    if (_apiEndpoint == null || _sender == null) {
       return false;
     }
 

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -99,6 +99,7 @@ class _PlayScreenState extends State<PlayScreen> {
         'action': 'initState',
         'region': widget.region.name,
       });
+      WebErrorBridge.show('PlayScreen.initState crash:\n$e\n\n$st');
       // Set error synchronously — first build() will see it and skip _game.
       _error = 'initState crashed.\n\nError: $e\n\nStack:\n$st';
     }
@@ -203,6 +204,7 @@ class _PlayScreenState extends State<PlayScreen> {
           'round': '$_currentRound',
         },
       );
+      WebErrorBridge.show('_startNewGame crash:\n$e\n\n$st');
       if (mounted) {
         setState(() {
           _error = 'Failed to start game session.\n\n'


### PR DESCRIPTION
…flush

Three failures in the error chain caused all crash reports to silently disappear:

1. PlayScreen catch blocks called ErrorService.reportCritical() but never called WebErrorBridge.show(). The JS overlay was never triggered, so no visible error appeared on iOS Safari.

2. ErrorService.flush() required _apiKey != null, but the key comes from String.fromEnvironment which is empty at build time. Flush was a permanent no-op. Removed the apiKey requirement from flush() since the POST endpoint is now unauthenticated. Also made errorSenderHttp only include X-API-Key header when a key is actually configured.

3. reportCritical() just queued like reportError() — waiting 60s for a flush that never worked. Now it calls flush() immediately (fire-and- forget) since the app may reload before the periodic timer fires.

https://claude.ai/code/session_015q8vaS4QBKYwB8UaQBHx5t