### PR TITLE
Fix plane direction, overlay crash, and climate visibility

### DIFF
--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -567,8 +567,7 @@ class FlitGame extends FlameGame
     );
 
     // Update heading based on turn input (left/right only).
-    // Negated so right input turns clockwise on the globe.
-    _heading -= _plane.turnDirection * PlaneComponent.turnRate * dt;
+    _heading += _plane.turnDirection * PlaneComponent.turnRate * dt;
 
     // Normalize heading to [-π, π] to prevent accumulation
     while (_heading > pi) { _heading -= 2 * pi; }


### PR DESCRIPTION
- Plane heading: change -= back to += so plane turns toward waypoints instead of away. The -= was incorrectly introduced as a rotation fix but inverted the relationship between turn input and bearing change.
- CountryBorderOverlay: add polygon decimation (stride-based point skipping for large polygons), per-frame point cap (1500 web / 6000 native), and reduced country limits (12 web / 40 native) to prevent canvas overload crash on iOS Safari at low altitude.
- Climate fills: increase opacity from 0.15-0.30 to 0.30-0.50 so Köppen-Geiger climate zones are actually visible over satellite texture.
- Error logging: replace bare catch with gameRef.onError forwarding so overlay errors surface in telemetry instead of being swallowed silently.

https://claude.ai/code/session_012GjBFWxCcAd8vHeZsXSKJB