### PR TITLE
Add chase-camera tilt offset to globe hit testing and rendering

### DIFF
--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -310,10 +310,13 @@ class FlitGame extends FlameGame
 
     // Convert to screen coords. Must match the shader's cameraRayDir:
     //   uv = (fragCoord - 0.5 * resolution) / resolution.y
-    //   uv.y = -uv.y   (Flutter y-down flip)
-    // Inverse: fragCoord = (uvX * res.y + 0.5 * res.x, -uvY * res.y + 0.5 * res.y)
+    //   uv.y = -uv.y          (Flutter y-down flip)
+    //   uv.y += tiltDown       (chase-camera tilt: 0.25)
+    // Inverse: fragCoord.x = uvX * res.y + 0.5 * res.x
+    //          fragCoord.y = -(uvY - tiltDown) * res.y + 0.5 * res.y
+    const tiltDown = 0.25; // Must match globe.frag cameraRayDir tiltDown
     final screenX = uvX * size.y + size.x * 0.5;
-    final screenY = -uvY * size.y + size.y * 0.5;
+    final screenY = -(uvY - tiltDown) * size.y + size.y * 0.5;
 
     return Vector2(screenX, screenY);
   }

--- a/lib/game/rendering/globe_hit_test.dart
+++ b/lib/game/rendering/globe_hit_test.dart
@@ -38,10 +38,14 @@ class GlobeHitTest {
     // -- Step 1: Screen -> UV (matching shader convention) --
     // The shader computes: uv = (fragCoord - 0.5 * resolution) / resolution.y
     // This maps x to [-0.5*aspect, 0.5*aspect] and y to [-0.5, 0.5].
-    // The shader then flips Y (uv.y = -uv.y) because Flutter is y-down.
+    // The shader then flips Y (uv.y = -uv.y) because Flutter is y-down,
+    // and adds a tiltDown offset (uv.y += 0.25) for the chase-camera view.
     // We replicate that here so the inverse projection matches exactly.
+    const tiltDown = 0.25; // Must match globe.frag cameraRayDir tiltDown
     final ndcX = (screenPoint.dx - 0.5 * screenSize.width) / screenSize.height;
-    final ndcY = -(screenPoint.dy - 0.5 * screenSize.height) / screenSize.height;
+    final ndcY =
+        -(screenPoint.dy - 0.5 * screenSize.height) / screenSize.height +
+            tiltDown;
 
     // -- Step 2: NDC -> ray direction --
     // Use the camera's FOV to determine the view-plane distance.

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,8 @@
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Flit - A geography-based flight game">
 
-  <!-- iOS meta tags & icons -->
+  <!-- Mobile web app meta tags & icons -->
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Flit">


### PR DESCRIPTION
## Summary
This PR adds support for a chase-camera tilt offset (0.25 units downward) to both the globe rendering and hit testing systems. This ensures that mouse/touch input correctly maps to the tilted camera view where the horizon is shifted upward on screen.

## Changes

- **Globe rendering (`flit_game.dart`)**: Updated the UV-to-screen coordinate conversion to account for the `tiltDown` offset applied by the shader. The inverse transformation now correctly applies the tilt when converting from normalized device coordinates back to screen space.

- **Hit testing (`globe_hit_test.dart`)**: Added the same `tiltDown` offset (0.25) to the screen-to-NDC conversion so that raycasting for hit detection matches the actual rendered view. This ensures clicks/taps on the globe correspond to the correct 3D positions.

- **Web metadata (`index.html`)**: Updated HTML meta tags to be more inclusive by changing the comment from "iOS meta tags" to "Mobile web app meta tags" and added the `mobile-web-app-capable` meta tag for better Android web app support.

## Implementation Details

The `tiltDown` constant (0.25) is now defined in both files with a comment indicating it must match the value in `globe.frag`. This is a critical synchronization point—if the shader's camera tilt changes, both Dart files must be updated to maintain correct hit detection and rendering alignment.

The mathematical transformation ensures that:
- The shader applies: `uv.y = -uv.y + tiltDown` (after the y-flip for Flutter's y-down coordinate system)
- The inverse in Dart applies: `ndcY = -(screenY - 0.5 * height) / height + tiltDown`

https://claude.ai/code/session_01LsieBRoeNwF2vwFJRTRHbT