### PR TITLE
Progressive turning, mobile L/R buttons, seamless rounds, clue consis…

### DIFF
--- a/lib/features/daily/daily_challenge_screen.dart
+++ b/lib/features/daily/daily_challenge_screen.dart
@@ -102,6 +102,7 @@ class _DailyChallengeScreenState extends ConsumerState<DailyChallengeScreen> {
           clueBoost: license.clueBoost,
           clueChance: license.clueChance,
           preferredClueType: license.preferredClueType,
+          enabledClueTypes: _challenge.enabledClueTypes,
           onComplete: (totalScore) {
             ref.read(accountProvider.notifier).addCoins(reward);
           },

--- a/lib/game/clues/clue_types.dart
+++ b/lib/game/clues/clue_types.dart
@@ -84,6 +84,10 @@ class Clue {
 
   /// Generate a random clue for a country, with validation to avoid "Unknown" data.
   ///
+  /// When [allowedTypes] is provided (e.g. from a daily challenge theme),
+  /// only those clue types will be considered. This overrides the
+  /// [preferredClueType]/[clueBoost] mechanism.
+  ///
   /// When [preferredClueType] and [clueBoost] are provided, the preferred
   /// type has [clueBoost]% more chance of being selected (e.g. clueBoost=5
   /// gives the preferred type a 5 percentage-point bonus).
@@ -91,8 +95,19 @@ class Clue {
     String countryCode, {
     String? preferredClueType,
     int clueBoost = 0,
+    Set<String>? allowedTypes,
   }) {
-    const types = ClueType.values;
+    // Determine the pool of clue types to draw from.
+    final List<ClueType> typePool;
+    if (allowedTypes != null && allowedTypes.isNotEmpty) {
+      typePool = ClueType.values
+          .where((t) => allowedTypes.contains(t.name))
+          .toList();
+    } else {
+      typePool = ClueType.values.toList();
+    }
+    // If the filter left nothing valid, fall back to all types.
+    final types = typePool.isEmpty ? ClueType.values : typePool;
     final random = Random();
     final triedTypes = <ClueType>{};
     const maxRetries = 10;

--- a/lib/game/components/plane_component.dart
+++ b/lib/game/components/plane_component.dart
@@ -96,10 +96,11 @@ class PlaneComponent extends PositionComponent with HasGameRef<FlitGame> {
   static const double _contrailIntervalBase = 0.02;
 
   /// Contrail wing span scale factor.
-  /// Reduces the visual wing span in world-space coordinates to position
-  /// contrails closer to rendered wing tips. Value of 0.5 ensures contrails
-  /// appear to emanate from the wing tips rather than beyond them.
-  static const double _contrailWingSpanScale = 0.5;
+  /// Scales the visual wing span in world-space coordinates to position
+  /// contrails at the wing tips. Value of 0.7 keeps contrails near the
+  /// rendered wing tips while making the gap wide enough that the
+  /// banking foreshortening (bankCos) visibly narrows contrails during turns.
+  static const double _contrailWingSpanScale = 0.7;
 
   /// World position set by FlitGame each frame (lng, lat degrees).
   Vector2 worldPos = Vector2.zero();

--- a/lib/game/session/game_session.dart
+++ b/lib/game/session/game_session.dart
@@ -95,12 +95,16 @@ class GameSession {
 
   /// Create a new random game session.
   ///
+  /// When [allowedClueTypes] is provided (e.g. from a daily challenge
+  /// theme), only those clue types will be generated.
+  ///
   /// When [preferredClueType] and [clueBoost] are provided, the generated
-  /// clue will favour the preferred type.
+  /// clue will favour the preferred type within the allowed set.
   factory GameSession.random({
     GameRegion region = GameRegion.world,
     String? preferredClueType,
     int clueBoost = 0,
+    Set<String>? allowedClueTypes,
   }) {
     final random = Random();
 
@@ -111,6 +115,7 @@ class GameSession {
         country.code,
         preferredClueType: preferredClueType,
         clueBoost: clueBoost,
+        allowedTypes: allowedClueTypes,
       );
 
       // Generate random start position (not too close to target)


### PR DESCRIPTION
…tency

- Progressive keyboard/button turning: taps give gentle 1-5deg corrections, holding ramps up to full turn over ~0.6s (was instant full-turn before)
- Add translucent L/R turn buttons for mobile/touch browser users
- Seamless multi-round advance: correct answer swaps target/clue without teleporting the plane — flight continues from current position/heading
- Wider contrail base gap (0.5 → 0.7 scale) so banking foreshortening during turns visibly narrows the gap between contrails
- Daily challenge clue consistency: thread enabledClueTypes from DailyChallenge through PlayScreen → GameSession → Clue.random so 'borders' mode only generates border clues (was ignoring the filter)

https://claude.ai/code/session_01LsieBRoeNwF2vwFJRTRHbT