### PR TITLE
Fix globe orientation, turn mechanics, contrail behavior, and climate…

### DIFF
--- a/lib/game/rendering/globe_hit_test.dart
+++ b/lib/game/rendering/globe_hit_test.dart
@@ -41,7 +41,7 @@ class GlobeHitTest {
     // The shader then flips Y (uv.y = -uv.y) because Flutter is y-down,
     // and adds a tiltDown offset (uv.y += 0.25) for the chase-camera view.
     // We replicate that here so the inverse projection matches exactly.
-    const tiltDown = 0.25; // Must match globe.frag cameraRayDir tiltDown
+    const tiltDown = -0.25; // Must match globe.frag cameraRayDir tiltDown
     final ndcX = (screenPoint.dx - 0.5 * screenSize.width) / screenSize.height;
     final ndcY =
         -(screenPoint.dy - 0.5 * screenSize.height) / screenSize.height +

--- a/shaders/globe.frag
+++ b/shaders/globe.frag
@@ -215,10 +215,10 @@ vec3 cameraRayDir(vec2 fragCoord, vec2 resolution, vec3 camPos, vec3 camUp, floa
     // of the screen, giving an inverted chase-camera view.
     uv.y = -uv.y;
     
-    // Tilt the view downward for a chase-camera perspective.
-    // This creates a flatter horizon at the bottom of the screen.
-    // Higher values = more downward tilt (0.25 ≈ 14° down from horizontal)
-    const float tiltDown = 0.25;
+    // Tilt the view upward so the globe surface stretches off the bottom
+    // of the screen and the globe's curvature (horizon) is visible at the
+    // top, near the clue menu. Negative = camera looks slightly up.
+    const float tiltDown = -0.25;
     uv.y += tiltDown;
     
     float halfFov = tan(fov * 0.5);


### PR DESCRIPTION
… coloring

Globe rendering:
- Invert tiltDown (-0.25) so globe bleeds off bottom with curvature at top
- Matching fix in hit test and worldToScreen for correct waypoint placement

Turn mechanics:
- Poll HardwareKeyboard each frame for reliable key release on web
- Invert wing shading: turning-side wing darkens, opposite brightens
- snapStraight() zeros turn instantly on waymarker arrival (no drift)
- steerToward() uses dt*12 for visible banking when following waypoints

Contrails:
- Increase maxBankAngle to 1.3 rad (~75°) so contrails nearly touch at max turn
- Asymmetric bank smoothing: fast into turns (10x), slow release (2.5x)

Climate:
- Per-polygon centroid for KG climate colors instead of per-country
- Fine-resolution climate variation within large countries

https://claude.ai/code/session_01LsieBRoeNwF2vwFJRTRHbT