### PR TITLE
fix: point error telemetry to live Vercel deployment (flit-olive)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -151,7 +151,7 @@ If more textures needed → pack into RGBA channels or use multi-pass rendering.
 ### Debugging
 ```bash
 # Fetch recent errors from Vercel
-curl -H "X-API-Key: $KEY" https://flit-errors.vercel.app/api/errors?limit=10
+curl -H "X-API-Key: $KEY" https://flit-olive.vercel.app/api/errors?limit=10
 
 # Trigger error log fetch
 gh workflow run fetch-errors.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ dart format lib/ test/ --fix # Auto-fix formatting
 flutter analyze              # Static analysis
 
 # Error Telemetry
-curl -H "X-API-Key: $KEY" https://flit-errors.vercel.app/api/errors?limit=10
+curl -H "X-API-Key: $KEY" https://flit-olive.vercel.app/api/errors?limit=10
 gh workflow run fetch-errors.yml
 ```
 

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -842,7 +842,7 @@ flutter run -d chrome --enable-experiment=native-assets
 git push origin main  # triggers GitHub Action
 
 # Check error telemetry
-curl -H "X-API-Key: $VERCEL_KEY" https://flit-errors.vercel.app/api/errors?limit=10
+curl -H "X-API-Key: $VERCEL_KEY" https://flit-olive.vercel.app/api/errors?limit=10
 
 # Fetch errors into repo
 gh workflow run fetch-errors.yml

--- a/docs/ERROR_TELEMETRY_FIXES.md
+++ b/docs/ERROR_TELEMETRY_FIXES.md
@@ -121,7 +121,7 @@ Added debug logging (only active in debug builds):
 Example output:
 ```
 [ErrorService] Initialized:
-[ErrorService]   Endpoint: https://flit-errors.vercel.app/api/errors
+[ErrorService]   Endpoint: https://flit-olive.vercel.app/api/errors
 [ErrorService]   API Key: SET (32 chars)
 [ErrorService]   Session ID: abc123-def456
 
@@ -198,7 +198,7 @@ Check errors via API:
 ```bash
 # Get recent errors (requires API key)
 curl -H "X-API-Key: $KEY" \
-  "https://flit-errors.vercel.app/api/errors?limit=10"
+  "https://flit-olive.vercel.app/api/errors?limit=10"
 
 # Expected response:
 {
@@ -277,7 +277,7 @@ The app uses these environment variables (passed via `--dart-define`):
 
 ```yaml
 # In GitHub Actions deploy.yml
---dart-define=ERROR_ENDPOINT=https://flit-errors.vercel.app/api/errors
+--dart-define=ERROR_ENDPOINT=https://flit-olive.vercel.app/api/errors
 --dart-define=VERCEL_ERRORS_API_KEY=${{ secrets.VERCEL_ERRORS_API_KEY }}
 ```
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -70,7 +70,7 @@ flutter run -d chrome \
 
 # Test the endpoint directly with curl.
 # POST an error:
-curl -X POST https://flit-errors.vercel.app/api/errors \
+curl -X POST https://flit-olive.vercel.app/api/errors \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $VERCEL_ERRORS_API_KEY" \
   -d '{
@@ -85,7 +85,7 @@ curl -X POST https://flit-errors.vercel.app/api/errors \
 
 # GET errors:
 curl -H "X-API-Key: $VERCEL_ERRORS_API_KEY" \
-  "https://flit-errors.vercel.app/api/errors?limit=5"
+  "https://flit-olive.vercel.app/api/errors?limit=5"
 ```
 
 You can also create a `.env` file in the project root (already in

--- a/lib/core/services/error_service.dart
+++ b/lib/core/services/error_service.dart
@@ -83,7 +83,7 @@ typedef ErrorSender = Future<bool> Function({
 /// ```dart
 /// final errorService = ErrorService.instance;
 /// errorService.initialize(
-///   apiEndpoint: 'https://flit-errors.vercel.app/api/errors',
+///   apiEndpoint: 'https://flit-olive.vercel.app/api/errors',
 ///   apiKey: const String.fromEnvironment('VERCEL_ERRORS_API_KEY'),
 /// );
 ///

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,7 +31,7 @@ void main() {
   errorService.initialize(
     apiEndpoint: const String.fromEnvironment(
       'ERROR_ENDPOINT',
-      defaultValue: 'https://flit-errors.vercel.app/api/errors',
+      defaultValue: 'https://flit-olive.vercel.app/api/errors',
     ),
     apiKey: const String.fromEnvironment('VERCEL_ERRORS_API_KEY'),
   );

--- a/web/index.html
+++ b/web/index.html
@@ -117,7 +117,7 @@
     var errors = [];
     var frozen = false;
     var STORAGE_KEY = 'flit_crash_errors';
-    var ERROR_ENDPOINT = 'https://flit-errors.vercel.app/api/errors';
+    var ERROR_ENDPOINT = 'https://flit-olive.vercel.app/api/errors';
 
     // Restore errors from a previous page load (iOS PWA reload recovery).
     // Check both localStorage and sessionStorage.


### PR DESCRIPTION
The app and all docs referenced flit-errors.vercel.app which returns DEPLOYMENT_NOT_FOUND. The actual live deployment is flit-olive.vercel.app. Updated all 8 files: main.dart, web/index.html, error_service.dart docstring, CLAUDE.md, copilot-instructions.md, SECRETS.md, ERROR_TELEMETRY_FIXES.md, and SPRINTS.md.

https://claude.ai/code/session_013dfWtRh6QPMR5kGC8pv5iZ