### PR TITLE
fix: correct blue_marble texture extension from .jpg to .png

### DIFF
--- a/lib/game/rendering/shader_manager.dart
+++ b/lib/game/rendering/shader_manager.dart
@@ -168,7 +168,7 @@ class ShaderManager {
     // All textures are optional - the game will run with black fallback
     // textures if any fail to load.
     final textureResults = await Future.wait<Map<String, dynamic>>([
-      _loadImage('assets/textures/blue_marble.jpg')
+      _loadImage('assets/textures/blue_marble.png')
           .then((img) => <String, dynamic>{'name': 'satellite', 'image': img})
           .catchError((e, st) => <String, dynamic>{'name': 'satellite', 'error': e, 'stack': st}),
       _loadImage('assets/textures/heightmap.png')
@@ -213,7 +213,7 @@ class ShaderManager {
         
         // Extract more details from the error for better debugging
         final errorStr = error.toString();
-        final assetPath = name == 'satellite' ? 'assets/textures/blue_marble.jpg'
+        final assetPath = name == 'satellite' ? 'assets/textures/blue_marble.png'
             : name == 'heightmap' ? 'assets/textures/heightmap.png'
             : name == 'shore_distance' ? 'assets/textures/shore_distance.png'
             : 'assets/textures/city_lights.png';


### PR DESCRIPTION
The convert_assets.py script converts blue_marble.jpg to .png and
deletes the original, but shader_manager.dart still referenced the
.jpg extension. This caused a 404 on web, preventing the satellite
texture from loading and forcing fallback to Canvas rendering.

https://claude.ai/code/session_01X3NUPicCV1FyR5Kf5oVeJg