### PR TITLE
Fix 6 gameplay issues: plane direction, shading, turns, clues, borders

### DIFF
--- a/lib/core/services/game_settings.dart
+++ b/lib/core/services/game_settings.dart
@@ -58,17 +58,6 @@ class GameSettings extends ChangeNotifier {
 
   // ─── Display ────────────────────────────────────────────────────
 
-  /// When false, the globe renders the raw satellite texture with no
-  /// diffuse lighting, ocean effects, foam, clouds, or atmosphere.
-  bool _enableShading = true;
-
-  bool get enableShading => _enableShading;
-
-  set enableShading(bool value) {
-    _enableShading = value;
-    notifyListeners();
-  }
-
   /// When false, the globe is always fully lit (daytime everywhere).
   /// No city lights, no terminator glow, no stars behind the globe.
   bool _enableNight = true;

--- a/lib/core/widgets/settings_sheet.dart
+++ b/lib/core/widgets/settings_sheet.dart
@@ -118,16 +118,6 @@ class _SettingsSheetContentState extends State<_SettingsSheetContent> {
           // ── Display ────────────────────────────────────────
           const _SectionHeader(title: 'Display'),
           _SettingsToggle(
-            label: 'Shading',
-            icon: Icons.wb_sunny_outlined,
-            value: GameSettings.instance.enableShading,
-            onChanged: (value) {
-              GameSettings.instance.enableShading = value;
-              setState(() {});
-            },
-          ),
-          const Divider(color: FlitColors.cardBorder, height: 1),
-          _SettingsToggle(
             label: 'Night / Day Cycle',
             icon: Icons.nightlight_outlined,
             value: GameSettings.instance.enableNight,

--- a/lib/game/clues/clue_types.dart
+++ b/lib/game/clues/clue_types.dart
@@ -286,11 +286,20 @@ class Clue {
         // Flag clues are always valid
         return true;
       case ClueType.outline:
-        // Check if polygons/points exist and are not empty
+        // Check if polygons/points exist and have enough vertices to be
+        // recognisable.  Countries with fewer than 10 total vertices look
+        // like generic rectangles and are impossible to identify by shape.
         final polygons = clue.displayData['polygons'] as List?;
         final points = clue.displayData['points'] as List?;
-        return (polygons != null && polygons.isNotEmpty) ||
-               (points != null && points.isNotEmpty);
+        if (polygons != null && polygons.isNotEmpty) {
+          var totalVertices = 0;
+          for (final poly in polygons) {
+            totalVertices += (poly as List).length;
+          }
+          return totalVertices >= 10;
+        }
+        if (points != null && points.length >= 10) return true;
+        return false;
       case ClueType.borders:
         // Check if neighbors list exists and is not empty
         final neighbors = clue.displayData['neighbors'] as List<String>?;

--- a/lib/game/components/country_border_overlay.dart
+++ b/lib/game/components/country_border_overlay.dart
@@ -257,9 +257,9 @@ class CountryBorderOverlay extends Component with HasGameRef<FlitGame> {
     if (borderOpacity < 0.01) return;
 
     final borderPaint = Paint()
-      ..color = FlitColors.border.withOpacity(borderOpacity * 0.7)
+      ..color = Colors.white.withOpacity(borderOpacity * 0.8)
       ..style = PaintingStyle.stroke
-      ..strokeWidth = continuousAlt >= 0.6 ? 0.6 : 1.0
+      ..strokeWidth = continuousAlt >= 0.6 ? 1.0 : 1.5
       ..strokeJoin = StrokeJoin.round;
 
     // Active country highlight: thicker, brighter border.

--- a/lib/game/components/plane_component.dart
+++ b/lib/game/components/plane_component.dart
@@ -1237,15 +1237,14 @@ class PlaneComponent extends PositionComponent with HasGameRef<FlitGame> {
     _isDragging = true;
   }
 
-  /// Smoothly steer toward a target turn direction (for waypoint auto-steering).
+  /// Steer toward a target turn direction (for waypoint auto-steering).
   /// Sets [_isDragging] so that update()'s turn-decay doesn't fight the input.
-  /// Interpolates with fast attack (dt*12) so banking is clearly visible
-  /// when following a waypoint.
+  /// Sets _turnDirection directly (like keyboard input) so that the bank
+  /// animation in update() is clearly visible during waypoint turns.
+  /// The bank smoothing in update() already provides visual easing.
   void steerToward(double target, double dt) {
     final clamped = target.clamp(-1.0, 1.0);
-    // Fast interpolation toward target turn direction for visible banking
-    _turnDirection += (clamped - _turnDirection) * (dt * 12.0).clamp(0.0, 1.0);
-    _turnDirection = _turnDirection.clamp(-1.0, 1.0);
+    _turnDirection = clamped;
     _isDragging = true;
   }
 

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -174,7 +174,11 @@ class FlitGame extends FlameGame
   double _countryCheckTimer = 0.0;
 
   /// How often to check country (seconds).
-  static const double _countryCheckInterval = 0.5;
+  /// Must be short enough that at max speed the plane doesn't skip over
+  /// small countries between checks. At high altitude + fast speed the
+  /// plane covers ~5.8°/s, so 0.1 s → 0.58° per check — safe for most
+  /// countries.
+  static const double _countryCheckInterval = 0.1;
 
   /// Flash animation timer when entering a new country (seconds remaining).
   double _countryFlashTimer = 0.0;
@@ -341,12 +345,14 @@ class FlitGame extends FlameGame
 
     // Convert to screen coords. Must match the shader's cameraRayDir:
     //   uv = (fragCoord - 0.5 * resolution) / resolution.y
-    //   uv.y += tiltDown       (chase-camera tilt, no Y-flip)
-    // Inverse: fragCoord.x = uvX * res.y + 0.5 * res.x
-    //          fragCoord.y = (uvY - tiltDown) * res.y + 0.5 * res.y
+    //   uv.y = -uv.y           (Y-flip: Flutter y-down → screen y-up)
+    //   uv.y += tiltDown        (chase-camera tilt)
+    // Solving for fragCoord:
+    //   fragCoord.x = uvX * res.y + 0.5 * res.x
+    //   fragCoord.y = (tiltDown - uvY) * res.y + 0.5 * res.y
     const tiltDown = 0.25; // Must match globe.frag cameraRayDir tiltDown
     final screenX = uvX * size.y + size.x * 0.5;
-    final screenY = (uvY - tiltDown) * size.y + size.y * 0.5;
+    final screenY = (tiltDown - uvY) * size.y + size.y * 0.5;
 
     return Vector2(screenX, screenY);
   }

--- a/lib/game/rendering/globe_hit_test.dart
+++ b/lib/game/rendering/globe_hit_test.dart
@@ -37,14 +37,13 @@ class GlobeHitTest {
 
     // -- Step 1: Screen -> UV (matching shader convention) --
     // The shader computes: uv = (fragCoord - 0.5 * resolution) / resolution.y
-    // This maps x to [-0.5*aspect, 0.5*aspect] and y to [-0.5, 0.5].
-    // The shader computes uv.y = (fragCoord.y - 0.5*res.y) / res.y + tiltDown.
-    // No Y-flip: positive uv.y = screen bottom = heading direction.
+    // then flips Y: uv.y = -uv.y (Flutter y-down → screen y-up).
+    // Then adds tiltDown to shift view toward heading.
     // We replicate that here so the inverse projection matches exactly.
     const tiltDown = 0.25; // Must match globe.frag cameraRayDir tiltDown
     final ndcX = (screenPoint.dx - 0.5 * screenSize.width) / screenSize.height;
     final ndcY =
-        (screenPoint.dy - 0.5 * screenSize.height) / screenSize.height +
+        -((screenPoint.dy - 0.5 * screenSize.height) / screenSize.height) +
             tiltDown;
 
     // -- Step 2: NDC -> ray direction --

--- a/lib/game/rendering/shader_manager.dart
+++ b/lib/game/rendering/shader_manager.dart
@@ -339,8 +339,8 @@ class ShaderManager {
       // uFOV
       s.setFloat(14, camera.fov);
 
-      // uEnableShading (0.0 = raw texture, 1.0 = full shading)
-      s.setFloat(15, GameSettings.instance.enableShading ? 1.0 : 0.0);
+      // uEnableShading — always disabled (raw satellite texture, no lighting)
+      s.setFloat(15, 0.0);
 
       // uEnableNight (0.0 = always day, 1.0 = day/night cycle)
       s.setFloat(16, GameSettings.instance.enableNight ? 1.0 : 0.0);

--- a/shaders/globe.frag
+++ b/shaders/globe.frag
@@ -212,14 +212,13 @@ vec2 equirectangularUV(vec3 p) {
 // to prevent rolling at non-equatorial latitudes.
 vec3 cameraRayDir(vec2 fragCoord, vec2 resolution, vec3 camPos, vec3 camUp, float fov) {
     vec2 uv = (fragCoord - 0.5 * resolution) / resolution.y;
-    // Flutter fragCoord is y-down, so uv.y < 0 at screen top, > 0 at
-    // screen bottom.  Camera "up" aligns with the heading direction,
-    // so positive uv.y (bottom) shows what's ahead of the plane —
-    // a natural chase-camera view (ground below, horizon at top).
-    //
-    // tiltDown > 0 shifts the view toward heading, pushing the globe
-    // disk down so more surface is visible and the curvature / horizon
-    // sits near the top of the screen.
+    // Flutter fragCoord is y-down (0 at top, height at bottom).
+    // Negate uv.y so that screen-up = positive = heading direction,
+    // matching the plane overlay which faces up on screen.
+    uv.y = -uv.y;
+    // tiltDown > 0 shifts the view toward heading (up on screen),
+    // pushing the globe disk down so more surface is visible and
+    // the curvature / horizon sits near the top of the screen.
     const float tiltDown = 0.25;
     uv.y += tiltDown;
     


### PR DESCRIPTION
1. Fix upside-down globe: negate shader uv.y so heading maps to screen-up, matching the plane overlay direction. Update hit-test and worldToScreen inverse projections for consistency.

2. Remove shading: always disable the shader lighting pipeline (raw satellite texture only). Remove the Shading toggle from Settings UI and the enableShading property from GameSettings.

3. Fix waypoint turn animation: change steerToward() to set _turnDirection directly (like keyboard input) instead of slow interpolation, so banking is clearly visible during waypoint-guided turns.

4. Fix clue completion at any altitude: reduce country detection interval from 0.5s to 0.1s so fast-moving high-altitude planes don't skip over small countries between checks.

5. Make country borders white: change border stroke color from dark green (FlitColors.border) to white with higher opacity and thicker strokes for better visibility against satellite imagery.

6. Reject low-resolution outline clues: add minimum 10-vertex threshold to outline clue validation so unrecognizable country shapes (4-6 vertices) fall back to other clue types like flag or capital.

https://claude.ai/code/session_01VbXD4janXzr5FVdXHmafWR