### PR TITLE
Rebuild turning system to meet all user requirements

### DIFF
--- a/lib/game/components/wayline_renderer.dart
+++ b/lib/game/components/wayline_renderer.dart
@@ -58,8 +58,9 @@ class WaylineRenderer extends Component with HasGameRef<FlitGame> {
     bool isHint = false,
   }) {
     // Build screen points along the great-circle arc.
+    // Start from i=1 (skip the plane origin) — we prepend the nose below.
     final points = <Offset>[];
-    for (var i = 0; i <= _segments; i++) {
+    for (var i = 1; i <= _segments; i++) {
       final t = i / _segments;
       final interp = _interpolateGreatCircle(planePos, target, t);
       final screen = gameRef.worldToScreen(interp);
@@ -67,6 +68,19 @@ class WaylineRenderer extends Component with HasGameRef<FlitGame> {
         points.add(Offset(screen.x, screen.y));
       }
     }
+
+    if (points.isEmpty) return;
+
+    // Prepend the plane's nose screen position so the line visually
+    // originates from the front of the aircraft, not the center.
+    final plane = gameRef.plane;
+    final totalRotation = plane.visualHeading + plane.turnDirection * 0.4;
+    const noseLength = 13.0; // ~16px nose offset * perspectiveScaleY(0.80)
+    final nosePos = Offset(
+      plane.position.x + sin(totalRotation) * noseLength,
+      plane.position.y - cos(totalRotation) * noseLength,
+    );
+    points.insert(0, nosePos);
 
     if (points.length < 2) return;
 

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -802,11 +802,11 @@ class FlitGame extends FlameGame
     } else {
       // Smooth ease-out: camera heading chases plane heading.
       // During turns, reduce the tracking speed so the camera lags behind,
-      // creating a cinematic "catch-up" effect. At full bank the rate drops
-      // to 40% of normal (~4.8), giving a ~0.6s convergence time vs ~0.25s
-      // in straight flight. This prevents motion sickness during sharp turns.
+      // creating a really gradual "catch-up" effect. At full bank the rate
+      // drops to 20% of normal (~2.4), giving a ~1.3s convergence time vs
+      // ~0.25s in straight flight. This prevents motion sickness.
       final turnMag = _plane.turnDirection.abs();
-      final easeRate = _cameraHeadingEaseRate * (1.0 - turnMag * 0.6);
+      final easeRate = _cameraHeadingEaseRate * (1.0 - turnMag * 0.8);
       final factor = 1.0 - exp(-easeRate * dt);
       _cameraHeading = _lerpAngle(_cameraHeading, _heading, factor);
     }
@@ -957,7 +957,7 @@ class FlitGame extends FlameGame
       _waymarker = null; // keyboard/button overrides waymarker
     } else if (_waymarker == null &&
         (_keyTurnHoldTime > 0 || _buttonTurnHoldTime > 0)) {
-      // Just released — coast to straight.
+      // Just released — immediately stop turning and straighten.
       _keyTurnHoldTime = 0.0;
       _buttonTurnHoldTime = 0.0;
       _plane.releaseTurn();


### PR DESCRIPTION
Fixes 5 failing/partial requirements from the turning audit:

R1 (wayline from nose): Wayline now starts from the plane's nose screen position using sin/cos of the total rotation angle, not the center.

R2+R4+R5 (nose/fuselage rotation proportional to severity): Increased turn yaw from 0.15 rad (8.6°, barely visible) to 0.4 rad (23° at max turn). canvas.rotate() applies to the entire plane (nose, fuselage, wings), making the whole aircraft visibly point toward the turn direction. Proportional: 8% tap → 1.8°, full hold → 23°.

R8+R11 (release stops turning immediately): releaseTurn() now zeros _turnDirection instantly instead of relying on exponential decay (0.5s coast). The heading stops changing the frame the player releases. The bank angle still smooths out visually via the 2.5 rate for a natural wing-leveling animation. Removed the decay loop and _turnDecayRate constant.

R7 (camera more gradual): Increased turn damping from 0.6 to 0.8, so at full bank the camera ease rate drops to 20% (2.4), giving ~1.3s convergence vs the previous ~0.6s.

https://claude.ai/code/session_013WhXQE5ZGtHmvHJBWER6oG