### PR TITLE
Fix mirrored globe, turn direction, propeller order, fuselage roll, c…

### DIFF
--- a/lib/game/rendering/globe_hit_test.dart
+++ b/lib/game/rendering/globe_hit_test.dart
@@ -75,17 +75,17 @@ class GlobeHitTest {
     final cupY = camera.upY;
     final cupZ = camera.upZ;
 
-    // Right = normalize(cross(forward, camUp))
-    var rX = fY * cupZ - fZ * cupY;
-    var rY = fZ * cupX - fX * cupZ;
-    var rZ = fX * cupY - fY * cupX;
+    // Right = normalize(cross(camUp, forward)) — east on screen-right
+    var rX = cupY * fZ - cupZ * fY;
+    var rY = cupZ * fX - cupX * fZ;
+    var rZ = cupX * fY - cupY * fX;
 
     final rLen = sqrt(rX * rX + rY * rY + rZ * rZ);
     if (rLen < 1e-8) {
-      // Degenerate: forward and up are parallel. Fall back to world up.
-      rX = fY * 0.0 - fZ * 1.0;
-      rY = fZ * 0.0 - fX * 0.0;
-      rZ = fX * 1.0 - fY * 0.0;
+      // Degenerate: forward and up are parallel. Fall back to cross(worldUp, forward).
+      rX = 1.0 * fZ - 0.0 * fY;
+      rY = 0.0 * fX - 0.0 * fZ;
+      rZ = 0.0 * fY - 1.0 * fX;
       final rLen2 = sqrt(rX * rX + rY * rY + rZ * rZ);
       if (rLen2 < 1e-8) return null;
       rX /= rLen2;
@@ -97,10 +97,10 @@ class GlobeHitTest {
       rZ /= rLen;
     }
 
-    // Up = cross(right, forward)
-    final uX = rY * fZ - rZ * fY;
-    final uY = rZ * fX - rX * fZ;
-    final uZ = rX * fY - rY * fX;
+    // Up = cross(forward, right) — heading direction on screen-up
+    final uX = fY * rZ - fZ * rY;
+    final uY = fZ * rX - fX * rZ;
+    final uZ = fX * rY - fY * rX;
 
     // Transform local ray direction to world space.
     // rayWorld = right * localX + up * localY + forward * (-localZ)

--- a/shaders/globe.frag
+++ b/shaders/globe.frag
@@ -230,8 +230,8 @@ vec3 cameraRayDir(vec2 fragCoord, vec2 resolution, vec3 camPos, vec3 camUp, floa
 
     // Camera always looks at the globe center (origin).
     vec3 forward = normalize(-camPos);
-    vec3 right   = normalize(cross(forward, camUp));
-    vec3 up      = cross(right, forward);
+    vec3 right   = normalize(cross(camUp, forward));
+    vec3 up      = cross(forward, right);
 
     return normalize(uv.x * right + uv.y * up + forward);
 }


### PR DESCRIPTION
…ontrails, game start

- Unmirror globe: swap cross(forward,camUp) → cross(camUp,forward) in shader, Dart projection, and hit test so east appears on screen-right
- Fix turn direction: flip invert sign so RIGHT input → right turn on unmirrored globe; revert bank negation to match
- Move propellers to bottom render layer (behind fuselage/wings) in biplane; add missing propeller to triplane
- Add fuselage roll: horizontal compression (rollScale) when banked across all 7 plane renderers
- Smooth contrail altitude transition: use _altitudeTransition instead of _continuousAltitude to avoid step artifact
- Game start: compute heading toward target via great-circle bearing instead of random heading

https://claude.ai/code/session_013WhXQE5ZGtHmvHJBWER6oG