### PR TITLE
Bump minimum SDK to >=3.6.0 for flutter_map ^8.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.1.0+1
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
flutter_map >=8.0.0 requires Dart SDK >=3.6.0. The previous constraint of >=3.2.0 caused version solving to fail.

https://claude.ai/code/session_013WhXQE5ZGtHmvHJBWER6oG