### PR TITLE
Fix CI: downgrade flutter_map to ^6.1.0 for Dart 3.2 compatibility

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -776,7 +776,6 @@ class _PlayScreenState extends State<PlayScreen> {
 
           // OSM tile map — shown during descent mode (low altitude).
           // Covers the globe shader with real-world map tiles.
-          // flutter_map's built-in caching stores tiles for offline use.
           if (_gameReady && _session != null && !_isHighAltitude)
             Positioned.fill(
               child: DescentMapView(

--- a/lib/game/map/descent_map_view.dart
+++ b/lib/game/map/descent_map_view.dart
@@ -7,8 +7,8 @@ import 'package:latlong2/latlong.dart';
 /// OSM tile map shown during descent mode.
 ///
 /// Renders OpenStreetMap tiles with the player's current position and heading.
-/// Uses flutter_map's built-in tile caching (1 GB soft limit on non-web;
-/// browser cache on web). No additional caching package needed.
+/// Uses flutter_map v6 (compatible with Dart 3.2 / Flutter 3.16).
+/// On web, the browser cache handles tile storage.
 ///
 /// The map is non-interactive — position and zoom are driven entirely by
 /// the game state (player lng/lat and altitude transition). Wrapped in
@@ -95,7 +95,6 @@ class _DescentMapViewState extends State<DescentMapView> {
             userAgentPackageName: 'com.jamiembright.flit',
             maxZoom: 18,
             subdomains: const ['a', 'b', 'c'],
-            // Built-in caching is enabled by default on non-web platforms.
             // On web, the browser cache handles tile storage.
           ),
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.1.0+1
 
 environment:
-  sdk: '>=3.6.0 <4.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -26,8 +26,8 @@ dependencies:
   flag: ^7.0.2
 
   # OSM tile map for descent mode (cross-platform: iOS, Android, Web)
-  # Built-in tile caching since v8.2 (1GB soft limit, auto on non-web)
-  flutter_map: ^8.2.2
+  # Pinned to v6 for Dart SDK 3.2 compatibility (Flutter 3.16)
+  flutter_map: ^6.1.0
   latlong2: ^0.9.1
 
   # Audio (cross-platform: iOS, Android, Web)


### PR DESCRIPTION
CI uses Flutter 3.16.0 (Dart 3.2.3), but flutter_map ^8.2.2 requires Dart >=3.6.0. Downgrade to ^6.1.0 and revert SDK constraint to >=3.2.0.

https://claude.ai/code/session_013WhXQE5ZGtHmvHJBWER6oG