### PR TITLE
Fix CI: pin flag to 7.0.0 for Dart SDK 3.2 compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,8 @@ dependencies:
   http: ^1.1.0
 
   # Country flag SVGs (cross-platform: iOS, Android, Web)
-  flag: ^7.0.2
+  # Pinned to 7.0.0 for Dart SDK 3.2 compatibility (>=7.0.1 needs >=3.4.0)
+  flag: 7.0.0
 
   # OSM tile map for descent mode (cross-platform: iOS, Android, Web)
   # Pinned to v6 for Dart SDK 3.2 compatibility (Flutter 3.16)


### PR DESCRIPTION
flag >=7.0.1 depends on flutter_svg >=2.0.11 which requires Dart >=3.4.0, incompatible with CI's Dart 3.2.0 (Flutter 3.16.0).

https://claude.ai/code/session_013WhXQE5ZGtHmvHJBWER6oG