### PR TITLE
Fix descend mode: keep game sprite, topo default, align OSM to globe,…

### DIFF
--- a/lib/core/services/game_settings.dart
+++ b/lib/core/services/game_settings.dart
@@ -87,7 +87,7 @@ class GameSettings extends ChangeNotifier {
   }
 
   /// Map tile style for descent mode (OSM, dark, voyager, topo).
-  MapStyle _mapStyle = MapStyle.dark;
+  MapStyle _mapStyle = MapStyle.topo;
 
   MapStyle get mapStyle => _mapStyle;
 

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -779,8 +779,8 @@ class _PlayScreenState extends State<PlayScreen> {
           if (_gameReady && _session != null && !_isHighAltitude)
             Positioned.fill(
               child: DescentMapView(
-                playerLng: _game.worldPosition.x,
-                playerLat: _game.worldPosition.y,
+                centerLng: _game.cameraPosition.x,
+                centerLat: _game.cameraPosition.y,
                 heading: _game.heading,
                 altitudeTransition: 0.0,
                 tileUrl: GameSettings.instance.mapTileUrl,

--- a/lib/game/components/plane_component.dart
+++ b/lib/game/components/plane_component.dart
@@ -58,8 +58,8 @@ class PlaneComponent extends PositionComponent with HasGameRef<FlitGame> {
   /// 36 units ≈ 3.6°/sec → crossing Europe (~36°) takes ~10 seconds.
   static const double highAltitudeSpeed = 36;
 
-  /// Speed multiplier at low altitude
-  static const double lowAltitudeSpeedMultiplier = 0.5;
+  /// Speed multiplier at low altitude (really slow for descent exploration).
+  static const double lowAltitudeSpeedMultiplier = 0.1;
 
   /// Turn rate in radians per second at high altitude.
   /// 2.2 gives sweeping arcs (~2.9s per full circle).

--- a/lib/game/map/descent_map_view.dart
+++ b/lib/game/map/descent_map_view.dart
@@ -16,16 +16,17 @@ import 'package:latlong2/latlong.dart';
 class DescentMapView extends StatefulWidget {
   const DescentMapView({
     super.key,
-    required this.playerLng,
-    required this.playerLat,
+    required this.centerLng,
+    required this.centerLat,
     required this.heading,
     required this.altitudeTransition,
     required this.tileUrl,
   });
 
-  /// Player position in degrees.
-  final double playerLng;
-  final double playerLat;
+  /// Map center in degrees (offset ahead of player so the player
+  /// appears at ~80% screen height, matching the plane sprite).
+  final double centerLng;
+  final double centerLat;
 
   /// Player heading in radians (code convention: 0 = east, π/2 = north).
   final double heading;
@@ -64,7 +65,7 @@ class _DescentMapViewState extends State<DescentMapView> {
     super.didUpdateWidget(oldWidget);
     if (_mapReady) {
       _mapController.move(
-        LatLng(widget.playerLat, widget.playerLng),
+        LatLng(widget.centerLat, widget.centerLng),
         _zoom,
       );
       _mapController.rotate(_rotation);
@@ -77,7 +78,7 @@ class _DescentMapViewState extends State<DescentMapView> {
       child: FlutterMap(
         mapController: _mapController,
         options: MapOptions(
-          initialCenter: LatLng(widget.playerLat, widget.playerLng),
+          initialCenter: LatLng(widget.centerLat, widget.centerLng),
           initialZoom: _zoom,
           initialRotation: _rotation,
           // Disable all user interaction — game controls the camera
@@ -98,35 +99,8 @@ class _DescentMapViewState extends State<DescentMapView> {
             // On web, the browser cache handles tile storage.
           ),
 
-          // Player position marker (plane icon)
-          MarkerLayer(
-            markers: [
-              Marker(
-                point: LatLng(widget.playerLat, widget.playerLng),
-                width: 40,
-                height: 40,
-                child: Transform.rotate(
-                  // Rotate plane icon to match heading.
-                  // Icon points up (north) by default. Map is rotated so
-                  // the player's heading faces screen-up, so the plane
-                  // icon should point up = forward.
-                  angle: 0, // already aligned via map rotation
-                  child: const Icon(
-                    Icons.airplanemode_active,
-                    color: Colors.white,
-                    size: 32,
-                    shadows: [
-                      Shadow(
-                        blurRadius: 4,
-                        color: Colors.black54,
-                        offset: Offset(1, 1),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ],
-          ),
+          // No plane marker — the game's existing plane sprite stays visible
+          // on the Canvas overlay at its fixed screen position (50%, 80%).
 
           // OSM attribution (required by tile usage policy)
           const RichAttributionWidget(


### PR DESCRIPTION
… slow speed

- Remove Material airplane marker from DescentMapView — the game's existing plane sprite stays visible at its fixed screen position (50%, 80%)
- Default map style to topo (OpenTopoMap) instead of dark
- Center OSM map on cameraPosition (ahead of player) to match Blue Marble globe framing so lat/lon alignment is consistent across modes
- Reduce low altitude speed multiplier from 0.5 to 0.1 for really slow descent exploration

https://claude.ai/code/session_013WhXQE5ZGtHmvHJBWER6oG