### PR TITLE
Fix descend mode: sprite visibility, map orientation, navigation

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -743,7 +743,23 @@ class _PlayScreenState extends State<PlayScreen> {
       body: Stack(
         fit: StackFit.expand,
         children: [
-          // Game canvas – use builders to avoid white flash during init
+          // OSM tile map — shown during descent mode (low altitude).
+          // Sits BEHIND the game canvas so the plane sprite floats on top.
+          // In descent mode the game canvas is transparent (globe shader skipped).
+          if (_gameReady && _session != null && !_isHighAltitude)
+            Positioned.fill(
+              child: DescentMapView(
+                centerLng: _game.cameraPosition.x,
+                centerLat: _game.cameraPosition.y,
+                heading: _game.cameraHeadingBearing,
+                altitudeTransition: 0.0,
+                tileUrl: GameSettings.instance.mapTileUrl,
+              ),
+            ),
+
+          // Game canvas – use builders to avoid white flash during init.
+          // In descent mode the background is transparent so the OSM map
+          // shows through, with the plane sprite rendered on top.
           GameWidget(
             game: _game,
             loadingBuilder: (_) => Container(
@@ -773,19 +789,6 @@ class _PlayScreenState extends State<PlayScreen> {
               return Container(color: FlitColors.backgroundDark);
             },
           ),
-
-          // OSM tile map — shown during descent mode (low altitude).
-          // Covers the globe shader with real-world map tiles.
-          if (_gameReady && _session != null && !_isHighAltitude)
-            Positioned.fill(
-              child: DescentMapView(
-                centerLng: _game.cameraPosition.x,
-                centerLat: _game.cameraPosition.y,
-                heading: _game.heading,
-                altitudeTransition: 0.0,
-                tileUrl: GameSettings.instance.mapTileUrl,
-              ),
-            ),
 
           // HUD overlay
           if (_gameReady && _session != null)

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -430,7 +430,8 @@ class FlitGame extends FlameGame
   static const double _speedToAngular = pi / 1800;
 
   @override
-  Color backgroundColor() => FlitColors.oceanDeep;
+  Color backgroundColor() =>
+      _plane.isHighAltitude ? FlitColors.oceanDeep : const Color(0x00000000);
 
   @override
   Future<void> onLoad() async {

--- a/lib/game/map/descent_map_view.dart
+++ b/lib/game/map/descent_map_view.dart
@@ -28,7 +28,8 @@ class DescentMapView extends StatefulWidget {
   final double centerLng;
   final double centerLat;
 
-  /// Player heading in radians (code convention: 0 = east, π/2 = north).
+  /// Camera heading as navigation bearing in radians (0 = north, π/2 = east).
+  /// Uses the lagged camera heading for smooth rotation matching the globe view.
   final double heading;
 
   /// Altitude transition value (0.0 = ground, 1.0 = high altitude).
@@ -53,11 +54,10 @@ class _DescentMapViewState extends State<DescentMapView> {
     return 4.0 + (1.0 - widget.altitudeTransition) * 6.0;
   }
 
-  /// Convert game heading (radians, 0=east, π/2=north) to map rotation
-  /// (degrees). The map rotates so the plane's direction faces screen-up.
+  /// Convert camera bearing (radians, 0=north, π/2=east) to map rotation
+  /// (degrees). The map rotates so the flight direction faces screen-up.
   double get _rotation {
-    final headingDeg = widget.heading * 180.0 / math.pi;
-    return -(90.0 - headingDeg);
+    return -widget.heading * 180.0 / math.pi;
   }
 
   @override

--- a/lib/game/map/world_map.dart
+++ b/lib/game/map/world_map.dart
@@ -78,6 +78,10 @@ class WorldMap extends Component with HasGameRef<FlitGame> {
   void render(Canvas canvas) {
     super.render(canvas);
 
+    // In descent mode the OSM tile map provides the background.
+    // Skip the canvas globe so the game canvas stays transparent.
+    if (!gameRef.plane.isHighAltitude) return;
+
     final screenSize = gameRef.size;
     final center = Offset(
       screenSize.x * FlitGame.projectionCenterX,

--- a/lib/game/rendering/globe_renderer.dart
+++ b/lib/game/rendering/globe_renderer.dart
@@ -118,6 +118,10 @@ class GlobeRenderer extends Component with HasGameRef<FlitGame> {
   void render(Canvas canvas) {
     super.render(canvas);
 
+    // In descent mode the OSM tile map sits behind the transparent game canvas.
+    // Skip the full-screen globe shader so the plane sprite floats on top.
+    if (!gameRef.plane.isHighAltitude) return;
+
     try {
       final screenSize = gameRef.size;
       _lastSize = Size(screenSize.x, screenSize.y);


### PR DESCRIPTION
The OSM map was stacked on top of the GameWidget, hiding the plane sprite and making navigation feel broken.

- Move DescentMapView behind GameWidget in Stack so plane renders on top
- Make game canvas transparent in descent mode (skip globe/world rendering)
- Use lagged camera heading bearing for OSM map rotation (matches globe)
- Waypoint taps now reach GameWidget directly (OSM behind, not in front)

https://claude.ai/code/session_013WhXQE5ZGtHmvHJBWER6oG