### PR TITLE
Fix lint warnings: const constructors, string interpolation, getter/s…

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -899,13 +899,13 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
                   child: Center(
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
-                      children: [
+                      children: const [
                         Icon(
                           Icons.flight_takeoff,
                           color: FlitColors.accent,
                           size: 48,
                         ),
-                        const SizedBox(height: 16),
+                        SizedBox(height: 16),
                         Text(
                           'Preparing Flight...',
                           style: TextStyle(

--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -456,7 +456,7 @@ class _StatsGrid extends StatelessWidget {
     if (d == null) return '--';
     final s = d.inSeconds;
     final ms = (d.inMilliseconds % 1000) ~/ 10;
-    return '${s}.${ms.toString().padLeft(2, '0')}s';
+    return '$s.${ms.toString().padLeft(2, '0')}s';
   }
 
   static String _fmtFlightTime(Duration d) {

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -240,7 +240,7 @@ class FlitGame extends FlameGame
 
   /// Whether fuel mechanics are active for this session.
   /// Off for free flight; on for training, daily, dogfight.
-  bool _fuelEnabled = false;
+  bool fuelEnabled = false;
 
   /// Current fuel level (0.0 = empty, 1.0 = full tank).
   double _fuel = 1.0;
@@ -255,16 +255,11 @@ class FlitGame extends FlameGame
   /// Current fuel level (0.0–1.0).
   double get fuel => _fuel;
 
-  /// Whether fuel is enabled for this session.
-  bool get fuelEnabled => _fuelEnabled;
-
-  /// Enable or disable fuel for this session.
-  set fuelEnabled(bool value) => _fuelEnabled = value;
 
   /// Refuel the tank (called when a clue is answered correctly).
   /// The license boost extends how much fuel is restored.
   void refuel() {
-    if (!_fuelEnabled) return;
+    if (!fuelEnabled) return;
     // Restore fuel, license boost adds extra: base * (1 + boost%)
     final refuelAmount = 1.0 * fuelBoostMultiplier;
     _fuel = (_fuel + refuelAmount).clamp(0.0, 1.0);
@@ -816,7 +811,7 @@ class FlitGame extends FlameGame
     }
 
     // --- Fuel consumption ---
-    if (_fuelEnabled && _fuel > 0) {
+    if (fuelEnabled && _fuel > 0) {
       // Burn rate scales with speed multiplier so faster = more fuel.
       final burnRate = _baseFuelBurnRate * _speedMultiplier;
       // License boost reduces effective burn: burn / boostMultiplier.


### PR DESCRIPTION
…etter

- play_screen.dart: Add const to widget list and children (prefer_const_constructors)
- profile_screen.dart: Remove unnecessary braces in string interpolation
- flit_game.dart: Replace trivial getter/setter with public field (unnecessary_getters_setters)

https://claude.ai/code/session_01BBAqSwqVSPys7saDVfVNv7