### PR TITLE
Fix remaining prefer_const_constructors warnings in play_screen

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -899,14 +899,14 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
                   child: Center(
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
-                      children: const [
-                        Icon(
+                      children: [
+                        const Icon(
                           Icons.flight_takeoff,
                           color: FlitColors.accent,
                           size: 48,
                         ),
-                        SizedBox(height: 16),
-                        Text(
+                        const SizedBox(height: 16),
+                        const Text(
                           'Preparing Flight...',
                           style: TextStyle(
                             color: FlitColors.textPrimary,


### PR DESCRIPTION
Use explicit const on each child widget instead of const on the children list, which Flutter 3.16 analyzer handles correctly.

https://claude.ai/code/session_01BBAqSwqVSPys7saDVfVNv7