### PR TITLE
Fix launch overlay const lint: promote entire IgnorePointer subtree t…

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -893,20 +893,20 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
             AnimatedOpacity(
               opacity: _launchIntroVisible ? 1.0 : 0.0,
               duration: const Duration(milliseconds: 500),
-              child: IgnorePointer(
-                child: Container(
+              child: const IgnorePointer(
+                child: ColoredBox(
                   color: FlitColors.backgroundDark,
                   child: Center(
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        const Icon(
+                        Icon(
                           Icons.flight_takeoff,
                           color: FlitColors.accent,
                           size: 48,
                         ),
-                        const SizedBox(height: 16),
-                        const Text(
+                        SizedBox(height: 16),
+                        Text(
                           'Preparing Flight...',
                           style: TextStyle(
                             color: FlitColors.textPrimary,


### PR DESCRIPTION
…o const

Use const IgnorePointer + ColoredBox so all nested widgets (Icon, SizedBox, Text, TextStyle) inherit const context. Replaces individual const annotations that weren't fully satisfying prefer_const_constructors and prefer_const_literals_to_create_immutables.

https://claude.ai/code/session_01BBAqSwqVSPys7saDVfVNv7