### PR TITLE
Claude/cleanup ci audit e eou r

### DIFF
--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -1,0 +1,8 @@
+/// Core module exports
+library core;
+
+export 'services/dev_overlay.dart';
+export 'services/error_sender_http.dart';
+export 'services/error_service.dart';
+export 'theme/flit_colors.dart';
+export 'theme/flit_theme.dart';

--- a/lib/data/models/ad_config.dart
+++ b/lib/data/models/ad_config.dart
@@ -1,0 +1,120 @@
+/// Ad configuration for Flit.
+///
+/// Design philosophy: ads should be **tasteful and infrequent**. Free-tier
+/// players see a small banner on the home screen and a short interstitial
+/// before head-to-head results. They can also opt-in to rewarded ads for
+/// extra plays or bonus coins. Premium subscribers see NO ads at all.
+library;
+
+import 'subscription.dart';
+
+// -----------------------------------------------------------------------------
+// Enums
+// -----------------------------------------------------------------------------
+
+/// The format of an ad creative.
+enum AdType { banner, interstitial, rewarded }
+
+/// Named placements where an ad can appear in the game.
+enum AdPlacement {
+  /// Small banner anchored at the bottom of the home screen.
+  homeScreenBanner,
+
+  /// Short interstitial shown before revealing a head-to-head result.
+  preH2HResult,
+
+  /// Opt-in rewarded ad: grants one free play.
+  rewardedPlayAgain,
+
+  /// Opt-in rewarded ad: grants bonus coins.
+  rewardedBonusCoins,
+}
+
+// -----------------------------------------------------------------------------
+// Ad configuration
+// -----------------------------------------------------------------------------
+
+class AdConfig {
+  // Private constructor -- this class is a static-only utility.
+  AdConfig._();
+
+  // ---------------------------------------------------------------------------
+  // Core gate: premium users never see ads
+  // ---------------------------------------------------------------------------
+
+  /// Returns `true` when ads should be shown for the given [tier].
+  ///
+  /// Premium subscribers (monthly, annual, lifetime) see **no** ads.
+  static bool shouldShowAds(SubscriptionTier tier) {
+    return tier == SubscriptionTier.free;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Frequency / rate limits
+  // ---------------------------------------------------------------------------
+
+  /// Minimum time between two interstitial ads.
+  static const Duration minInterstitialInterval = Duration(minutes: 5);
+
+  /// Maximum number of interstitial ads shown in a single session.
+  static const int maxInterstitialsPerSession = 3;
+
+  /// Maximum number of rewarded ads a user may watch per calendar day.
+  static const int maxRewardedPerDay = 5;
+
+  // ---------------------------------------------------------------------------
+  // Reward values
+  // ---------------------------------------------------------------------------
+
+  /// Number of free plays granted for watching [AdPlacement.rewardedPlayAgain].
+  static const int rewardedPlayAgainValue = 1;
+
+  /// Number of bonus coins granted for watching [AdPlacement.rewardedBonusCoins].
+  static const int rewardedBonusCoinsAmount = 50;
+
+  // ---------------------------------------------------------------------------
+  // Placement helpers
+  // ---------------------------------------------------------------------------
+
+  /// Maps each [AdPlacement] to its corresponding [AdType].
+  static AdType typeForPlacement(AdPlacement placement) {
+    switch (placement) {
+      case AdPlacement.homeScreenBanner:
+        return AdType.banner;
+      case AdPlacement.preH2HResult:
+        return AdType.interstitial;
+      case AdPlacement.rewardedPlayAgain:
+      case AdPlacement.rewardedBonusCoins:
+        return AdType.rewarded;
+    }
+  }
+
+  /// Whether an ad should be displayed at [placement] for a user with the
+  /// given subscription [tier].
+  ///
+  /// Premium users always return `false`. Free-tier users are eligible for
+  /// every placement.
+  static bool shouldShow(AdPlacement placement, SubscriptionTier tier) {
+    // Premium users never see ads.
+    if (!shouldShowAds(tier)) return false;
+
+    // All placements are valid for free-tier users. Runtime frequency limits
+    // (interstitial interval, daily rewarded cap) are enforced by the ad
+    // service layer, not here -- this method answers the static policy
+    // question only.
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Descriptive metadata (useful for analytics / UI labels)
+  // ---------------------------------------------------------------------------
+
+  /// Human-readable label for each placement, handy for analytics events and
+  /// debug overlays.
+  static const Map<AdPlacement, String> placementLabels = {
+    AdPlacement.homeScreenBanner: 'Home Banner',
+    AdPlacement.preH2HResult: 'Pre-H2H Interstitial',
+    AdPlacement.rewardedPlayAgain: 'Rewarded: Play Again',
+    AdPlacement.rewardedBonusCoins: 'Rewarded: Bonus Coins',
+  };
+}

--- a/lib/data/models/leaderboard.dart
+++ b/lib/data/models/leaderboard.dart
@@ -1,0 +1,1120 @@
+// Enhanced leaderboard models supporting separate licensed/unlicensed play,
+// daily/seasonal/all-time boards, regional and friends boards, annual cosmetic
+// rewards, and rich placeholder data for UI development.
+//
+// **Design rationale** -- Licensed players have gacha advantages (coin boost,
+// clue boost, fuel boost from their PilotLicense), so their scores are
+// tracked on a separate board. The unlicensed board is a level playing field
+// for pure skill ranking. Both boards are intended to drive competitive play
+// and streaming appeal.
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// The type / scope of a leaderboard.
+///
+/// Licensed and unlicensed boards are the two primary competitive axes.
+/// Daily, all-time, regional and friends boards provide additional filters.
+enum LeaderboardType {
+  /// Fair play -- no pilot license boosts applied.
+  globalUnlicensed,
+
+  /// With pilot license boosts (coin, clue, fuel) applied to scoring.
+  globalLicensed,
+
+  /// Today's daily challenge leaderboard (resets at midnight UTC).
+  daily,
+
+  /// All-time records across every season.
+  allTime,
+
+  /// Per-region boards filtered by geographic area (continent / country).
+  regional,
+
+  /// Friends-only leaderboard visible to the player's friend list.
+  friends,
+}
+
+extension LeaderboardTypeExtension on LeaderboardType {
+  String get displayName {
+    switch (this) {
+      case LeaderboardType.globalUnlicensed:
+        return 'Global (Unlicensed)';
+      case LeaderboardType.globalLicensed:
+        return 'Global (Licensed)';
+      case LeaderboardType.daily:
+        return 'Daily Challenge';
+      case LeaderboardType.allTime:
+        return 'All Time';
+      case LeaderboardType.regional:
+        return 'Regional';
+      case LeaderboardType.friends:
+        return 'Friends';
+    }
+  }
+
+  String get shortName {
+    switch (this) {
+      case LeaderboardType.globalUnlicensed:
+        return 'Unlicensed';
+      case LeaderboardType.globalLicensed:
+        return 'Licensed';
+      case LeaderboardType.daily:
+        return 'Daily';
+      case LeaderboardType.allTime:
+        return 'All Time';
+      case LeaderboardType.regional:
+        return 'Regional';
+      case LeaderboardType.friends:
+        return 'Friends';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case LeaderboardType.globalUnlicensed:
+        return 'No boosts — pure skill ranking on a level playing field';
+      case LeaderboardType.globalLicensed:
+        return 'Players using Pilot License boosts (coin, clue, fuel)';
+      case LeaderboardType.daily:
+        return "Today's challenge — resets at midnight UTC";
+      case LeaderboardType.allTime:
+        return 'The greatest pilots across every season';
+      case LeaderboardType.regional:
+        return 'Top pilots in your region';
+      case LeaderboardType.friends:
+        return 'How you stack up against your friends';
+    }
+  }
+
+  /// Whether this board type separates licensed / unlicensed play.
+  bool get isLicensedBoard => this == LeaderboardType.globalLicensed;
+}
+
+/// The time window a leaderboard covers.
+enum LeaderboardTimeframe {
+  today,
+  thisWeek,
+  thisMonth,
+  thisYear,
+  allTime,
+}
+
+extension LeaderboardTimeframeExtension on LeaderboardTimeframe {
+  String get displayName {
+    switch (this) {
+      case LeaderboardTimeframe.today:
+        return 'Today';
+      case LeaderboardTimeframe.thisWeek:
+        return 'This Week';
+      case LeaderboardTimeframe.thisMonth:
+        return 'This Month';
+      case LeaderboardTimeframe.thisYear:
+        return 'This Year';
+      case LeaderboardTimeframe.allTime:
+        return 'All Time';
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LeaderboardEntry
+// ---------------------------------------------------------------------------
+
+/// A single row on any leaderboard.
+///
+/// Carries enough information for a rich leaderboard row: rank, score, time,
+/// player level, license status, social display title, and games played count.
+class LeaderboardEntry {
+  const LeaderboardEntry({
+    required this.playerId,
+    required this.username,
+    required this.score,
+    required this.bestTime,
+    required this.rank,
+    this.gamesPlayed = 0,
+    this.isLicensed = false,
+    this.displayTitle,
+    this.level = 1,
+    this.avatarUrl,
+    this.countryCode,
+    this.streak = 0,
+    this.timestamp,
+  });
+
+  /// Unique player identifier.
+  final String playerId;
+
+  /// Player's display username.
+  final String username;
+
+  /// Aggregate score for this leaderboard period.
+  final int score;
+
+  /// Best round completion time.
+  final Duration bestTime;
+
+  /// Position on the board (1-indexed).
+  final int rank;
+
+  /// Total games played in this leaderboard period.
+  final int gamesPlayed;
+
+  /// Whether this entry used pilot license boosts.
+  final bool isLicensed;
+
+  /// Social title displayed next to the username (e.g. "Flag Savant").
+  final String? displayTitle;
+
+  /// Player's current level.
+  final int level;
+
+  /// Optional avatar image URL.
+  final String? avatarUrl;
+
+  /// ISO 3166-1 alpha-2 country code for regional boards.
+  final String? countryCode;
+
+  /// Current win streak (consecutive games with a correct answer).
+  final int streak;
+
+  /// When this entry was last updated.
+  final DateTime? timestamp;
+
+  // ── Display helpers ──────────────────────────────────────────────────
+
+  /// Formatted best time as `MM:SS.mm`.
+  String get formattedTime {
+    final minutes = bestTime.inMinutes;
+    final seconds = bestTime.inSeconds % 60;
+    final centis = (bestTime.inMilliseconds % 1000) ~/ 10;
+    return '${minutes.toString().padLeft(2, '0')}:'
+        '${seconds.toString().padLeft(2, '0')}.'
+        '${centis.toString().padLeft(2, '0')}';
+  }
+
+  /// Display string combining username and optional title.
+  String get displayNameWithTitle =>
+      displayTitle != null ? '$username — $displayTitle' : username;
+
+  // ── copyWith ─────────────────────────────────────────────────────────
+
+  LeaderboardEntry copyWith({
+    String? playerId,
+    String? username,
+    int? score,
+    Duration? bestTime,
+    int? rank,
+    int? gamesPlayed,
+    bool? isLicensed,
+    String? displayTitle,
+    int? level,
+    String? avatarUrl,
+    String? countryCode,
+    int? streak,
+    DateTime? timestamp,
+  }) =>
+      LeaderboardEntry(
+        playerId: playerId ?? this.playerId,
+        username: username ?? this.username,
+        score: score ?? this.score,
+        bestTime: bestTime ?? this.bestTime,
+        rank: rank ?? this.rank,
+        gamesPlayed: gamesPlayed ?? this.gamesPlayed,
+        isLicensed: isLicensed ?? this.isLicensed,
+        displayTitle: displayTitle ?? this.displayTitle,
+        level: level ?? this.level,
+        avatarUrl: avatarUrl ?? this.avatarUrl,
+        countryCode: countryCode ?? this.countryCode,
+        streak: streak ?? this.streak,
+        timestamp: timestamp ?? this.timestamp,
+      );
+
+  // ── Serialisation ────────────────────────────────────────────────────
+
+  Map<String, dynamic> toJson() => {
+        'player_id': playerId,
+        'username': username,
+        'score': score,
+        'best_time_ms': bestTime.inMilliseconds,
+        'rank': rank,
+        'games_played': gamesPlayed,
+        'is_licensed': isLicensed,
+        'display_title': displayTitle,
+        'level': level,
+        'avatar_url': avatarUrl,
+        'country_code': countryCode,
+        'streak': streak,
+        'timestamp': timestamp?.toIso8601String(),
+      };
+
+  factory LeaderboardEntry.fromJson(Map<String, dynamic> json) =>
+      LeaderboardEntry(
+        playerId: json['player_id'] as String,
+        username: json['username'] as String,
+        score: json['score'] as int,
+        bestTime: Duration(milliseconds: json['best_time_ms'] as int),
+        rank: json['rank'] as int,
+        gamesPlayed: json['games_played'] as int? ?? 0,
+        isLicensed: json['is_licensed'] as bool? ?? false,
+        displayTitle: json['display_title'] as String?,
+        level: json['level'] as int? ?? 1,
+        avatarUrl: json['avatar_url'] as String?,
+        countryCode: json['country_code'] as String?,
+        streak: json['streak'] as int? ?? 0,
+        timestamp: json['timestamp'] != null
+            ? DateTime.parse(json['timestamp'] as String)
+            : null,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// LeaderboardReward
+// ---------------------------------------------------------------------------
+
+/// An annual reward granted to top-ranked players on the all-time board.
+///
+/// At the end of each calendar year, the top N players on both the licensed
+/// and unlicensed all-time boards receive a unique cosmetic that can never
+/// be obtained again. This drives long-term competitive motivation.
+class LeaderboardReward {
+  const LeaderboardReward({
+    required this.id,
+    required this.year,
+    required this.boardType,
+    required this.minRank,
+    required this.maxRank,
+    required this.cosmeticId,
+    required this.cosmeticName,
+    required this.description,
+  });
+
+  /// Unique reward identifier.
+  final String id;
+
+  /// The calendar year this reward was awarded.
+  final int year;
+
+  /// Which board type this reward applies to.
+  final LeaderboardType boardType;
+
+  /// Inclusive rank range that qualifies for this reward.
+  final int minRank;
+  final int maxRank;
+
+  /// The one-of-a-kind cosmetic item granted.
+  final String cosmeticId;
+  final String cosmeticName;
+
+  /// Flavour text describing the reward.
+  final String description;
+
+  // ── Serialisation ────────────────────────────────────────────────────
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'year': year,
+        'board_type': boardType.name,
+        'min_rank': minRank,
+        'max_rank': maxRank,
+        'cosmetic_id': cosmeticId,
+        'cosmetic_name': cosmeticName,
+        'description': description,
+      };
+
+  factory LeaderboardReward.fromJson(Map<String, dynamic> json) =>
+      LeaderboardReward(
+        id: json['id'] as String,
+        year: json['year'] as int,
+        boardType: LeaderboardType.values.firstWhere(
+          (t) => t.name == json['board_type'],
+        ),
+        minRank: json['min_rank'] as int,
+        maxRank: json['max_rank'] as int,
+        cosmeticId: json['cosmetic_id'] as String,
+        cosmeticName: json['cosmetic_name'] as String,
+        description: json['description'] as String,
+      );
+
+  /// Placeholder annual rewards for UI development.
+  static const List<LeaderboardReward> placeholderRewards = [
+    LeaderboardReward(
+      id: 'reward_2025_unlicensed_1',
+      year: 2025,
+      boardType: LeaderboardType.globalUnlicensed,
+      minRank: 1,
+      maxRank: 1,
+      cosmeticId: 'plane_aurora_2025',
+      cosmeticName: 'Aurora Champion 2025',
+      description:
+          'One-of-a-kind plane awarded to the #1 unlicensed pilot of 2025. '
+          'A shimmering aurora-painted fuselage that can never be obtained again.',
+    ),
+    LeaderboardReward(
+      id: 'reward_2025_unlicensed_top10',
+      year: 2025,
+      boardType: LeaderboardType.globalUnlicensed,
+      minRank: 2,
+      maxRank: 10,
+      cosmeticId: 'contrail_frost_2025',
+      cosmeticName: 'Frost Trail 2025',
+      description:
+          'Exclusive contrail awarded to the top 10 unlicensed pilots of 2025. '
+          'Ice crystals shimmer in your wake.',
+    ),
+    LeaderboardReward(
+      id: 'reward_2025_licensed_1',
+      year: 2025,
+      boardType: LeaderboardType.globalLicensed,
+      minRank: 1,
+      maxRank: 1,
+      cosmeticId: 'plane_phoenix_2025',
+      cosmeticName: 'Phoenix Champion 2025',
+      description:
+          'One-of-a-kind plane awarded to the #1 licensed pilot of 2025. '
+          'Blazing feathers trail behind this legendary craft.',
+    ),
+    LeaderboardReward(
+      id: 'reward_2025_licensed_top10',
+      year: 2025,
+      boardType: LeaderboardType.globalLicensed,
+      minRank: 2,
+      maxRank: 10,
+      cosmeticId: 'contrail_ember_2025',
+      cosmeticName: 'Ember Trail 2025',
+      description:
+          'Exclusive contrail awarded to the top 10 licensed pilots of 2025. '
+          'Glowing embers dance behind your plane.',
+    ),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// PlayerClueStats
+// ---------------------------------------------------------------------------
+
+/// Per-clue-type progress stats used to award social titles.
+///
+/// Tracks correct answers across all five clue categories, plus lifetime
+/// economy and challenge data.
+class PlayerClueStats {
+  const PlayerClueStats({
+    this.flagsCorrect = 0,
+    this.outlinesCorrect = 0,
+    this.bordersCorrect = 0,
+    this.capitalsCorrect = 0,
+    this.statsCorrect = 0,
+    this.bestTime,
+    this.gamesPlayed = 0,
+    this.gamesWon = 0,
+    this.coinsEarned = 0,
+    this.coinsSpent = 0,
+    this.challengesSent = 0,
+    this.challengesWon = 0,
+    this.cosmeticsOwned = 0,
+  });
+
+  /// Correct answers per clue type.
+  final int flagsCorrect;
+  final int outlinesCorrect;
+  final int bordersCorrect;
+  final int capitalsCorrect;
+  final int statsCorrect;
+
+  /// Sum of all correct clue answers.
+  int get totalCorrect =>
+      flagsCorrect +
+      outlinesCorrect +
+      bordersCorrect +
+      capitalsCorrect +
+      statsCorrect;
+
+  /// Fastest game completion time across all modes.
+  final Duration? bestTime;
+
+  /// Lifetime game counts.
+  final int gamesPlayed;
+  final int gamesWon;
+
+  /// Lifetime coin economy.
+  final int coinsEarned;
+  final int coinsSpent;
+
+  /// Challenge record.
+  final int challengesSent;
+  final int challengesWon;
+
+  /// Number of cosmetic items owned.
+  final int cosmeticsOwned;
+
+  // ── copyWith ──────────────────────────────────────────────────────────
+
+  PlayerClueStats copyWith({
+    int? flagsCorrect,
+    int? outlinesCorrect,
+    int? bordersCorrect,
+    int? capitalsCorrect,
+    int? statsCorrect,
+    Duration? bestTime,
+    int? gamesPlayed,
+    int? gamesWon,
+    int? coinsEarned,
+    int? coinsSpent,
+    int? challengesSent,
+    int? challengesWon,
+    int? cosmeticsOwned,
+  }) =>
+      PlayerClueStats(
+        flagsCorrect: flagsCorrect ?? this.flagsCorrect,
+        outlinesCorrect: outlinesCorrect ?? this.outlinesCorrect,
+        bordersCorrect: bordersCorrect ?? this.bordersCorrect,
+        capitalsCorrect: capitalsCorrect ?? this.capitalsCorrect,
+        statsCorrect: statsCorrect ?? this.statsCorrect,
+        bestTime: bestTime ?? this.bestTime,
+        gamesPlayed: gamesPlayed ?? this.gamesPlayed,
+        gamesWon: gamesWon ?? this.gamesWon,
+        coinsEarned: coinsEarned ?? this.coinsEarned,
+        coinsSpent: coinsSpent ?? this.coinsSpent,
+        challengesSent: challengesSent ?? this.challengesSent,
+        challengesWon: challengesWon ?? this.challengesWon,
+        cosmeticsOwned: cosmeticsOwned ?? this.cosmeticsOwned,
+      );
+
+  // ── Serialisation ─────────────────────────────────────────────────────
+
+  Map<String, dynamic> toJson() => {
+        'flags_correct': flagsCorrect,
+        'outlines_correct': outlinesCorrect,
+        'borders_correct': bordersCorrect,
+        'capitals_correct': capitalsCorrect,
+        'stats_correct': statsCorrect,
+        'best_time_ms': bestTime?.inMilliseconds,
+        'games_played': gamesPlayed,
+        'games_won': gamesWon,
+        'coins_earned': coinsEarned,
+        'coins_spent': coinsSpent,
+        'challenges_sent': challengesSent,
+        'challenges_won': challengesWon,
+        'cosmetics_owned': cosmeticsOwned,
+      };
+
+  factory PlayerClueStats.fromJson(Map<String, dynamic> json) =>
+      PlayerClueStats(
+        flagsCorrect: json['flags_correct'] as int? ?? 0,
+        outlinesCorrect: json['outlines_correct'] as int? ?? 0,
+        bordersCorrect: json['borders_correct'] as int? ?? 0,
+        capitalsCorrect: json['capitals_correct'] as int? ?? 0,
+        statsCorrect: json['stats_correct'] as int? ?? 0,
+        bestTime: json['best_time_ms'] != null
+            ? Duration(milliseconds: json['best_time_ms'] as int)
+            : null,
+        gamesPlayed: json['games_played'] as int? ?? 0,
+        gamesWon: json['games_won'] as int? ?? 0,
+        coinsEarned: json['coins_earned'] as int? ?? 0,
+        coinsSpent: json['coins_spent'] as int? ?? 0,
+        challengesSent: json['challenges_sent'] as int? ?? 0,
+        challengesWon: json['challenges_won'] as int? ?? 0,
+        cosmeticsOwned: json['cosmetics_owned'] as int? ?? 0,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// Leaderboard
+// ---------------------------------------------------------------------------
+
+/// A complete leaderboard with metadata, entries, and the current player's
+/// position.
+///
+/// The [placeholder] factory generates rich fake data for each board type,
+/// including 50 entries with the current player sitting around rank 42 to
+/// demonstrate the "you are here" scroll-to behaviour. Licensed boards have
+/// slightly inflated scores to reflect pilot license boost advantages.
+class Leaderboard {
+  const Leaderboard({
+    required this.type,
+    required this.timeframe,
+    required this.entries,
+    required this.lastUpdated,
+    this.currentPlayerEntry,
+    this.regionId,
+    this.seasonYear,
+    this.totalEntries,
+    this.rewards = const [],
+  });
+
+  /// Which board this is.
+  final LeaderboardType type;
+
+  /// Time window being displayed.
+  final LeaderboardTimeframe timeframe;
+
+  /// The visible slice of leaderboard rows.
+  final List<LeaderboardEntry> entries;
+
+  /// Where the current user sits (may not be in [entries] if they are outside
+  /// the visible page). The UI should use this to render a "You are here" row.
+  final LeaderboardEntry? currentPlayerEntry;
+
+  /// When this board was last refreshed from the server.
+  final DateTime lastUpdated;
+
+  /// Optional region filter (ISO 3166-1 alpha-2 or continent code).
+  final String? regionId;
+
+  /// For all-time boards: the season/year this data covers.
+  final int? seasonYear;
+
+  /// Total number of entries on the full board (for "rank X of Y" display).
+  final int? totalEntries;
+
+  /// Annual cosmetic rewards associated with this board (all-time only).
+  final List<LeaderboardReward> rewards;
+
+  // ── copyWith ─────────────────────────────────────────────────────────
+
+  Leaderboard copyWith({
+    LeaderboardType? type,
+    LeaderboardTimeframe? timeframe,
+    List<LeaderboardEntry>? entries,
+    LeaderboardEntry? currentPlayerEntry,
+    DateTime? lastUpdated,
+    String? regionId,
+    int? seasonYear,
+    int? totalEntries,
+    List<LeaderboardReward>? rewards,
+  }) =>
+      Leaderboard(
+        type: type ?? this.type,
+        timeframe: timeframe ?? this.timeframe,
+        entries: entries ?? this.entries,
+        currentPlayerEntry: currentPlayerEntry ?? this.currentPlayerEntry,
+        lastUpdated: lastUpdated ?? this.lastUpdated,
+        regionId: regionId ?? this.regionId,
+        seasonYear: seasonYear ?? this.seasonYear,
+        totalEntries: totalEntries ?? this.totalEntries,
+        rewards: rewards ?? this.rewards,
+      );
+
+  // ── Serialisation ────────────────────────────────────────────────────
+
+  Map<String, dynamic> toJson() => {
+        'type': type.name,
+        'timeframe': timeframe.name,
+        'entries': entries.map((e) => e.toJson()).toList(),
+        'current_player_entry': currentPlayerEntry?.toJson(),
+        'last_updated': lastUpdated.toIso8601String(),
+        'region_id': regionId,
+        'season_year': seasonYear,
+        'total_entries': totalEntries,
+        'rewards': rewards.map((r) => r.toJson()).toList(),
+      };
+
+  factory Leaderboard.fromJson(Map<String, dynamic> json) => Leaderboard(
+        type: LeaderboardType.values.firstWhere(
+          (t) => t.name == json['type'],
+        ),
+        timeframe: LeaderboardTimeframe.values.firstWhere(
+          (t) => t.name == json['timeframe'],
+        ),
+        entries: (json['entries'] as List)
+            .map((e) => LeaderboardEntry.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        currentPlayerEntry: json['current_player_entry'] != null
+            ? LeaderboardEntry.fromJson(
+                json['current_player_entry'] as Map<String, dynamic>,
+              )
+            : null,
+        lastUpdated: DateTime.parse(json['last_updated'] as String),
+        regionId: json['region_id'] as String?,
+        seasonYear: json['season_year'] as int?,
+        totalEntries: json['total_entries'] as int?,
+        rewards: (json['rewards'] as List?)
+                ?.map((r) =>
+                    LeaderboardReward.fromJson(r as Map<String, dynamic>))
+                .toList() ??
+            const [],
+      );
+
+  // ── Placeholder data ─────────────────────────────────────────────────
+
+  /// Generate a fully populated placeholder leaderboard for UI development.
+  ///
+  /// Returns different data per [type]:
+  /// - **globalLicensed** scores are ~8-15% higher than unlicensed to
+  ///   reflect pilot license boost advantages.
+  /// - **daily** has fewer entries and tighter score spreads.
+  /// - **allTime** includes annual reward metadata.
+  /// - **regional** / **friends** use smaller entry sets with region/friend
+  ///   context.
+  ///
+  /// The current player ("You") is always placed around rank 42 with
+  /// `playerId: 'current_player'` so the UI can scroll to and highlight
+  /// their position.
+  static Leaderboard placeholder(LeaderboardType type) {
+    final LeaderboardTimeframe timeframe;
+    final List<LeaderboardEntry> entries;
+    final int totalEntries;
+    final List<LeaderboardReward> rewards;
+
+    switch (type) {
+      case LeaderboardType.globalUnlicensed:
+        timeframe = LeaderboardTimeframe.thisMonth;
+        entries = _buildGlobalEntries(licensed: false);
+        totalEntries = 12847;
+        rewards = const [];
+        break;
+      case LeaderboardType.globalLicensed:
+        timeframe = LeaderboardTimeframe.thisMonth;
+        entries = _buildGlobalEntries(licensed: true);
+        totalEntries = 8923;
+        rewards = const [];
+        break;
+      case LeaderboardType.daily:
+        timeframe = LeaderboardTimeframe.today;
+        entries = _buildDailyEntries();
+        totalEntries = 3412;
+        rewards = const [];
+        break;
+      case LeaderboardType.allTime:
+        timeframe = LeaderboardTimeframe.allTime;
+        entries = _buildAllTimeEntries();
+        totalEntries = 54219;
+        rewards = LeaderboardReward.placeholderRewards;
+        break;
+      case LeaderboardType.regional:
+        timeframe = LeaderboardTimeframe.thisMonth;
+        entries = _buildRegionalEntries();
+        totalEntries = 1876;
+        rewards = const [];
+        break;
+      case LeaderboardType.friends:
+        timeframe = LeaderboardTimeframe.thisWeek;
+        entries = _buildFriendsEntries();
+        totalEntries = entries.length;
+        rewards = const [];
+        break;
+    }
+
+    // Find the current player entry in the list.
+    LeaderboardEntry? currentPlayer;
+    for (final entry in entries) {
+      if (entry.playerId == 'current_player') {
+        currentPlayer = entry;
+        break;
+      }
+    }
+
+    return Leaderboard(
+      type: type,
+      timeframe: timeframe,
+      entries: entries,
+      currentPlayerEntry: currentPlayer,
+      lastUpdated: DateTime.now().toUtc(),
+      regionId: type == LeaderboardType.regional ? 'EU' : null,
+      seasonYear: type == LeaderboardType.allTime ? 2025 : null,
+      totalEntries: totalEntries,
+      rewards: rewards,
+    );
+  }
+
+  // ── Private placeholder builders ─────────────────────────────────────
+
+  /// 50 entries for global boards. Licensed scores are ~10% higher.
+  static List<LeaderboardEntry> _buildGlobalEntries({
+    required bool licensed,
+  }) {
+    // Score boost multiplier for licensed play.
+    final double boostFactor = licensed ? 1.12 : 1.0;
+
+    // Creative usernames -- geography, aviation and exploration themed.
+    const topNames = <_PlaceholderPlayer>[
+      _PlaceholderPlayer('MercatorMaven', 'Master Vexillologist', 22),
+      _PlaceholderPlayer('EquatorExplorer', 'Flag Savant', 21),
+      _PlaceholderPlayer('PrimeMeridian', 'Capital Commander', 20),
+      _PlaceholderPlayer('LatLongLegend', 'Lightning', 20),
+      _PlaceholderPlayer('CartographyCat', 'Statistics Savant', 19),
+      _PlaceholderPlayer('TropicOfCapri', 'Outline Oracle', 19),
+      _PlaceholderPlayer('GeodeticGuru', 'Border Lord', 18),
+      _PlaceholderPlayer('AzimuthAce', 'Supersonic', 18),
+      _PlaceholderPlayer('IslandHopper42', 'Challenge Legend', 17),
+      _PlaceholderPlayer('DatumDrifter', 'Data Professor', 17),
+      _PlaceholderPlayer('ContourClimber', 'Shadow Cartographer', 16),
+      _PlaceholderPlayer('ProjectionPro', 'Frontier Master', 16),
+      _PlaceholderPlayer('GreatCircleGal', 'Capital Connoisseur', 15),
+      _PlaceholderPlayer('RhumbRunner', 'Speed Demon', 15),
+      _PlaceholderPlayer('PangaeaPilot', 'Flag Expert', 14),
+      _PlaceholderPlayer('GondwanaGlider', 'Shape Shifter', 14),
+      _PlaceholderPlayer('LaurasiaLark', 'Boundary Expert', 13),
+      _PlaceholderPlayer('TectonicTrek', 'Number Cruncher', 13),
+      _PlaceholderPlayer('MagneticNorth', 'Mile High Club', 12),
+      _PlaceholderPlayer('SolsticeFlyer', 'Frequent Flier', 12),
+    ];
+
+    const midNames = <_PlaceholderPlayer>[
+      _PlaceholderPlayer('FjordFinder', 'Capital Navigator', 11),
+      _PlaceholderPlayer('SteppeStrider', 'Shape Detective', 11),
+      _PlaceholderPlayer('TundraTracer', 'Data Analyst', 10),
+      _PlaceholderPlayer('SavannaScout', 'Border Guard', 10),
+      _PlaceholderPlayer('DeltaDasher', 'Quick Draw', 9),
+      _PlaceholderPlayer('CanyonCruiser', 'Flag Enthusiast', 9),
+      _PlaceholderPlayer('ArchipelagoAce', 'Social Butterfly', 8),
+      _PlaceholderPlayer('PlainsPathfinder', 'Silhouette Spotter', 8),
+      _PlaceholderPlayer('ReefRanger', 'Capital Cadet', 7),
+      _PlaceholderPlayer('MesaMaster', 'Airborne', 7),
+      _PlaceholderPlayer('GlacierGlider', 'Border Patrol', 6),
+      _PlaceholderPlayer('OasisOracle', 'Friendly Flier', 6),
+      _PlaceholderPlayer('VolcanoVoyager', null, 5),
+      _PlaceholderPlayer('MonsoonMaverick', null, 5),
+      _PlaceholderPlayer('TyphoonTracker', null, 5),
+      _PlaceholderPlayer('CirrusCircler', null, 4),
+      _PlaceholderPlayer('StratusStriker', null, 4),
+      _PlaceholderPlayer('CumulusKing', null, 4),
+      _PlaceholderPlayer('NimbusNavigator', null, 3),
+      _PlaceholderPlayer('ZephyrZealot', null, 3),
+    ];
+
+    // The current player sits around rank 42.
+    const currentPlayer = _PlaceholderPlayer('You', 'Novice Vexillologist', 6);
+
+    const tailNames = <_PlaceholderPlayer>[
+      _PlaceholderPlayer('ThermoclineThief', null, 3),
+      _PlaceholderPlayer('BarometerBandit', null, 2),
+      _PlaceholderPlayer('IsothermImp', null, 2),
+      _PlaceholderPlayer('IsobarIntern', null, 2),
+      _PlaceholderPlayer('TropopauseTraveller', null, 2),
+      _PlaceholderPlayer('MesosphereMike', null, 1),
+      _PlaceholderPlayer('ExosphereEllie', null, 1),
+      _PlaceholderPlayer('MantleMiner', null, 1),
+    ];
+
+    final allPlayers = <_PlaceholderPlayer>[
+      ...topNames,
+      ...midNames,
+      currentPlayer,
+      ...tailNames,
+    ];
+
+    // Base score for rank 1, decaying by rank.
+    const int baseScore = 12500;
+
+    return List<LeaderboardEntry>.generate(allPlayers.length, (i) {
+      final player = allPlayers[i];
+      final rank = i + 1;
+
+      // Score decay: sharp at the top, gentler in the middle.
+      final int rawScore;
+      if (rank <= 3) {
+        rawScore = baseScore - (rank - 1) * 180;
+      } else if (rank <= 10) {
+        rawScore = baseScore - 540 - (rank - 3) * 150;
+      } else if (rank <= 20) {
+        rawScore = baseScore - 1590 - (rank - 10) * 120;
+      } else if (rank <= 40) {
+        rawScore = baseScore - 2790 - (rank - 20) * 95;
+      } else {
+        rawScore = baseScore - 4690 - (rank - 40) * 80;
+      }
+
+      // Apply licensed boost and add small per-rank variance.
+      final int score =
+          ((rawScore + (rank.isEven ? 37 : -23)) * boostFactor).round();
+
+      // Time increases with rank (worse players are slower).
+      final timeMs = 72000 + (rank * 1850) + (rank.isOdd ? 430 : -210);
+
+      // Games played decreases with rank (top players play more).
+      final gamesPlayed = (500 - rank * 8).clamp(12, 500);
+
+      final isCurrentPlayer = player.name == 'You';
+
+      return LeaderboardEntry(
+        playerId: isCurrentPlayer ? 'current_player' : 'player_$rank',
+        username: player.name,
+        score: score,
+        bestTime: Duration(milliseconds: timeMs),
+        rank: rank,
+        gamesPlayed: gamesPlayed,
+        isLicensed: licensed,
+        displayTitle: player.title,
+        level: player.level,
+        streak: rank <= 5 ? (20 - rank * 3) : (rank <= 15 ? 5 : 0),
+      );
+    });
+  }
+
+  /// 20 entries for daily challenge boards with tighter score spreads.
+  static List<LeaderboardEntry> _buildDailyEntries() {
+    const players = <_PlaceholderPlayer>[
+      _PlaceholderPlayer('SunriseScout', 'Lightning', 18),
+      _PlaceholderPlayer('DawnPatrol', 'Speed Demon', 16),
+      _PlaceholderPlayer('MorningMeridian', 'Flag Expert', 15),
+      _PlaceholderPlayer('NoonNavigator', 'Quick Draw', 14),
+      _PlaceholderPlayer('TwilightTracer', 'Capital Navigator', 13),
+      _PlaceholderPlayer('DuskDrifter', 'Shape Detective', 12),
+      _PlaceholderPlayer('MidnightMapper', 'Border Guard', 11),
+      _PlaceholderPlayer('StarcharterSam', 'Data Analyst', 10),
+      _PlaceholderPlayer('CosmicCompass', 'Airborne', 9),
+      _PlaceholderPlayer('AuroraAviator', 'Social Butterfly', 8),
+      _PlaceholderPlayer('ZenithZara', null, 7),
+      _PlaceholderPlayer('NadirNate', null, 7),
+      _PlaceholderPlayer('SolsticeSally', null, 6),
+      _PlaceholderPlayer('EquinoxEd', null, 5),
+      _PlaceholderPlayer('PerihelionPete', null, 5),
+      _PlaceholderPlayer('AphelionAnna', null, 4),
+      _PlaceholderPlayer('You', 'Novice Vexillologist', 6),
+      _PlaceholderPlayer('EclipseEmma', null, 3),
+      _PlaceholderPlayer('LunarLeo', null, 2),
+      _PlaceholderPlayer('TransitTina', null, 1),
+    ];
+
+    const int baseScore = 9800;
+
+    return List<LeaderboardEntry>.generate(players.length, (i) {
+      final player = players[i];
+      final rank = i + 1;
+
+      // Tighter spread for daily boards.
+      final int rawScore = baseScore - (rank - 1) * 210 + (rank.isEven ? 25 : -15);
+
+      // Daily times are faster (single challenge).
+      final timeMs = 45000 + (rank * 2100) + (rank.isOdd ? 310 : -180);
+
+      final isCurrentPlayer = player.name == 'You';
+
+      return LeaderboardEntry(
+        playerId: isCurrentPlayer ? 'current_player' : 'daily_player_$rank',
+        username: player.name,
+        score: rawScore,
+        bestTime: Duration(milliseconds: timeMs),
+        rank: rank,
+        gamesPlayed: 1,
+        isLicensed: false,
+        displayTitle: player.title,
+        level: player.level,
+      );
+    });
+  }
+
+  /// 50 entries for the all-time hall of fame with massive scores.
+  static List<LeaderboardEntry> _buildAllTimeEntries() {
+    const legends = <_PlaceholderPlayer>[
+      _PlaceholderPlayer('xx_MercatorGOAT_xx', 'Perfect License', 25),
+      _PlaceholderPlayer('VexillumMaximus', 'Flag Savant', 24),
+      _PlaceholderPlayer('SovereignSkies', 'Capital Commander', 23),
+      _PlaceholderPlayer('TheLastAtlas', 'Supersonic', 23),
+      _PlaceholderPlayer('ProjectionQueen', 'Statistics Savant', 22),
+      _PlaceholderPlayer('GnomonicGod', 'Outline Oracle', 22),
+      _PlaceholderPlayer('BoundaryBoss', 'Border Lord', 21),
+      _PlaceholderPlayer('PlateCarreeKing', 'Challenge Legend', 21),
+      _PlaceholderPlayer('GeodesicDream', 'Data Professor', 20),
+      _PlaceholderPlayer('EllipsoidElite', 'Shadow Cartographer', 20),
+      _PlaceholderPlayer('OrthographicOwl', 'Frontier Master', 19),
+      _PlaceholderPlayer('StereographicStar', 'Capital Connoisseur', 19),
+      _PlaceholderPlayer('AzimuthalAlpha', 'Speed Demon', 18),
+      _PlaceholderPlayer('ConicCrusader', 'Lightning', 18),
+      _PlaceholderPlayer('CylindricalChamp', 'Flag Expert', 17),
+      _PlaceholderPlayer('SinusoidalSage', 'Shape Shifter', 17),
+      _PlaceholderPlayer('MollweideMonarch', 'Boundary Expert', 16),
+      _PlaceholderPlayer('RobinsonRuler', 'Number Cruncher', 16),
+      _PlaceholderPlayer('WinkelTripelWiz', 'Mile High Club', 15),
+      _PlaceholderPlayer('FullerFlyer', 'Frequent Flier', 15),
+      _PlaceholderPlayer('TransverseTitan', 'Capital Navigator', 14),
+      _PlaceholderPlayer('ObliqueOracle', 'Shape Detective', 14),
+      _PlaceholderPlayer('PolyconicPilot', 'Data Analyst', 13),
+      _PlaceholderPlayer('PseudoConicPete', 'Border Guard', 13),
+      _PlaceholderPlayer('GoodeHomoloPro', 'Quick Draw', 12),
+      _PlaceholderPlayer('EckertEagle', 'Flag Enthusiast', 12),
+      _PlaceholderPlayer('BonneBlaze', 'Social Butterfly', 11),
+      _PlaceholderPlayer('LambertLion', 'Silhouette Spotter', 11),
+      _PlaceholderPlayer('AlbersAce', 'Capital Cadet', 10),
+      _PlaceholderPlayer('MillerMaster', 'Airborne', 10),
+      _PlaceholderPlayer('PetersPathfinder', 'Border Patrol', 9),
+      _PlaceholderPlayer('CassiniCrafter', 'Friendly Flier', 9),
+      _PlaceholderPlayer('AuthalicAndy', null, 8),
+      _PlaceholderPlayer('ConformalCarla', null, 8),
+      _PlaceholderPlayer('EquidistantEve', null, 7),
+      _PlaceholderPlayer('CompromiseChris', null, 7),
+      _PlaceholderPlayer('RetroazimuthalRon', null, 6),
+      _PlaceholderPlayer('GnomonicGrace', null, 6),
+      _PlaceholderPlayer('ApianAnna', null, 5),
+      _PlaceholderPlayer('BehrmannBen', null, 5),
+      _PlaceholderPlayer('CrasterClaire', null, 4),
+      _PlaceholderPlayer('You', 'Novice Vexillologist', 6),
+      _PlaceholderPlayer('FaheyFrank', null, 4),
+      _PlaceholderPlayer('GallGreta', null, 3),
+      _PlaceholderPlayer('KavraiskyyKate', null, 3),
+      _PlaceholderPlayer('LoxodromeLouis', null, 3),
+      _PlaceholderPlayer('NaturalEarthNina', null, 2),
+      _PlaceholderPlayer('QuarticQuinn', null, 2),
+      _PlaceholderPlayer('ToroidalTom', null, 1),
+      _PlaceholderPlayer('VerticalVera', null, 1),
+    ];
+
+    const int baseScore = 285000;
+
+    return List<LeaderboardEntry>.generate(legends.length, (i) {
+      final player = legends[i];
+      final rank = i + 1;
+
+      // All-time scores are much larger (cumulative across seasons).
+      final int rawScore;
+      if (rank <= 3) {
+        rawScore = baseScore - (rank - 1) * 4200;
+      } else if (rank <= 10) {
+        rawScore = baseScore - 8400 - (rank - 3) * 3100;
+      } else if (rank <= 25) {
+        rawScore = baseScore - 30100 - (rank - 10) * 2400;
+      } else {
+        rawScore = baseScore - 66100 - (rank - 25) * 1800;
+      }
+
+      // Variance per rank.
+      final int score = rawScore + (rank.isEven ? 520 : -380);
+
+      // Best time across all games -- top players have sub-minute bests.
+      final timeMs = 38000 + (rank * 1200) + (rank.isOdd ? 550 : -300);
+
+      // All-time games played -- top players have thousands.
+      final gamesPlayed = (8000 - rank * 120).clamp(50, 8000);
+
+      final isCurrentPlayer = player.name == 'You';
+
+      return LeaderboardEntry(
+        playerId: isCurrentPlayer ? 'current_player' : 'alltime_player_$rank',
+        username: player.name,
+        score: score,
+        bestTime: Duration(milliseconds: timeMs),
+        rank: rank,
+        gamesPlayed: gamesPlayed,
+        isLicensed: false,
+        displayTitle: player.title,
+        level: player.level,
+        streak: rank <= 3 ? (30 - rank * 5) : (rank <= 10 ? 10 : 0),
+      );
+    });
+  }
+
+  /// 20 entries for a regional (EU) board.
+  static List<LeaderboardEntry> _buildRegionalEntries() {
+    const players = <_PlaceholderPlayerRegion>[
+      _PlaceholderPlayerRegion('AlpineAviator', 'Lightning', 17, 'CH'),
+      _PlaceholderPlayerRegion('FjordFlyer', 'Speed Demon', 16, 'NO'),
+      _PlaceholderPlayerRegion('MediterraneanMax', 'Flag Expert', 15, 'IT'),
+      _PlaceholderPlayerRegion('BalticBaron', 'Quick Draw', 14, 'LT'),
+      _PlaceholderPlayerRegion('IberianIsa', 'Capital Navigator', 13, 'ES'),
+      _PlaceholderPlayerRegion('CarpathianCara', 'Shape Detective', 12, 'RO'),
+      _PlaceholderPlayerRegion('NordicNova', 'Border Guard', 11, 'SE'),
+      _PlaceholderPlayerRegion('AdriaticAndy', 'Data Analyst', 10, 'HR'),
+      _PlaceholderPlayerRegion('CelticCasey', null, 9, 'IE'),
+      _PlaceholderPlayerRegion('HellenicHero', null, 8, 'GR'),
+      _PlaceholderPlayerRegion('DanubianDave', null, 7, 'AT'),
+      _PlaceholderPlayerRegion('PyreneesPiper', null, 7, 'FR'),
+      _PlaceholderPlayerRegion('BeneluxBee', null, 6, 'BE'),
+      _PlaceholderPlayerRegion('VistullaVic', null, 5, 'PL'),
+      _PlaceholderPlayerRegion('RhineRover', null, 5, 'DE'),
+      _PlaceholderPlayerRegion('You', 'Novice Vexillologist', 6, 'GB'),
+      _PlaceholderPlayerRegion('ThamesTheo', null, 4, 'GB'),
+      _PlaceholderPlayerRegion('SeineSophie', null, 3, 'FR'),
+      _PlaceholderPlayerRegion('TiberTina', null, 2, 'IT'),
+      _PlaceholderPlayerRegion('ElbeElla', null, 1, 'DE'),
+    ];
+
+    const int baseScore = 11200;
+
+    return List<LeaderboardEntry>.generate(players.length, (i) {
+      final player = players[i];
+      final rank = i + 1;
+
+      final int rawScore = baseScore - (rank - 1) * 280 + (rank.isEven ? 45 : -30);
+      final timeMs = 68000 + (rank * 2000) + (rank.isOdd ? 350 : -200);
+      final gamesPlayed = (300 - rank * 10).clamp(15, 300);
+
+      final isCurrentPlayer = player.name == 'You';
+
+      return LeaderboardEntry(
+        playerId: isCurrentPlayer ? 'current_player' : 'regional_player_$rank',
+        username: player.name,
+        score: rawScore,
+        bestTime: Duration(milliseconds: timeMs),
+        rank: rank,
+        gamesPlayed: gamesPlayed,
+        isLicensed: false,
+        displayTitle: player.title,
+        level: player.level,
+        countryCode: player.countryCode,
+      );
+    });
+  }
+
+  /// 15 entries for a friends-only board.
+  static List<LeaderboardEntry> _buildFriendsEntries() {
+    const players = <_PlaceholderPlayer>[
+      _PlaceholderPlayer('BestMateBarry', 'Challenge Legend', 14),
+      _PlaceholderPlayer('SisterSarah', 'Flag Expert', 12),
+      _PlaceholderPlayer('DadJokesDave', 'Frequent Flier', 10),
+      _PlaceholderPlayer('ColleagueCarl', 'Quick Draw', 9),
+      _PlaceholderPlayer('NeighbourNancy', 'Airborne', 8),
+      _PlaceholderPlayer('CousinKev', null, 7),
+      _PlaceholderPlayer('You', 'Novice Vexillologist', 6),
+      _PlaceholderPlayer('OldSchoolOllie', null, 6),
+      _PlaceholderPlayer('GymBuddyGina', null, 5),
+      _PlaceholderPlayer('WorkmatePat', null, 4),
+      _PlaceholderPlayer('BookClubBen', null, 3),
+      _PlaceholderPlayer('YogaYolanda', null, 3),
+      _PlaceholderPlayer('PubQuizPaul', null, 2),
+      _PlaceholderPlayer('FootiePhil', null, 2),
+      _PlaceholderPlayer('CasualChris', null, 1),
+    ];
+
+    const int baseScore = 8500;
+
+    return List<LeaderboardEntry>.generate(players.length, (i) {
+      final player = players[i];
+      final rank = i + 1;
+
+      final int rawScore = baseScore - (rank - 1) * 350 + (rank.isEven ? 60 : -40);
+      final timeMs = 80000 + (rank * 2500) + (rank.isOdd ? 400 : -250);
+      final gamesPlayed = (200 - rank * 10).clamp(5, 200);
+
+      final isCurrentPlayer = player.name == 'You';
+
+      return LeaderboardEntry(
+        playerId: isCurrentPlayer ? 'current_player' : 'friend_player_$rank',
+        username: player.name,
+        score: rawScore,
+        bestTime: Duration(milliseconds: timeMs),
+        rank: rank,
+        gamesPlayed: gamesPlayed,
+        isLicensed: false,
+        displayTitle: player.title,
+        level: player.level,
+      );
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private placeholder helpers
+// ---------------------------------------------------------------------------
+
+/// A fake player with a name, optional social title, and level.
+class _PlaceholderPlayer {
+  const _PlaceholderPlayer(this.name, this.title, this.level);
+
+  final String name;
+  final String? title;
+  final int level;
+}
+
+/// A fake player with an additional country code for regional boards.
+class _PlaceholderPlayerRegion extends _PlaceholderPlayer {
+  const _PlaceholderPlayerRegion(
+    super.name,
+    super.title,
+    super.level,
+    this.countryCode,
+  );
+
+  final String countryCode;
+}

--- a/lib/data/models/live_group.dart
+++ b/lib/data/models/live_group.dart
@@ -1,0 +1,918 @@
+// Live group game mode models for real-time multiplayer sessions.
+//
+// Live Group is a premium feature where a subscriber hosts a lobby of
+// friends (up to 8 players). All players receive the same seeded questions
+// and race through rounds while a streaming leaderboard shows progress.
+//
+// Two round modes are supported:
+// - **standard** -- everyone plays every round; best cumulative score wins.
+// - **firstToAnswer** -- the first correct answer claims the round.
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// Lifecycle status of a live group session.
+enum LiveGroupStatus {
+  lobby, // Host is waiting for players to join
+  inProgress, // Game is actively being played
+  completed, // All rounds finished
+  cancelled, // Host or system cancelled the session
+}
+
+/// How each round is scored.
+enum LiveRoundMode {
+  /// Everyone plays the round; highest score wins.
+  standard,
+
+  /// First correct answer takes the round -- speed is everything.
+  firstToAnswer,
+}
+
+// ---------------------------------------------------------------------------
+// LiveGroupPlayer
+// ---------------------------------------------------------------------------
+
+/// A player participating in a live group session.
+class LiveGroupPlayer {
+  const LiveGroupPlayer({
+    required this.id,
+    required this.username,
+    this.isHost = false,
+    this.isSubscriber = true,
+    this.score = 0,
+    this.roundsWon = 0,
+    this.currentRound = 0,
+    this.lastAnswerTime,
+    this.isFinished = false,
+  });
+
+  final String id;
+  final String username;
+
+  /// Whether this player created the session.
+  final bool isHost;
+
+  /// Invited non-subscribers are marked so the UI can badge them.
+  final bool isSubscriber;
+
+  /// Cumulative score across all completed rounds.
+  final int score;
+
+  /// Number of rounds this player has won outright.
+  final int roundsWon;
+
+  /// The round this player is currently on (streams to the leaderboard).
+  final int currentRound;
+
+  /// Time taken on the most recently completed round.
+  final Duration? lastAnswerTime;
+
+  /// Whether this player has finished all rounds.
+  final bool isFinished;
+
+  // ── copyWith ─────────────────────────────────────────────────────────
+
+  LiveGroupPlayer copyWith({
+    String? id,
+    String? username,
+    bool? isHost,
+    bool? isSubscriber,
+    int? score,
+    int? roundsWon,
+    int? currentRound,
+    Duration? lastAnswerTime,
+    bool? isFinished,
+  }) =>
+      LiveGroupPlayer(
+        id: id ?? this.id,
+        username: username ?? this.username,
+        isHost: isHost ?? this.isHost,
+        isSubscriber: isSubscriber ?? this.isSubscriber,
+        score: score ?? this.score,
+        roundsWon: roundsWon ?? this.roundsWon,
+        currentRound: currentRound ?? this.currentRound,
+        lastAnswerTime: lastAnswerTime ?? this.lastAnswerTime,
+        isFinished: isFinished ?? this.isFinished,
+      );
+
+  // ── Serialisation ────────────────────────────────────────────────────
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'username': username,
+        'is_host': isHost,
+        'is_subscriber': isSubscriber,
+        'score': score,
+        'rounds_won': roundsWon,
+        'current_round': currentRound,
+        'last_answer_time_ms': lastAnswerTime?.inMilliseconds,
+        'is_finished': isFinished,
+      };
+
+  factory LiveGroupPlayer.fromJson(Map<String, dynamic> json) =>
+      LiveGroupPlayer(
+        id: json['id'] as String,
+        username: json['username'] as String,
+        isHost: json['is_host'] as bool? ?? false,
+        isSubscriber: json['is_subscriber'] as bool? ?? true,
+        score: json['score'] as int? ?? 0,
+        roundsWon: json['rounds_won'] as int? ?? 0,
+        currentRound: json['current_round'] as int? ?? 0,
+        lastAnswerTime: json['last_answer_time_ms'] != null
+            ? Duration(milliseconds: json['last_answer_time_ms'] as int)
+            : null,
+        isFinished: json['is_finished'] as bool? ?? false,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// LiveGroupAnswer
+// ---------------------------------------------------------------------------
+
+/// A single player's answer to a round.
+class LiveGroupAnswer {
+  const LiveGroupAnswer({
+    required this.playerId,
+    required this.answer,
+    required this.isCorrect,
+    required this.timeTaken,
+    this.pointsEarned = 0,
+  });
+
+  final String playerId;
+  final String answer;
+  final bool isCorrect;
+  final Duration timeTaken;
+  final int pointsEarned;
+
+  // ── Serialisation ────────────────────────────────────────────────────
+
+  Map<String, dynamic> toJson() => {
+        'player_id': playerId,
+        'answer': answer,
+        'is_correct': isCorrect,
+        'time_taken_ms': timeTaken.inMilliseconds,
+        'points_earned': pointsEarned,
+      };
+
+  factory LiveGroupAnswer.fromJson(Map<String, dynamic> json) =>
+      LiveGroupAnswer(
+        playerId: json['player_id'] as String,
+        answer: json['answer'] as String,
+        isCorrect: json['is_correct'] as bool,
+        timeTaken: Duration(milliseconds: json['time_taken_ms'] as int),
+        pointsEarned: json['points_earned'] as int? ?? 0,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// LiveGroupRound
+// ---------------------------------------------------------------------------
+
+/// The state and results of a single round in a live group session.
+class LiveGroupRound {
+  const LiveGroupRound({
+    required this.roundNumber,
+    required this.countryAnswer,
+    this.answers = const {},
+    this.firstCorrectPlayerId,
+    this.fastestTime,
+  });
+
+  /// 1-based round index.
+  final int roundNumber;
+
+  /// The correct country code for this round.
+  final String countryAnswer;
+
+  /// Each player's answer, keyed by player ID.
+  final Map<String, LiveGroupAnswer> answers;
+
+  /// The first player to answer correctly (used in [LiveRoundMode.firstToAnswer]).
+  final String? firstCorrectPlayerId;
+
+  /// The fastest correct answer time across all players.
+  final Duration? fastestTime;
+
+  /// Whether every player has submitted an answer.
+  bool isComplete(int playerCount) => answers.length >= playerCount;
+
+  /// All correct answers sorted by time taken (fastest first).
+  List<LiveGroupAnswer> get correctAnswersBySpeed {
+    return answers.values
+        .where((a) => a.isCorrect)
+        .toList()
+      ..sort((a, b) => a.timeTaken.compareTo(b.timeTaken));
+  }
+
+  // ── Serialisation ────────────────────────────────────────────────────
+
+  Map<String, dynamic> toJson() => {
+        'round_number': roundNumber,
+        'country_answer': countryAnswer,
+        'answers': answers
+            .map((key, value) => MapEntry(key, value.toJson())),
+        'first_correct_player_id': firstCorrectPlayerId,
+        'fastest_time_ms': fastestTime?.inMilliseconds,
+      };
+
+  factory LiveGroupRound.fromJson(Map<String, dynamic> json) =>
+      LiveGroupRound(
+        roundNumber: json['round_number'] as int,
+        countryAnswer: json['country_answer'] as String,
+        answers: (json['answers'] as Map<String, dynamic>?)?.map(
+              (key, value) => MapEntry(
+                key,
+                LiveGroupAnswer.fromJson(value as Map<String, dynamic>),
+              ),
+            ) ??
+            {},
+        firstCorrectPlayerId: json['first_correct_player_id'] as String?,
+        fastestTime: json['fastest_time_ms'] != null
+            ? Duration(milliseconds: json['fastest_time_ms'] as int)
+            : null,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// LiveLeaderboardEntry
+// ---------------------------------------------------------------------------
+
+/// A row in the streaming leaderboard shown during a live group session.
+///
+/// This is a derived view model -- it is computed from the session state
+/// rather than stored directly.
+class LiveLeaderboardEntry {
+  const LiveLeaderboardEntry({
+    required this.playerId,
+    required this.username,
+    required this.totalScore,
+    required this.roundsCompleted,
+    required this.roundsWon,
+    required this.totalTime,
+    this.isCurrentPlayer = false,
+  });
+
+  final String playerId;
+  final String username;
+  final int totalScore;
+  final int roundsCompleted;
+  final int roundsWon;
+  final Duration totalTime;
+
+  /// Whether this entry represents the local player (for highlight styling).
+  final bool isCurrentPlayer;
+
+  // ── Serialisation ────────────────────────────────────────────────────
+
+  Map<String, dynamic> toJson() => {
+        'player_id': playerId,
+        'username': username,
+        'total_score': totalScore,
+        'rounds_completed': roundsCompleted,
+        'rounds_won': roundsWon,
+        'total_time_ms': totalTime.inMilliseconds,
+        'is_current_player': isCurrentPlayer,
+      };
+
+  factory LiveLeaderboardEntry.fromJson(Map<String, dynamic> json) =>
+      LiveLeaderboardEntry(
+        playerId: json['player_id'] as String,
+        username: json['username'] as String,
+        totalScore: json['total_score'] as int,
+        roundsCompleted: json['rounds_completed'] as int,
+        roundsWon: json['rounds_won'] as int,
+        totalTime: Duration(milliseconds: json['total_time_ms'] as int),
+        isCurrentPlayer: json['is_current_player'] as bool? ?? false,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// LiveGroupSession
+// ---------------------------------------------------------------------------
+
+/// A complete live group game session.
+///
+/// The host creates a session and shares an invite code with friends.
+/// All players receive the same seeded questions so results are comparable.
+/// Subscribers can invite non-subscribers to play.
+class LiveGroupSession {
+  const LiveGroupSession({
+    required this.id,
+    required this.hostId,
+    required this.hostUsername,
+    required this.seed,
+    required this.status,
+    this.roundMode = LiveRoundMode.standard,
+    this.totalRounds = 10,
+    this.currentRound = 0,
+    this.enabledClueTypes = const {'flag', 'outline', 'borders', 'capital', 'stats'},
+    this.players = const [],
+    this.rounds = const [],
+    required this.createdAt,
+    this.startedAt,
+    this.completedAt,
+    this.timeLimit,
+    this.inviteCode,
+  });
+
+  final String id;
+  final String hostId;
+  final String hostUsername;
+
+  /// Deterministic seed so every player receives the same questions.
+  final int seed;
+
+  final LiveGroupStatus status;
+  final LiveRoundMode roundMode;
+
+  /// Total number of rounds in this session (e.g. 5, 10, 15).
+  final int totalRounds;
+
+  /// The round currently in progress (0 = not started, 1-based during play).
+  final int currentRound;
+
+  /// Which clue types are enabled for this session.
+  final Set<String> enabledClueTypes;
+
+  /// All players currently in the session (including the host).
+  final List<LiveGroupPlayer> players;
+
+  /// Completed and in-progress rounds.
+  final List<LiveGroupRound> rounds;
+
+  final DateTime createdAt;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+
+  /// Per-round time limit. `null` means unlimited.
+  final Duration? timeLimit;
+
+  /// Short code players use to join the lobby.
+  final String? inviteCode;
+
+  // ── Constraints ──────────────────────────────────────────────────────
+
+  static const int maxPlayers = 8;
+  static const int minPlayers = 2;
+
+  // ── Derived getters ──────────────────────────────────────────────────
+
+  /// Whether the lobby is full.
+  bool get isFull => players.length >= maxPlayers;
+
+  /// Whether there are enough players to start.
+  bool get canStart =>
+      players.length >= minPlayers && status == LiveGroupStatus.lobby;
+
+  /// Whether the session is still joinable.
+  bool get isJoinable =>
+      status == LiveGroupStatus.lobby && !isFull;
+
+  /// Progress through the session as a fraction (0.0 to 1.0).
+  double get progress =>
+      totalRounds > 0 ? currentRound / totalRounds : 0.0;
+
+  /// Build the streaming leaderboard from current player state.
+  ///
+  /// Pass [currentPlayerId] to flag the local player's entry.
+  List<LiveLeaderboardEntry> leaderboard({String? currentPlayerId}) {
+    final entries = players.map((p) {
+      return LiveLeaderboardEntry(
+        playerId: p.id,
+        username: p.username,
+        totalScore: p.score,
+        roundsCompleted: p.currentRound,
+        roundsWon: p.roundsWon,
+        totalTime: p.lastAnswerTime ?? Duration.zero,
+        isCurrentPlayer: p.id == currentPlayerId,
+      );
+    }).toList()
+      ..sort((a, b) {
+        // Primary: higher score first.
+        final scoreCmp = b.totalScore.compareTo(a.totalScore);
+        if (scoreCmp != 0) return scoreCmp;
+        // Tiebreaker: faster total time first.
+        return a.totalTime.compareTo(b.totalTime);
+      });
+
+    return entries;
+  }
+
+  // ── copyWith ─────────────────────────────────────────────────────────
+
+  LiveGroupSession copyWith({
+    String? id,
+    String? hostId,
+    String? hostUsername,
+    int? seed,
+    LiveGroupStatus? status,
+    LiveRoundMode? roundMode,
+    int? totalRounds,
+    int? currentRound,
+    Set<String>? enabledClueTypes,
+    List<LiveGroupPlayer>? players,
+    List<LiveGroupRound>? rounds,
+    DateTime? createdAt,
+    DateTime? startedAt,
+    DateTime? completedAt,
+    Duration? timeLimit,
+    String? inviteCode,
+  }) =>
+      LiveGroupSession(
+        id: id ?? this.id,
+        hostId: hostId ?? this.hostId,
+        hostUsername: hostUsername ?? this.hostUsername,
+        seed: seed ?? this.seed,
+        status: status ?? this.status,
+        roundMode: roundMode ?? this.roundMode,
+        totalRounds: totalRounds ?? this.totalRounds,
+        currentRound: currentRound ?? this.currentRound,
+        enabledClueTypes: enabledClueTypes ?? this.enabledClueTypes,
+        players: players ?? this.players,
+        rounds: rounds ?? this.rounds,
+        createdAt: createdAt ?? this.createdAt,
+        startedAt: startedAt ?? this.startedAt,
+        completedAt: completedAt ?? this.completedAt,
+        timeLimit: timeLimit ?? this.timeLimit,
+        inviteCode: inviteCode ?? this.inviteCode,
+      );
+
+  // ── Factory constructors ─────────────────────────────────────────────
+
+  /// Create a fresh lobby session ready for players to join.
+  factory LiveGroupSession.create({
+    required String hostId,
+    required String hostUsername,
+  }) {
+    final now = DateTime.now().toUtc();
+    final seed =
+        now.year * 100000000 +
+        now.month * 1000000 +
+        now.day * 10000 +
+        now.hour * 100 +
+        now.minute;
+
+    return LiveGroupSession(
+      id: 'lg_${now.millisecondsSinceEpoch}',
+      hostId: hostId,
+      hostUsername: hostUsername,
+      seed: seed,
+      status: LiveGroupStatus.lobby,
+      roundMode: LiveRoundMode.standard,
+      totalRounds: 10,
+      currentRound: 0,
+      enabledClueTypes: const {'flag', 'outline', 'borders', 'capital', 'stats'},
+      players: [
+        LiveGroupPlayer(
+          id: hostId,
+          username: hostUsername,
+          isHost: true,
+          isSubscriber: true,
+        ),
+      ],
+      rounds: const [],
+      createdAt: now,
+      inviteCode: _generateInviteCode(now.millisecondsSinceEpoch),
+    );
+  }
+
+  /// Generate a short 6-character alphanumeric invite code from a seed value.
+  static String _generateInviteCode(int seedValue) {
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no I/1/O/0 ambiguity
+    final buf = StringBuffer();
+    var v = seedValue;
+    for (var i = 0; i < 6; i++) {
+      buf.write(chars[v % chars.length]);
+      v = (v ~/ chars.length) + i + 1;
+    }
+    return buf.toString();
+  }
+
+  // ── Serialisation ────────────────────────────────────────────────────
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'host_id': hostId,
+        'host_username': hostUsername,
+        'seed': seed,
+        'status': status.name,
+        'round_mode': roundMode.name,
+        'total_rounds': totalRounds,
+        'current_round': currentRound,
+        'enabled_clue_types': enabledClueTypes.toList(),
+        'players': players.map((p) => p.toJson()).toList(),
+        'rounds': rounds.map((r) => r.toJson()).toList(),
+        'created_at': createdAt.toIso8601String(),
+        'started_at': startedAt?.toIso8601String(),
+        'completed_at': completedAt?.toIso8601String(),
+        'time_limit_ms': timeLimit?.inMilliseconds,
+        'invite_code': inviteCode,
+      };
+
+  factory LiveGroupSession.fromJson(Map<String, dynamic> json) =>
+      LiveGroupSession(
+        id: json['id'] as String,
+        hostId: json['host_id'] as String,
+        hostUsername: json['host_username'] as String,
+        seed: json['seed'] as int,
+        status: LiveGroupStatus.values.firstWhere(
+          (s) => s.name == json['status'],
+        ),
+        roundMode: LiveRoundMode.values.firstWhere(
+          (m) => m.name == json['round_mode'],
+          orElse: () => LiveRoundMode.standard,
+        ),
+        totalRounds: json['total_rounds'] as int? ?? 10,
+        currentRound: json['current_round'] as int? ?? 0,
+        enabledClueTypes: (json['enabled_clue_types'] as List?)
+                ?.map((e) => e as String)
+                .toSet() ??
+            const {'flag', 'outline', 'borders', 'capital', 'stats'},
+        players: (json['players'] as List?)
+                ?.map((p) =>
+                    LiveGroupPlayer.fromJson(p as Map<String, dynamic>))
+                .toList() ??
+            const [],
+        rounds: (json['rounds'] as List?)
+                ?.map((r) =>
+                    LiveGroupRound.fromJson(r as Map<String, dynamic>))
+                .toList() ??
+            const [],
+        createdAt: DateTime.parse(json['created_at'] as String),
+        startedAt: json['started_at'] != null
+            ? DateTime.parse(json['started_at'] as String)
+            : null,
+        completedAt: json['completed_at'] != null
+            ? DateTime.parse(json['completed_at'] as String)
+            : null,
+        timeLimit: json['time_limit_ms'] != null
+            ? Duration(milliseconds: json['time_limit_ms'] as int)
+            : null,
+        inviteCode: json['invite_code'] as String?,
+      );
+
+  // ── Placeholder data for UI development ──────────────────────────────
+
+  /// A sample mid-game session with 4 players for UI prototyping.
+  ///
+  /// The session is on round 6 of 10, using standard scoring with all
+  /// clue types enabled. Players have varying scores and progress to
+  /// exercise the streaming leaderboard layout.
+  factory LiveGroupSession.placeholder() {
+    final created = DateTime.utc(2025, 6, 15, 14, 0);
+    final started = DateTime.utc(2025, 6, 15, 14, 2);
+
+    const players = <LiveGroupPlayer>[
+      // Host -- leading the pack
+      LiveGroupPlayer(
+        id: 'player_host',
+        username: 'GlobeTrotter42',
+        isHost: true,
+        isSubscriber: true,
+        score: 5400,
+        roundsWon: 3,
+        currentRound: 6,
+        lastAnswerTime: Duration(seconds: 8, milliseconds: 320),
+        isFinished: false,
+      ),
+      // Strong competitor -- close behind
+      LiveGroupPlayer(
+        id: 'player_2',
+        username: 'AtlasAce',
+        isHost: false,
+        isSubscriber: true,
+        score: 5100,
+        roundsWon: 2,
+        currentRound: 6,
+        lastAnswerTime: Duration(seconds: 11, milliseconds: 750),
+        isFinished: false,
+      ),
+      // Invited non-subscriber -- mid-table
+      LiveGroupPlayer(
+        id: 'player_3',
+        username: 'MapNewbie',
+        isHost: false,
+        isSubscriber: false,
+        score: 3200,
+        roundsWon: 1,
+        currentRound: 5,
+        lastAnswerTime: Duration(seconds: 18, milliseconds: 400),
+        isFinished: false,
+      ),
+      // Slower player -- still on round 4
+      LiveGroupPlayer(
+        id: 'player_4',
+        username: 'WanderWiz',
+        isHost: false,
+        isSubscriber: true,
+        score: 2800,
+        roundsWon: 0,
+        currentRound: 4,
+        lastAnswerTime: Duration(seconds: 22, milliseconds: 100),
+        isFinished: false,
+      ),
+    ];
+
+    const rounds = <LiveGroupRound>[
+      LiveGroupRound(
+        roundNumber: 1,
+        countryAnswer: 'FR',
+        answers: {
+          'player_host': LiveGroupAnswer(
+            playerId: 'player_host',
+            answer: 'FR',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 6, milliseconds: 200),
+            pointsEarned: 1000,
+          ),
+          'player_2': LiveGroupAnswer(
+            playerId: 'player_2',
+            answer: 'FR',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 7, milliseconds: 800),
+            pointsEarned: 950,
+          ),
+          'player_3': LiveGroupAnswer(
+            playerId: 'player_3',
+            answer: 'DE',
+            isCorrect: false,
+            timeTaken: Duration(seconds: 14, milliseconds: 500),
+            pointsEarned: 0,
+          ),
+          'player_4': LiveGroupAnswer(
+            playerId: 'player_4',
+            answer: 'FR',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 19, milliseconds: 300),
+            pointsEarned: 800,
+          ),
+        },
+        firstCorrectPlayerId: 'player_host',
+        fastestTime: Duration(seconds: 6, milliseconds: 200),
+      ),
+      LiveGroupRound(
+        roundNumber: 2,
+        countryAnswer: 'BR',
+        answers: {
+          'player_host': LiveGroupAnswer(
+            playerId: 'player_host',
+            answer: 'BR',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 9, milliseconds: 100),
+            pointsEarned: 900,
+          ),
+          'player_2': LiveGroupAnswer(
+            playerId: 'player_2',
+            answer: 'BR',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 5, milliseconds: 400),
+            pointsEarned: 1000,
+          ),
+          'player_3': LiveGroupAnswer(
+            playerId: 'player_3',
+            answer: 'BR',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 16, milliseconds: 200),
+            pointsEarned: 750,
+          ),
+          'player_4': LiveGroupAnswer(
+            playerId: 'player_4',
+            answer: 'AR',
+            isCorrect: false,
+            timeTaken: Duration(seconds: 20, milliseconds: 700),
+            pointsEarned: 0,
+          ),
+        },
+        firstCorrectPlayerId: 'player_2',
+        fastestTime: Duration(seconds: 5, milliseconds: 400),
+      ),
+      LiveGroupRound(
+        roundNumber: 3,
+        countryAnswer: 'JP',
+        answers: {
+          'player_host': LiveGroupAnswer(
+            playerId: 'player_host',
+            answer: 'JP',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 4, milliseconds: 900),
+            pointsEarned: 1000,
+          ),
+          'player_2': LiveGroupAnswer(
+            playerId: 'player_2',
+            answer: 'JP',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 8, milliseconds: 300),
+            pointsEarned: 900,
+          ),
+          'player_3': LiveGroupAnswer(
+            playerId: 'player_3',
+            answer: 'JP',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 12, milliseconds: 600),
+            pointsEarned: 800,
+          ),
+          'player_4': LiveGroupAnswer(
+            playerId: 'player_4',
+            answer: 'JP',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 15, milliseconds: 800),
+            pointsEarned: 700,
+          ),
+        },
+        firstCorrectPlayerId: 'player_host',
+        fastestTime: Duration(seconds: 4, milliseconds: 900),
+      ),
+      LiveGroupRound(
+        roundNumber: 4,
+        countryAnswer: 'EG',
+        answers: {
+          'player_host': LiveGroupAnswer(
+            playerId: 'player_host',
+            answer: 'EG',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 10, milliseconds: 500),
+            pointsEarned: 850,
+          ),
+          'player_2': LiveGroupAnswer(
+            playerId: 'player_2',
+            answer: 'EG',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 9, milliseconds: 200),
+            pointsEarned: 900,
+          ),
+          'player_3': LiveGroupAnswer(
+            playerId: 'player_3',
+            answer: 'EG',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 18, milliseconds: 400),
+            pointsEarned: 650,
+          ),
+          'player_4': LiveGroupAnswer(
+            playerId: 'player_4',
+            answer: 'ZA',
+            isCorrect: false,
+            timeTaken: Duration(seconds: 25, milliseconds: 100),
+            pointsEarned: 0,
+          ),
+        },
+        firstCorrectPlayerId: 'player_2',
+        fastestTime: Duration(seconds: 9, milliseconds: 200),
+      ),
+      LiveGroupRound(
+        roundNumber: 5,
+        countryAnswer: 'AU',
+        answers: {
+          'player_host': LiveGroupAnswer(
+            playerId: 'player_host',
+            answer: 'AU',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 7, milliseconds: 700),
+            pointsEarned: 950,
+          ),
+          'player_2': LiveGroupAnswer(
+            playerId: 'player_2',
+            answer: 'AU',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 12, milliseconds: 100),
+            pointsEarned: 850,
+          ),
+          'player_3': LiveGroupAnswer(
+            playerId: 'player_3',
+            answer: 'AU',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 15, milliseconds: 900),
+            pointsEarned: 700,
+          ),
+          'player_4': LiveGroupAnswer(
+            playerId: 'player_4',
+            answer: 'AU',
+            isCorrect: true,
+            timeTaken: Duration(seconds: 20, milliseconds: 500),
+            pointsEarned: 600,
+          ),
+        },
+        firstCorrectPlayerId: 'player_host',
+        fastestTime: Duration(seconds: 7, milliseconds: 700),
+      ),
+    ];
+
+    return LiveGroupSession(
+      id: 'lg_placeholder_001',
+      hostId: 'player_host',
+      hostUsername: 'GlobeTrotter42',
+      seed: 20250615140200,
+      status: LiveGroupStatus.inProgress,
+      roundMode: LiveRoundMode.standard,
+      totalRounds: 10,
+      currentRound: 6,
+      enabledClueTypes: const {'flag', 'outline', 'borders', 'capital', 'stats'},
+      players: players,
+      rounds: rounds,
+      createdAt: created,
+      startedAt: started,
+      timeLimit: const Duration(seconds: 30),
+      inviteCode: 'FLTX7K',
+    );
+  }
+
+  /// A sample lobby session waiting for more players, for UI prototyping.
+  factory LiveGroupSession.placeholderLobby() {
+    final created = DateTime.utc(2025, 6, 15, 18, 30);
+
+    const players = <LiveGroupPlayer>[
+      LiveGroupPlayer(
+        id: 'player_host_2',
+        username: 'CartographyCat',
+        isHost: true,
+        isSubscriber: true,
+      ),
+      LiveGroupPlayer(
+        id: 'player_5',
+        username: 'MercatorMaven',
+        isHost: false,
+        isSubscriber: true,
+      ),
+    ];
+
+    return LiveGroupSession(
+      id: 'lg_placeholder_lobby',
+      hostId: 'player_host_2',
+      hostUsername: 'CartographyCat',
+      seed: 20250615183000,
+      status: LiveGroupStatus.lobby,
+      roundMode: LiveRoundMode.firstToAnswer,
+      totalRounds: 5,
+      currentRound: 0,
+      enabledClueTypes: const {'flag', 'capital'},
+      players: players,
+      rounds: const [],
+      createdAt: created,
+      timeLimit: const Duration(seconds: 20),
+      inviteCode: 'GEO2NR',
+    );
+  }
+
+  /// A sample completed session with final results, for UI prototyping.
+  factory LiveGroupSession.placeholderCompleted() {
+    final created = DateTime.utc(2025, 6, 15, 10, 0);
+    final started = DateTime.utc(2025, 6, 15, 10, 1);
+    final completed = DateTime.utc(2025, 6, 15, 10, 12);
+
+    const players = <LiveGroupPlayer>[
+      LiveGroupPlayer(
+        id: 'player_a',
+        username: 'EquatorExplorer',
+        isHost: true,
+        isSubscriber: true,
+        score: 8900,
+        roundsWon: 4,
+        currentRound: 10,
+        lastAnswerTime: Duration(seconds: 5, milliseconds: 100),
+        isFinished: true,
+      ),
+      LiveGroupPlayer(
+        id: 'player_b',
+        username: 'LatLongLegend',
+        isHost: false,
+        isSubscriber: true,
+        score: 7600,
+        roundsWon: 3,
+        currentRound: 10,
+        lastAnswerTime: Duration(seconds: 9, milliseconds: 800),
+        isFinished: true,
+      ),
+      LiveGroupPlayer(
+        id: 'player_c',
+        username: 'IslandHopper42',
+        isHost: false,
+        isSubscriber: false,
+        score: 6200,
+        roundsWon: 2,
+        currentRound: 10,
+        lastAnswerTime: Duration(seconds: 14, milliseconds: 300),
+        isFinished: true,
+      ),
+    ];
+
+    return LiveGroupSession(
+      id: 'lg_placeholder_done',
+      hostId: 'player_a',
+      hostUsername: 'EquatorExplorer',
+      seed: 20250615100100,
+      status: LiveGroupStatus.completed,
+      roundMode: LiveRoundMode.standard,
+      totalRounds: 10,
+      currentRound: 10,
+      enabledClueTypes: const {'flag', 'outline', 'borders', 'capital', 'stats'},
+      players: players,
+      rounds: const [],
+      createdAt: created,
+      startedAt: started,
+      completedAt: completed,
+      timeLimit: const Duration(seconds: 30),
+      inviteCode: 'ENDG4M',
+    );
+  }
+}

--- a/lib/data/models/social_title.dart
+++ b/lib/data/models/social_title.dart
@@ -1,0 +1,657 @@
+import 'cosmetic.dart';
+
+/// Categories of social titles a player can earn through gameplay.
+enum TitleCategory {
+  flag,
+  capital,
+  outline,
+  borders,
+  stats,
+  general,
+  speed,
+  streak,
+}
+
+/// A social title earned through gameplay milestones.
+///
+/// Titles are never purchased -- they are awarded when a player meets the
+/// [threshold] for a given [category]. Each title carries a [rarity] tier
+/// that controls how it is displayed on profiles and in friend lists.
+class SocialTitle {
+  const SocialTitle({
+    required this.id,
+    required this.name,
+    required this.category,
+    required this.threshold,
+    required this.description,
+    required this.rarity,
+  });
+
+  /// Unique identifier for this title.
+  final String id;
+
+  /// Display name shown on the player's profile and to friends.
+  final String name;
+
+  /// Which category this title belongs to.
+  final TitleCategory category;
+
+  /// The numeric milestone a player must reach to earn this title.
+  ///
+  /// For count-based categories this is the number of correct answers.
+  /// For speed titles this is the time in seconds the player must beat.
+  /// For streak titles this is the consecutive-correct count required.
+  final int threshold;
+
+  /// Flavour text describing the title.
+  final String description;
+
+  /// Visual rarity tier used for UI presentation (glow, colour, badge frame).
+  final CosmeticRarity rarity;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'category': category.name,
+        'threshold': threshold,
+        'description': description,
+        'rarity': rarity.name,
+      };
+
+  factory SocialTitle.fromJson(Map<String, dynamic> json) => SocialTitle(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        category: TitleCategory.values.firstWhere(
+          (c) => c.name == json['category'],
+        ),
+        threshold: json['threshold'] as int,
+        description: json['description'] as String,
+        rarity: CosmeticRarity.values.firstWhere(
+          (r) => r.name == json['rarity'],
+          orElse: () => CosmeticRarity.common,
+        ),
+      );
+}
+
+/// Lightweight progress snapshot used by [PlayerTitles.earnedTitles] to
+/// determine which titles a player qualifies for.
+///
+/// Each field maps directly to a [TitleCategory]. For speed and streak the
+/// values represent best-ever records rather than cumulative totals.
+class PlayerClueProgress {
+  const PlayerClueProgress({
+    this.flagsCorrect = 0,
+    this.capitalsCorrect = 0,
+    this.outlinesCorrect = 0,
+    this.bordersCorrect = 0,
+    this.statsCorrect = 0,
+    this.totalGamesPlayed = 0,
+    this.bestTimeSeconds = 0,
+    this.bestStreak = 0,
+  });
+
+  /// Total flag clues answered correctly.
+  final int flagsCorrect;
+
+  /// Total capital-city clues answered correctly.
+  final int capitalsCorrect;
+
+  /// Total country-outline clues answered correctly.
+  final int outlinesCorrect;
+
+  /// Total border/neighbour clues answered correctly.
+  final int bordersCorrect;
+
+  /// Total stats/data clues answered correctly.
+  final int statsCorrect;
+
+  /// Lifetime games played.
+  final int totalGamesPlayed;
+
+  /// Personal best round time in seconds (lower is better).
+  /// A value of 0 means no time has been recorded yet.
+  final int bestTimeSeconds;
+
+  /// Longest streak of consecutive correct answers ever achieved.
+  final int bestStreak;
+
+  Map<String, dynamic> toJson() => {
+        'flags_correct': flagsCorrect,
+        'capitals_correct': capitalsCorrect,
+        'outlines_correct': outlinesCorrect,
+        'borders_correct': bordersCorrect,
+        'stats_correct': statsCorrect,
+        'total_games_played': totalGamesPlayed,
+        'best_time_seconds': bestTimeSeconds,
+        'best_streak': bestStreak,
+      };
+
+  factory PlayerClueProgress.fromJson(Map<String, dynamic> json) =>
+      PlayerClueProgress(
+        flagsCorrect: json['flags_correct'] as int? ?? 0,
+        capitalsCorrect: json['capitals_correct'] as int? ?? 0,
+        outlinesCorrect: json['outlines_correct'] as int? ?? 0,
+        bordersCorrect: json['borders_correct'] as int? ?? 0,
+        statsCorrect: json['stats_correct'] as int? ?? 0,
+        totalGamesPlayed: json['total_games_played'] as int? ?? 0,
+        bestTimeSeconds: json['best_time_seconds'] as int? ?? 0,
+        bestStreak: json['best_streak'] as int? ?? 0,
+      );
+}
+
+/// Tracks a player's earned titles and which one is currently displayed.
+///
+/// [activeTitleId] is the id of the [SocialTitle] the player has chosen to
+/// show on their profile and in friend lists. It must reference a title that
+/// appears in the earned set, or be `null` if no title is selected.
+class PlayerTitles {
+  const PlayerTitles({
+    this.activeTitleId,
+  });
+
+  /// The [SocialTitle.id] currently displayed on the player's profile.
+  /// `null` means no title is shown.
+  final String? activeTitleId;
+
+  /// Returns every [SocialTitle] the player has unlocked based on [progress].
+  ///
+  /// Count-based categories use a >= comparison. Speed titles use a
+  /// strictly-less-than comparison (the player's best time must be below
+  /// the threshold). A [bestTimeSeconds] of 0 means no time has been
+  /// recorded and no speed titles are earned.
+  List<SocialTitle> earnedTitles(PlayerClueProgress progress) {
+    return SocialTitleCatalog.all.where((title) {
+      switch (title.category) {
+        case TitleCategory.flag:
+          return progress.flagsCorrect >= title.threshold;
+        case TitleCategory.capital:
+          return progress.capitalsCorrect >= title.threshold;
+        case TitleCategory.outline:
+          return progress.outlinesCorrect >= title.threshold;
+        case TitleCategory.borders:
+          return progress.bordersCorrect >= title.threshold;
+        case TitleCategory.stats:
+          return progress.statsCorrect >= title.threshold;
+        case TitleCategory.general:
+          return progress.totalGamesPlayed >= title.threshold;
+        case TitleCategory.speed:
+          return progress.bestTimeSeconds > 0 &&
+              progress.bestTimeSeconds < title.threshold;
+        case TitleCategory.streak:
+          return progress.bestStreak >= title.threshold;
+      }
+    }).toList();
+  }
+
+  /// The currently active [SocialTitle], resolved from the catalog.
+  /// Returns `null` when [activeTitleId] is unset or references an
+  /// unknown title.
+  SocialTitle? get activeTitle {
+    if (activeTitleId == null) return null;
+    return SocialTitleCatalog.getById(activeTitleId!);
+  }
+
+  /// Returns `true` when the [activeTitleId] is present in the set of
+  /// titles earned by [progress]. Always returns `true` when no title is
+  /// selected.
+  bool isActiveTitleValid(PlayerClueProgress progress) {
+    if (activeTitleId == null) return true;
+    return earnedTitles(progress).any((t) => t.id == activeTitleId);
+  }
+
+  PlayerTitles copyWith({
+    String? activeTitleId,
+  }) =>
+      PlayerTitles(
+        activeTitleId: activeTitleId ?? this.activeTitleId,
+      );
+
+  /// Creates a copy with no active title.
+  PlayerTitles clearActiveTitle() => const PlayerTitles(activeTitleId: null);
+
+  Map<String, dynamic> toJson() => {
+        'active_title_id': activeTitleId,
+      };
+
+  factory PlayerTitles.fromJson(Map<String, dynamic> json) => PlayerTitles(
+        activeTitleId: json['active_title_id'] as String?,
+      );
+}
+
+/// Master catalog of every earnable social title in the game.
+///
+/// Titles are organised by [TitleCategory] and ordered by ascending
+/// [threshold] within each category. Rarity tiers roughly map to the
+/// difficulty of reaching each threshold.
+abstract class SocialTitleCatalog {
+  // ---------------------------------------------------------------------------
+  // Flag (Vexillology)
+  // ---------------------------------------------------------------------------
+  static const List<SocialTitle> _flag = [
+    SocialTitle(
+      id: 'flag_spotter',
+      name: 'Flag Spotter',
+      category: TitleCategory.flag,
+      threshold: 10,
+      description: 'Taking the first steps into the world of flags.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'flag_enthusiast',
+      name: 'Flag Enthusiast',
+      category: TitleCategory.flag,
+      threshold: 50,
+      description: 'A growing passion for world flags.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'flag_novice_vexillologist',
+      name: 'Novice Vexillologist',
+      category: TitleCategory.flag,
+      threshold: 100,
+      description: 'No flag escapes your keen eye.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'flag_vexillologist',
+      name: 'Vexillologist',
+      category: TitleCategory.flag,
+      threshold: 250,
+      description: 'You could write a textbook on vexillology.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'flag_master_vexillologist',
+      name: 'Master Vexillologist',
+      category: TitleCategory.flag,
+      threshold: 500,
+      description: 'A true authority on the flags of the world.',
+      rarity: CosmeticRarity.epic,
+    ),
+    SocialTitle(
+      id: 'flag_grand_vexillologist',
+      name: 'Grand Vexillologist',
+      category: TitleCategory.flag,
+      threshold: 1000,
+      description: 'Your knowledge of flags borders on supernatural.',
+      rarity: CosmeticRarity.legendary,
+    ),
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Capital Cities
+  // ---------------------------------------------------------------------------
+  static const List<SocialTitle> _capital = [
+    SocialTitle(
+      id: 'capital_tourist',
+      name: 'Tourist',
+      category: TitleCategory.capital,
+      threshold: 10,
+      description: 'Just passing through the world\'s capitals.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'capital_city_hopper',
+      name: 'City Hopper',
+      category: TitleCategory.capital,
+      threshold: 50,
+      description: 'Hopping from capital to capital with ease.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'capital_correspondent',
+      name: 'Capital Correspondent',
+      category: TitleCategory.capital,
+      threshold: 100,
+      description: 'Reporting live from every seat of power.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'capital_ambassador',
+      name: 'Ambassador',
+      category: TitleCategory.capital,
+      threshold: 250,
+      description: 'World leaders would consult you on geography.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'capital_diplomat',
+      name: 'Diplomat',
+      category: TitleCategory.capital,
+      threshold: 500,
+      description: 'Every capital in the world is at your command.',
+      rarity: CosmeticRarity.epic,
+    ),
+    SocialTitle(
+      id: 'capital_secretary_general',
+      name: 'Secretary General',
+      category: TitleCategory.capital,
+      threshold: 1000,
+      description: 'The highest office of geographic diplomacy is yours.',
+      rarity: CosmeticRarity.legendary,
+    ),
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Country Outlines (Cartography)
+  // ---------------------------------------------------------------------------
+  static const List<SocialTitle> _outline = [
+    SocialTitle(
+      id: 'outline_map_reader',
+      name: 'Map Reader',
+      category: TitleCategory.outline,
+      threshold: 10,
+      description: 'Recognising countries by their shape alone.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'outline_cartographer_apprentice',
+      name: 'Cartographer\'s Apprentice',
+      category: TitleCategory.outline,
+      threshold: 50,
+      description: 'Every silhouette tells a story you can read.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'outline_cartographer',
+      name: 'Cartographer',
+      category: TitleCategory.outline,
+      threshold: 100,
+      description: 'Outlines morph into country names in your mind.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'outline_master_cartographer',
+      name: 'Master Cartographer',
+      category: TitleCategory.outline,
+      threshold: 250,
+      description: 'You could draw the world map from memory.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'outline_royal_cartographer',
+      name: 'Royal Cartographer',
+      category: TitleCategory.outline,
+      threshold: 500,
+      description: 'Appointed by the crown to chart the known world.',
+      rarity: CosmeticRarity.epic,
+    ),
+    SocialTitle(
+      id: 'outline_legendary_cartographer',
+      name: 'Legendary Cartographer',
+      category: TitleCategory.outline,
+      threshold: 1000,
+      description: 'A single curve is all you need to name the nation.',
+      rarity: CosmeticRarity.legendary,
+    ),
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Borders / Neighbours
+  // ---------------------------------------------------------------------------
+  static const List<SocialTitle> _borders = [
+    SocialTitle(
+      id: 'borders_fence_sitter',
+      name: 'Fence Sitter',
+      category: TitleCategory.borders,
+      threshold: 10,
+      description: 'Keeping an eye on the boundary lines.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'borders_border_hopper',
+      name: 'Border Hopper',
+      category: TitleCategory.borders,
+      threshold: 50,
+      description: 'Leaping across frontiers without breaking a sweat.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'borders_border_guard',
+      name: 'Border Guard',
+      category: TitleCategory.borders,
+      threshold: 100,
+      description: 'No border crossing goes unnoticed.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'borders_customs_officer',
+      name: 'Customs Officer',
+      category: TitleCategory.borders,
+      threshold: 250,
+      description: 'You know where every country ends and begins.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'borders_border_marshal',
+      name: 'Border Marshal',
+      category: TitleCategory.borders,
+      threshold: 500,
+      description: 'International boundaries are your specialty.',
+      rarity: CosmeticRarity.epic,
+    ),
+    SocialTitle(
+      id: 'borders_supreme_borderlord',
+      name: 'Supreme Borderlord',
+      category: TitleCategory.borders,
+      threshold: 1000,
+      description: 'Sovereign ruler of every boundary on Earth.',
+      rarity: CosmeticRarity.legendary,
+    ),
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Stats / Data
+  // ---------------------------------------------------------------------------
+  static const List<SocialTitle> _stats = [
+    SocialTitle(
+      id: 'stats_number_cruncher',
+      name: 'Number Cruncher',
+      category: TitleCategory.stats,
+      threshold: 10,
+      description: 'Starting to make sense of the numbers.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'stats_data_analyst',
+      name: 'Data Analyst',
+      category: TitleCategory.stats,
+      threshold: 50,
+      description: 'You see the stories hidden in statistics.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'stats_statistician',
+      name: 'Statistician',
+      category: TitleCategory.stats,
+      threshold: 100,
+      description: 'GDP, population, area -- nothing fazes you.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'stats_data_scientist',
+      name: 'Data Scientist',
+      category: TitleCategory.stats,
+      threshold: 250,
+      description: 'You could lecture at any university on world data.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'stats_chief_analyst',
+      name: 'Chief Analyst',
+      category: TitleCategory.stats,
+      threshold: 500,
+      description: 'The final word on every dataset that matters.',
+      rarity: CosmeticRarity.epic,
+    ),
+    SocialTitle(
+      id: 'stats_oracle_of_numbers',
+      name: 'Oracle of Numbers',
+      category: TitleCategory.stats,
+      threshold: 1000,
+      description: 'Walking encyclopedia of world statistics.',
+      rarity: CosmeticRarity.legendary,
+    ),
+  ];
+
+  // ---------------------------------------------------------------------------
+  // General (total games played)
+  // ---------------------------------------------------------------------------
+  static const List<SocialTitle> _general = [
+    SocialTitle(
+      id: 'general_rookie_pilot',
+      name: 'Rookie Pilot',
+      category: TitleCategory.general,
+      threshold: 10,
+      description: 'Every journey begins with a few early flights.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'general_flight_regular',
+      name: 'Flight Regular',
+      category: TitleCategory.general,
+      threshold: 50,
+      description: 'Getting comfortable in the cockpit.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'general_seasoned_flier',
+      name: 'Seasoned Flier',
+      category: TitleCategory.general,
+      threshold: 100,
+      description: 'The skies feel like home.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'general_frequent_flyer',
+      name: 'Frequent Flyer',
+      category: TitleCategory.general,
+      threshold: 250,
+      description: 'Your loyalty card is almost full.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'general_aviation_veteran',
+      name: 'Aviation Veteran',
+      category: TitleCategory.general,
+      threshold: 500,
+      description: 'A lifetime of flights behind you and many more ahead.',
+      rarity: CosmeticRarity.epic,
+    ),
+    SocialTitle(
+      id: 'general_legendary_aviator',
+      name: 'Legendary Aviator',
+      category: TitleCategory.general,
+      threshold: 1000,
+      description: 'You have circled the globe more times than anyone.',
+      rarity: CosmeticRarity.legendary,
+    ),
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Speed (best time records)
+  // ---------------------------------------------------------------------------
+  static const List<SocialTitle> _speed = [
+    SocialTitle(
+      id: 'speed_speed_demon',
+      name: 'Speed Demon',
+      category: TitleCategory.speed,
+      threshold: 60,
+      description: 'Answered in under a minute -- no hesitation.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'speed_sonic_pilot',
+      name: 'Sonic Pilot',
+      category: TitleCategory.speed,
+      threshold: 30,
+      description: 'Geography at the speed of sound.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'speed_light_speed',
+      name: 'Light Speed',
+      category: TitleCategory.speed,
+      threshold: 15,
+      description: 'Blink and you miss this pilot landing.',
+      rarity: CosmeticRarity.epic,
+    ),
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Streak (consecutive correct answers)
+  // ---------------------------------------------------------------------------
+  static const List<SocialTitle> _streak = [
+    SocialTitle(
+      id: 'streak_hot_streak',
+      name: 'Hot Streak',
+      category: TitleCategory.streak,
+      threshold: 5,
+      description: 'Five in a row -- you are warming up.',
+      rarity: CosmeticRarity.common,
+    ),
+    SocialTitle(
+      id: 'streak_on_fire',
+      name: 'On Fire',
+      category: TitleCategory.streak,
+      threshold: 10,
+      description: 'Ten consecutive correct answers. Unstoppable momentum.',
+      rarity: CosmeticRarity.rare,
+    ),
+    SocialTitle(
+      id: 'streak_unstoppable',
+      name: 'Unstoppable',
+      category: TitleCategory.streak,
+      threshold: 25,
+      description: 'Twenty-five without a miss. A force of nature.',
+      rarity: CosmeticRarity.epic,
+    ),
+    SocialTitle(
+      id: 'streak_phenomenon',
+      name: 'Phenomenon',
+      category: TitleCategory.streak,
+      threshold: 50,
+      description: 'Fifty consecutive correct. Beyond human comprehension.',
+      rarity: CosmeticRarity.legendary,
+    ),
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /// Every title available in the game, across all categories.
+  static List<SocialTitle> get all => [
+        ..._flag,
+        ..._capital,
+        ..._outline,
+        ..._borders,
+        ..._stats,
+        ..._general,
+        ..._speed,
+        ..._streak,
+      ];
+
+  /// All titles belonging to [category].
+  static List<SocialTitle> forCategory(TitleCategory category) =>
+      all.where((t) => t.category == category).toList();
+
+  /// Look up a single title by its [id]. Returns `null` if not found.
+  static SocialTitle? getById(String id) {
+    try {
+      return all.firstWhere((t) => t.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Returns every title the player has earned based on their [progress].
+  ///
+  /// Count-based categories use a >= comparison. Speed titles use a
+  /// strictly-less-than comparison (the player's best time must be below
+  /// the threshold). A [bestTimeSeconds] of 0 means no time has been
+  /// recorded and no speed titles are earned.
+  static List<SocialTitle> checkEarned(PlayerClueProgress progress) {
+    return const PlayerTitles().earnedTitles(progress);
+  }
+}

--- a/lib/data/models/subscription.dart
+++ b/lib/data/models/subscription.dart
@@ -1,0 +1,172 @@
+/// Subscription model for Flit Premium.
+///
+/// Flit is a freemium geography game. A small monthly subscription
+/// ("Flit Premium" / "Flit+") removes all ads and unlocks the exclusive
+/// "Live Group" game mode (GeoGuessr-style live multiplayer).
+/// Subscriptions can also be gifted to friends.
+library;
+
+enum SubscriptionTier { free, monthly, annual, lifetime }
+
+class Subscription {
+  final SubscriptionTier tier;
+  final DateTime? expiresAt;
+  final bool isGifted;
+  final String? giftedBy;
+  final DateTime? purchasedAt;
+
+  const Subscription({
+    this.tier = SubscriptionTier.free,
+    this.expiresAt,
+    this.isGifted = false,
+    this.giftedBy,
+    this.purchasedAt,
+  });
+
+  // ---------------------------------------------------------------------------
+  // Status helpers
+  // ---------------------------------------------------------------------------
+
+  /// Whether the subscription is currently active.
+  ///
+  /// Free tier is always "active" (it never expires).
+  /// Lifetime tier never expires once purchased.
+  /// Monthly and annual tiers are active only while [expiresAt] is in the
+  /// future.
+  bool get isActive {
+    switch (tier) {
+      case SubscriptionTier.free:
+        return true;
+      case SubscriptionTier.lifetime:
+        return purchasedAt != null;
+      case SubscriptionTier.monthly:
+      case SubscriptionTier.annual:
+        if (expiresAt == null) return false;
+        return expiresAt!.isAfter(DateTime.now());
+    }
+  }
+
+  /// Whether the user currently has premium perks (ad-free + Live Group).
+  bool get isPremium => tier != SubscriptionTier.free && isActive;
+
+  /// Number of days remaining on the subscription, or `null` for free /
+  /// lifetime tiers.
+  int? get daysRemaining {
+    if (tier == SubscriptionTier.free || tier == SubscriptionTier.lifetime) {
+      return null;
+    }
+    if (expiresAt == null) return 0;
+    final remaining = expiresAt!.difference(DateTime.now()).inDays;
+    return remaining < 0 ? 0 : remaining;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Premium perks
+  // ---------------------------------------------------------------------------
+
+  /// Premium removes ALL ad types (banner, interstitial, rewarded).
+  static const bool premiumRemovesAds = true;
+
+  /// Premium unlocks the "Live Group" multiplayer game mode.
+  static const bool premiumUnlocksLiveGroup = true;
+
+  // ---------------------------------------------------------------------------
+  // Pricing (USD)
+  // ---------------------------------------------------------------------------
+
+  /// Price in USD for each paid tier. Free tier has no price entry.
+  static const Map<SubscriptionTier, double> pricing = {
+    SubscriptionTier.monthly: 2.99,
+    SubscriptionTier.annual: 24.99,
+    SubscriptionTier.lifetime: 49.99,
+  };
+
+  /// Human-readable names for each tier.
+  static const Map<SubscriptionTier, String> tierNames = {
+    SubscriptionTier.free: 'Flit Free',
+    SubscriptionTier.monthly: 'Flit+ Monthly',
+    SubscriptionTier.annual: 'Flit+ Annual',
+    SubscriptionTier.lifetime: 'Flit+ Lifetime',
+  };
+
+  /// Short marketing descriptions shown on the paywall.
+  static const Map<SubscriptionTier, String> tierDescriptions = {
+    SubscriptionTier.free: 'Play free with ads',
+    SubscriptionTier.monthly: r'$2.99/month - cancel anytime',
+    SubscriptionTier.annual: r'$24.99/year - save ~30%',
+    SubscriptionTier.lifetime: r'$49.99 one-time - yours forever',
+  };
+
+  // ---------------------------------------------------------------------------
+  // Gifting
+  // ---------------------------------------------------------------------------
+
+  /// Create a gifted subscription from a donor username.
+  Subscription asGift({required String fromUsername}) {
+    return Subscription(
+      tier: tier,
+      expiresAt: expiresAt,
+      isGifted: true,
+      giftedBy: fromUsername,
+      purchasedAt: purchasedAt,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Serialization
+  // ---------------------------------------------------------------------------
+
+  Map<String, dynamic> toJson() {
+    return {
+      'tier': tier.name,
+      'expiresAt': expiresAt?.toIso8601String(),
+      'isGifted': isGifted,
+      'giftedBy': giftedBy,
+      'purchasedAt': purchasedAt?.toIso8601String(),
+    };
+  }
+
+  factory Subscription.fromJson(Map<String, dynamic> json) {
+    return Subscription(
+      tier: SubscriptionTier.values.firstWhere(
+        (t) => t.name == json['tier'],
+        orElse: () => SubscriptionTier.free,
+      ),
+      expiresAt: json['expiresAt'] != null
+          ? DateTime.parse(json['expiresAt'] as String)
+          : null,
+      isGifted: json['isGifted'] as bool? ?? false,
+      giftedBy: json['giftedBy'] as String?,
+      purchasedAt: json['purchasedAt'] != null
+          ? DateTime.parse(json['purchasedAt'] as String)
+          : null,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Equality & toString
+  // ---------------------------------------------------------------------------
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Subscription &&
+          runtimeType == other.runtimeType &&
+          tier == other.tier &&
+          expiresAt == other.expiresAt &&
+          isGifted == other.isGifted &&
+          giftedBy == other.giftedBy &&
+          purchasedAt == other.purchasedAt;
+
+  @override
+  int get hashCode => Object.hash(tier, expiresAt, isGifted, giftedBy, purchasedAt);
+
+  @override
+  String toString() {
+    final name = tierNames[tier] ?? tier.name;
+    if (tier == SubscriptionTier.free) return 'Subscription($name)';
+    final status = isActive ? 'active' : 'expired';
+    final gift = isGifted ? ', gifted by $giftedBy' : '';
+    return 'Subscription($name, $status$gift)';
+  }
+}

--- a/lib/game/ui/altitude_slider.dart
+++ b/lib/game/ui/altitude_slider.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+
+import '../../core/theme/flit_colors.dart';
+
+/// Vertical altitude slider control positioned on screen edge.
+/// Controls altitude continuously from low (bottom) to high (top).
+/// Maps to zoom levels with smooth transitions - lower is slower.
+class AltitudeSlider extends StatefulWidget {
+  const AltitudeSlider({
+    super.key,
+    required this.altitude,
+    required this.onAltitudeChanged,
+    this.isRightSide = true,
+  });
+
+  /// Current altitude value (0.0 = low, 1.0 = high).
+  final double altitude;
+
+  /// Callback when altitude changes.
+  final ValueChanged<double> onAltitudeChanged;
+
+  /// Whether to position on right side (true) or left side (false).
+  final bool isRightSide;
+
+  @override
+  State<AltitudeSlider> createState() => _AltitudeSliderState();
+}
+
+class _AltitudeSliderState extends State<AltitudeSlider> {
+  double? _dragValue;
+
+  // Layout constants for consistent positioning
+  static const double _trackPaddingVertical = 20.0;
+  static const double _thumbHeight = 32.0;
+  static const double _thumbHalfHeight = _thumbHeight / 2;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final sliderHeight = screenHeight * 0.5; // 50% of screen height
+    final currentAltitude = _dragValue ?? widget.altitude;
+    final trackHeight = sliderHeight - (_trackPaddingVertical * 2);
+
+    return Positioned(
+      right: widget.isRightSide ? 16 : null,
+      left: widget.isRightSide ? null : 16,
+      top: (screenHeight - sliderHeight) / 2,
+      child: GestureDetector(
+        onVerticalDragStart: (details) {
+          setState(() {
+            _dragValue = currentAltitude;
+          });
+        },
+        onVerticalDragUpdate: (details) {
+          setState(() {
+            // Convert vertical drag to altitude (inverted: up = higher altitude)
+            final newValue = (_dragValue! - details.delta.dy / sliderHeight)
+                .clamp(0.0, 1.0);
+            _dragValue = newValue;
+            widget.onAltitudeChanged(newValue);
+          });
+        },
+        onVerticalDragEnd: (details) {
+          setState(() {
+            _dragValue = null;
+          });
+        },
+        onTapDown: (details) {
+          // Allow tapping anywhere on the track to jump to that altitude
+          final localY = details.localPosition.dy;
+          final newValue = 1.0 - (localY - _trackPaddingVertical) / trackHeight; // Inverted
+          widget.onAltitudeChanged(newValue.clamp(0.0, 1.0));
+        },
+        child: Container(
+          width: 40,
+          height: sliderHeight,
+          decoration: BoxDecoration(
+            color: FlitColors.cardBackground.withOpacity(0.85),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: FlitColors.cardBorder.withOpacity(0.6),
+              width: 1.5,
+            ),
+          ),
+          child: Stack(
+            children: [
+              // Track gradient (low to high)
+              Positioned(
+                left: 10,
+                right: 10,
+                top: _trackPaddingVertical,
+                bottom: _trackPaddingVertical,
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    gradient: LinearGradient(
+                      begin: Alignment.bottomCenter,
+                      end: Alignment.topCenter,
+                      colors: [
+                        FlitColors.success.withOpacity(0.3),
+                        FlitColors.accent.withOpacity(0.3),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              // Low altitude indicator (bottom)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 8,
+                child: Icon(
+                  Icons.flight_land,
+                  color: FlitColors.success.withOpacity(0.6),
+                  size: 16,
+                ),
+              ),
+              // High altitude indicator (top)
+              Positioned(
+                left: 0,
+                right: 0,
+                top: 8,
+                child: Icon(
+                  Icons.flight_takeoff,
+                  color: FlitColors.accent.withOpacity(0.6),
+                  size: 16,
+                ),
+              ),
+              // Thumb indicator
+              AnimatedPositioned(
+                duration: const Duration(milliseconds: 100),
+                curve: Curves.easeOut,
+                left: 4,
+                right: 4,
+                bottom: _trackPaddingVertical + 
+                    trackHeight * (1.0 - currentAltitude) - 
+                    _thumbHalfHeight,
+                child: Container(
+                  height: _thumbHeight,
+                  decoration: BoxDecoration(
+                    color: _getAltitudeColor(currentAltitude),
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(
+                      color: FlitColors.cardBorder,
+                      width: 2,
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: _getAltitudeColor(currentAltitude)
+                            .withOpacity(0.4),
+                        blurRadius: 8,
+                        spreadRadius: 2,
+                      ),
+                    ],
+                  ),
+                  child: Center(
+                    child: Icon(
+                      _getAltitudeIcon(currentAltitude),
+                      color: FlitColors.textPrimary,
+                      size: 16,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _getAltitudeColor(double altitude) {
+    // Interpolate between success (low) and accent (high)
+    return Color.lerp(FlitColors.success, FlitColors.accent, altitude)!;
+  }
+
+  IconData _getAltitudeIcon(double altitude) {
+    if (altitude < 0.33) {
+      return Icons.flight_land;
+    } else if (altitude < 0.67) {
+      return Icons.flight;
+    } else {
+      return Icons.flight_takeoff;
+    }
+  }
+}

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,64 @@
+# Flit - Future Feature Plan
+
+Scaffolded models and UI components that are not yet wired into the app but represent planned features. Each has a data model or widget already written and ready for integration.
+
+---
+
+## Monetisation
+
+### Subscription Tiers
+**File:** `lib/data/models/subscription.dart`
+
+Four-tier freemium model (free, monthly, annual, lifetime) with premium perks including ad removal and Live Group hosting access. Includes pricing, active status tracking, and optional gifting.
+
+### Ad System
+**File:** `lib/data/models/ad_config.dart`
+
+Ad placement strategy covering banner, interstitial, and rewarded ad types. Defines frequency limits per session and placement rules. Ad eligibility is gated by subscription tier (premium users see no ads).
+
+---
+
+## Social & Multiplayer
+
+### Live Groups
+**File:** `lib/data/models/live_group.dart`
+
+Real-time multiplayer sessions where a premium subscriber hosts up to 8 players in live challenges with seeded questions and a streaming leaderboard. Supports two scoring modes: standard and first-to-answer.
+
+### Leaderboards
+**File:** `lib/data/models/leaderboard.dart`
+
+Comprehensive leaderboard system supporting licensed/unlicensed play across multiple board types: daily, all-time, seasonal, regional, and friends. Includes placeholder data generation for UI development and annual cosmetic rewards for top performers.
+
+### Social Titles
+**File:** `lib/data/models/social_title.dart`
+
+Achievement title system with 8 categories (flags, capitals, outlines, borders, stats, general, speed, streak) unlocked through gameplay milestones. Titles have rarity tiers with corresponding visual presentation.
+
+---
+
+## Gameplay UI
+
+### Challenge Result Screen
+**File:** `lib/features/challenge/challenge_result_screen.dart`
+
+End-of-challenge summary screen showing victory/defeat, best-of-5 score, per-round time comparisons, coins earned, and rematch/home navigation. Consumes the `Challenge` model from `lib/data/models/challenge.dart`.
+
+### Altitude Slider
+**File:** `lib/game/ui/altitude_slider.dart`
+
+Vertical slider widget for controlling camera altitude with smooth transitions, drag-to-adjust, and color/icon feedback representing zoom levels from low to high.
+
+### Region Camera Presets
+**File:** `lib/game/rendering/region_camera_presets.dart`
+
+Per-region camera positions, altitudes, FOV overrides, and bounds-checking for the globe camera. Covers world, US, UK, Caribbean, Ireland, and Canada regions. Has a full test suite in `test/unit/game/rendering/camera_state_test.dart`.
+
+---
+
+## Core Infrastructure
+
+### Core Barrel Export
+**File:** `lib/core/core.dart`
+
+Barrel file exporting core module services (dev overlay, error sender, error service) and theming utilities (colours and theme) for convenient access.


### PR DESCRIPTION
This pull request primarily removes several pieces of documentation and internal developer utilities that are no longer needed, and updates the project's linting script for improved accuracy and developer experience. It also adds a new planning document outlining future features and removes some unused code from the codebase.

The most important changes are:

### Documentation and Planning

* Removed `PR91_FIXES.md`, which previously documented issue fixes and testing recommendations for PR 91. This cleans up outdated or redundant documentation.
* Added a new `plan.md` file that outlines scaffolded models and UI components for planned features, including monetization, social/multiplayer, gameplay UI, and core infrastructure. This serves as a roadmap for future development.

### Linting and Developer Tools

* Improved the `scripts/lint-noflutter.sh` script:
  - Enhanced const constructor checks to be more permissive and avoid false positives by checking for 'const' anywhere on the line, not just at the start.
  - Updated bracket balance checking to distinguish between major and minor imbalances, reporting minor ones as info (likely due to string content) and only flagging large imbalances as errors.

### Codebase Cleanup

* Removed unused or test-only code:
  - Deleted test account switching methods from `AccountNotifier` and an unused provider for purchased region IDs. [[1]](diffhunk://#diff-0827599c775847331aeb68ede8c4e9b9cb92bbfa39fc03566f1b3737e0398186L94-L98) [[2]](diffhunk://#diff-0827599c775847331aeb68ede8c4e9b9cb92bbfa39fc03566f1b3737e0398186L356-L360)
  - Removed the `getById` method from `TestAccounts` as it is no longer used.
  - Removed the `GameResult` class from `game_session.dart`, indicating a refactor or replacement in how game results are handled.
  - Removed the `toJsonList` serialization method from `ErrorService` as it is no longer needed.