### PR TITLE
fix: render avatars properly instead of letter-only fallbacks

### DIFF
--- a/lib/data/models/friend.dart
+++ b/lib/data/models/friend.dart
@@ -1,3 +1,5 @@
+import 'avatar_config.dart';
+
 /// Friendship status between two players.
 enum FriendshipStatus {
   pending,
@@ -13,6 +15,7 @@ class Friend {
     required this.username,
     this.displayName,
     this.avatarUrl,
+    this.avatarConfig,
     this.status = FriendshipStatus.accepted,
     this.isOnline = false,
     this.lastSeen,
@@ -23,6 +26,7 @@ class Friend {
   final String username;
   final String? displayName;
   final String? avatarUrl;
+  final AvatarConfig? avatarConfig;
   final FriendshipStatus status;
   final bool isOnline;
   final DateTime? lastSeen;
@@ -35,6 +39,7 @@ class Friend {
         'username': username,
         'display_name': displayName,
         'avatar_url': avatarUrl,
+        if (avatarConfig != null) 'avatar_config': avatarConfig!.toJson(),
         'status': status.name,
         'is_online': isOnline,
         'last_seen': lastSeen?.toIso8601String(),
@@ -46,6 +51,10 @@ class Friend {
         username: json['username'] as String,
         displayName: json['display_name'] as String?,
         avatarUrl: json['avatar_url'] as String?,
+        avatarConfig: json['avatar_config'] != null
+            ? AvatarConfig.fromJson(
+                json['avatar_config'] as Map<String, dynamic>)
+            : null,
         status: FriendshipStatus.values.firstWhere(
           (s) => s.name == json['status'],
           orElse: () => FriendshipStatus.pending,

--- a/lib/features/avatar/avatar_widget.dart
+++ b/lib/features/avatar/avatar_widget.dart
@@ -1,18 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:http/http.dart' as http;
 
 import '../../core/theme/flit_colors.dart';
 import '../../data/models/avatar_config.dart';
 import 'avatar_compositor.dart';
+
+/// In-memory SVG cache keyed by DiceBear URL.
+///
+/// Survives widget rebuilds and screen navigation so repeated renders are
+/// instant. Entries are never evicted because the set of unique avatar
+/// configurations a single player sees in one session is small.
+final Map<String, String> _svgCache = {};
 
 /// Renders a DiceBear avatar as an SVG.
 ///
 /// For [AvatarStyle.adventurer], the avatar is composited entirely from local
 /// SVG parts — no network call, no loading state, instant render.
 ///
-/// For other styles, shows the style initial with a colored background as a
-/// fast, offline-capable representation. Network fetching from DiceBear has
-/// been removed entirely to avoid timeout issues on mobile/PWA.
+/// For other styles, the widget fetches the SVG from the DiceBear API on
+/// first render, caches it in memory, and shows the style initial as a
+/// placeholder while loading. Subsequent renders (including across screen
+/// navigations) hit the in-memory cache and are instant.
 ///
 /// The widget sizes itself to [size] × [size] logical pixels and is safe
 /// to use anywhere a square widget is expected (lists, cards, profiles).
@@ -34,36 +43,99 @@ class _AvatarWidgetState extends State<AvatarWidget> {
   /// Cached composed SVG string for the current config.
   String? _composedSvg;
 
-  /// Whether local SVG composition failed.
+  /// Whether local SVG composition failed and network fetch is needed.
   bool _composeFailed = false;
+
+  /// Whether the network SVG has been fetched (or failed).
+  bool _networkFetched = false;
+
+  /// Whether a network fetch is currently in progress.
+  bool _fetching = false;
 
   @override
   void initState() {
     super.initState();
-    _compose();
+    _resolve();
   }
 
   @override
   void didUpdateWidget(AvatarWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.config != widget.config) {
-      _compose();
+      _resolve();
     }
   }
 
-  void _compose() {
+  /// Attempt local composition first; fall back to cached/network SVG.
+  void _resolve() {
+    // Reset state.
+    _composeFailed = false;
+    _networkFetched = false;
+    _fetching = false;
+
+    // 1. Try local composition (adventurer style).
     try {
       final svg = AvatarCompositor.compose(widget.config);
-      setState(() {
-        _composedSvg = svg;
-        _composeFailed = svg == null;
-      });
+      if (svg != null) {
+        setState(() {
+          _composedSvg = svg;
+        });
+        return;
+      }
     } catch (e) {
       debugPrint('Avatar compose error: $e');
+    }
+
+    // 2. Local composition returned null or threw — check memory cache.
+    _composeFailed = true;
+    final cacheKey = widget.config.svgUri.toString();
+    final cached = _svgCache[cacheKey];
+    if (cached != null) {
       setState(() {
-        _composedSvg = null;
-        _composeFailed = true;
+        _composedSvg = cached;
+        _networkFetched = true;
       });
+      return;
+    }
+
+    // 3. Not in cache — fetch from DiceBear API.
+    setState(() {
+      _composedSvg = null;
+    });
+    _fetchFromNetwork(cacheKey);
+  }
+
+  Future<void> _fetchFromNetwork(String cacheKey) async {
+    if (_fetching) return;
+    _fetching = true;
+
+    try {
+      final response = await http
+          .get(widget.config.svgUri)
+          .timeout(const Duration(seconds: 8));
+
+      if (!mounted) return;
+
+      if (response.statusCode == 200 && response.body.contains('<svg')) {
+        _svgCache[cacheKey] = response.body;
+        setState(() {
+          _composedSvg = response.body;
+          _networkFetched = true;
+        });
+      } else {
+        setState(() {
+          _networkFetched = true; // Mark as attempted; show fallback.
+        });
+      }
+    } catch (e) {
+      debugPrint('Avatar network fetch error: $e');
+      if (mounted) {
+        setState(() {
+          _networkFetched = true; // Show fallback on error.
+        });
+      }
+    } finally {
+      _fetching = false;
     }
   }
 
@@ -99,6 +171,140 @@ class _AvatarWidgetState extends State<AvatarWidget> {
   }
 }
 
+/// Renders an avatar from a DiceBear SVG URL string.
+///
+/// Use this for models that only carry an [avatarUrl] (e.g. [Friend],
+/// [LeaderboardEntry]) instead of a full [AvatarConfig]. Fetches the SVG
+/// once, caches in memory, and shows a [name]-initial placeholder meanwhile.
+class AvatarFromUrl extends StatefulWidget {
+  const AvatarFromUrl({
+    super.key,
+    required this.avatarUrl,
+    required this.name,
+    this.size = 48,
+  });
+
+  /// DiceBear SVG URL (or any SVG URL).
+  final String? avatarUrl;
+
+  /// Display name used for the initial-letter fallback.
+  final String name;
+
+  final double size;
+
+  @override
+  State<AvatarFromUrl> createState() => _AvatarFromUrlState();
+}
+
+class _AvatarFromUrlState extends State<AvatarFromUrl> {
+  String? _svg;
+  bool _attempted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void didUpdateWidget(AvatarFromUrl oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.avatarUrl != widget.avatarUrl) {
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final url = widget.avatarUrl;
+    if (url == null || url.isEmpty) {
+      setState(() => _attempted = true);
+      return;
+    }
+
+    // Check cache.
+    final cached = _svgCache[url];
+    if (cached != null) {
+      setState(() {
+        _svg = cached;
+        _attempted = true;
+      });
+      return;
+    }
+
+    // Fetch.
+    try {
+      final response = await http
+          .get(Uri.parse(url))
+          .timeout(const Duration(seconds: 8));
+
+      if (!mounted) return;
+
+      if (response.statusCode == 200 && response.body.contains('<svg')) {
+        _svgCache[url] = response.body;
+        setState(() {
+          _svg = response.body;
+          _attempted = true;
+        });
+      } else {
+        setState(() => _attempted = true);
+      }
+    } catch (_) {
+      if (mounted) setState(() => _attempted = true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final fallbackLetter =
+        widget.name.isNotEmpty ? widget.name[0].toUpperCase() : '?';
+    final hash = widget.name.hashCode;
+    final hue = (hash % 360).abs().toDouble();
+    final bgColor = HSLColor.fromAHSL(1.0, hue, 0.5, 0.35).toColor();
+
+    return SizedBox(
+      width: widget.size,
+      height: widget.size,
+      child: ClipOval(
+        child: _svg != null
+            ? Container(
+                decoration: BoxDecoration(
+                  color: FlitColors.backgroundMid,
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: FlitColors.cardBorder,
+                    width: widget.size * 0.02,
+                  ),
+                ),
+                child: SvgPicture.string(
+                  _svg!,
+                  width: widget.size,
+                  height: widget.size,
+                  fit: BoxFit.cover,
+                ),
+              )
+            : Container(
+                width: widget.size,
+                height: widget.size,
+                decoration: BoxDecoration(
+                  color: bgColor,
+                  shape: BoxShape.circle,
+                ),
+                child: Center(
+                  child: Text(
+                    fallbackLetter,
+                    style: TextStyle(
+                      color: FlitColors.textPrimary,
+                      fontSize: widget.size * 0.4,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+              ),
+      ),
+    );
+  }
+}
+
 /// Wraps [SvgPicture.string] with an error boundary so invalid SVG data
 /// doesn't crash the widget tree — falls back to a person icon instead.
 class _SafeSvgRender extends StatelessWidget {
@@ -121,8 +327,8 @@ class _SafeSvgRender extends StatelessWidget {
 /// Offline fallback for non-adventurer styles.
 ///
 /// Shows the first letter of the style label inside a colored circle.
-/// This replaces the old network-based approach that constantly timed out
-/// on mobile and iOS PWA.
+/// Used as a placeholder while the DiceBear API SVG is being fetched,
+/// or as a final fallback when the fetch fails.
 class _StyleFallback extends StatelessWidget {
   const _StyleFallback({required this.style, required this.size});
 

--- a/lib/features/friends/friends_screen.dart
+++ b/lib/features/friends/friends_screen.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../data/models/avatar_config.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/models/friend.dart';
 import '../../data/providers/account_provider.dart';
+import '../avatar/avatar_widget.dart';
 import '../play/play_screen.dart';
 
 /// Friends list screen with add friend and H2H records.
@@ -24,6 +26,12 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
       username: 'SpeedyPilot',
       displayName: 'Speedy Pilot',
       isOnline: true,
+      avatarConfig: AvatarConfig(
+        eyes: AvatarEyes.variant05,
+        hair: AvatarHair.short03,
+        hairColor: AvatarHairColor.auburn,
+        skinColor: AvatarSkinColor.light,
+      ),
     ),
     Friend(
       id: '2',
@@ -32,12 +40,28 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
       displayName: 'Geo Master',
       isOnline: false,
       lastSeen: DateTime.now().subtract(const Duration(hours: 2)),
+      avatarConfig: const AvatarConfig(
+        eyes: AvatarEyes.variant12,
+        mouth: AvatarMouth.variant08,
+        hair: AvatarHair.long04,
+        hairColor: AvatarHairColor.black,
+        skinColor: AvatarSkinColor.medium,
+        glasses: AvatarGlasses.variant02,
+      ),
     ),
     const Friend(
       id: '3',
       playerId: 'p3',
       username: 'WorldFlyer',
       isOnline: true,
+      avatarConfig: AvatarConfig(
+        eyes: AvatarEyes.variant18,
+        mouth: AvatarMouth.variant03,
+        hair: AvatarHair.short10,
+        hairColor: AvatarHairColor.blonde,
+        skinColor: AvatarSkinColor.mediumLight,
+        feature: AvatarFeature.freckles,
+      ),
     ),
   ];
 
@@ -301,24 +325,17 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
               ),
               const SizedBox(height: 20),
               // Avatar
-              Container(
-                width: 64,
-                height: 64,
-                decoration: const BoxDecoration(
-                  color: FlitColors.accent,
-                  shape: BoxShape.circle,
+              if (friend.avatarConfig != null)
+                AvatarWidget(
+                  config: friend.avatarConfig!,
+                  size: 64,
+                )
+              else
+                AvatarFromUrl(
+                  avatarUrl: friend.avatarUrl,
+                  name: friend.name,
+                  size: 64,
                 ),
-                child: Center(
-                  child: Text(
-                    friend.name[0].toUpperCase(),
-                    style: const TextStyle(
-                      color: FlitColors.textPrimary,
-                      fontSize: 28,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ),
               const SizedBox(height: 12),
               Text(
                 friend.name,
@@ -786,24 +803,17 @@ class _FriendTile extends StatelessWidget {
                 // Avatar
                 Stack(
                   children: [
-                    Container(
-                      width: 48,
-                      height: 48,
-                      decoration: const BoxDecoration(
-                        color: FlitColors.accent,
-                        shape: BoxShape.circle,
+                    if (friend.avatarConfig != null)
+                      AvatarWidget(
+                        config: friend.avatarConfig!,
+                        size: 48,
+                      )
+                    else
+                      AvatarFromUrl(
+                        avatarUrl: friend.avatarUrl,
+                        name: friend.name,
+                        size: 48,
                       ),
-                      child: Center(
-                        child: Text(
-                          friend.name[0].toUpperCase(),
-                          style: const TextStyle(
-                            color: FlitColors.textPrimary,
-                            fontSize: 20,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    ),
                     if (friend.isOnline)
                       Positioned(
                         right: 0,

--- a/lib/features/leaderboard/leaderboard_screen.dart
+++ b/lib/features/leaderboard/leaderboard_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
 import '../../data/models/leaderboard_entry.dart';
+import '../avatar/avatar_widget.dart';
 
 /// Leaderboard screen showing top scores.
 class LeaderboardScreen extends StatefulWidget {
@@ -22,6 +23,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
       playerName: 'SpeedyPilot',
       time: const Duration(seconds: 12, milliseconds: 340),
       score: 9876,
+      avatarUrl: 'https://api.dicebear.com/7.x/adventurer/svg?seed=SpeedyPilot',
       timestamp: DateTime.now(),
     ),
     LeaderboardEntry(
@@ -30,6 +32,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
       playerName: 'GeoMaster',
       time: const Duration(seconds: 14, milliseconds: 120),
       score: 9588,
+      avatarUrl: 'https://api.dicebear.com/7.x/adventurer/svg?seed=GeoMaster',
       timestamp: DateTime.now(),
     ),
     LeaderboardEntry(
@@ -38,6 +41,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
       playerName: 'WorldFlyer',
       time: const Duration(seconds: 15, milliseconds: 890),
       score: 9411,
+      avatarUrl: 'https://api.dicebear.com/7.x/adventurer/svg?seed=WorldFlyer',
       timestamp: DateTime.now(),
     ),
     LeaderboardEntry(
@@ -46,6 +50,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
       playerName: 'Navigator99',
       time: const Duration(seconds: 18, milliseconds: 450),
       score: 9155,
+      avatarUrl: 'https://api.dicebear.com/7.x/adventurer/svg?seed=Navigator99',
       timestamp: DateTime.now(),
     ),
     LeaderboardEntry(
@@ -54,6 +59,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
       playerName: 'CloudSurfer',
       time: const Duration(seconds: 21, milliseconds: 230),
       score: 8877,
+      avatarUrl: 'https://api.dicebear.com/7.x/adventurer/svg?seed=CloudSurfer',
       timestamp: DateTime.now(),
     ),
   ];
@@ -173,7 +179,14 @@ class _LeaderboardRow extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(width: 12),
+          const SizedBox(width: 8),
+          // Avatar
+          AvatarFromUrl(
+            avatarUrl: entry.avatarUrl,
+            name: entry.playerName,
+            size: 36,
+          ),
+          const SizedBox(width: 10),
           // Player info
           Expanded(
             child: Column(


### PR DESCRIPTION
AvatarWidget now fetches SVGs from DiceBear API for non-adventurer styles (with in-memory caching and letter placeholder while loading). Previously only the adventurer style rendered locally; all other 9 styles silently fell back to showing a single letter.

Added AvatarFromUrl widget for models that carry avatarUrl strings (Friend, LeaderboardEntry) — fetches once, caches in memory, shows name-initial fallback while loading or on error.

Updated friends screen to use AvatarWidget/AvatarFromUrl instead of hard-coded letter circles. Updated leaderboard rows to show avatars. Added avatarConfig field to Friend model for full offline rendering.

https://claude.ai/code/session_01NKETArY1WfHKinMAsimPiy