### PR TITLE
fix: prevent web build OOM by adding swap space and reducing dart2js …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,14 @@ jobs:
       - name: Get dependencies
         run: flutter pub get
 
+      - name: Add swap space
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          echo "Swap enabled: $(swapon --show)"
+
       - name: Verify shader assets
         run: test -f shaders/globe.frag && echo "globe.frag OK"
 
@@ -97,7 +105,7 @@ jobs:
           set -o pipefail
           for attempt in 1 2; do
             echo "Build web attempt ${attempt}/2"
-            if flutter build web --release --dart2js-optimization=O3 --base-href "/flit/" 2>&1 | tee flutter-build.log; then
+            if flutter build web --release --dart2js-optimization=O2 --base-href "/flit/" 2>&1 | tee flutter-build.log; then
               break
             fi
             if [ "$attempt" -eq 2 ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@ PLATFORM=${1:-all}
 
 build_web() {
     echo "🌐 Building web..."
-    flutter build web --release --dart2js-optimization=O3 --base-href "/flit/"
+    flutter build web --release --dart2js-optimization=O2 --base-href "/flit/"
     echo "✅ Web build complete: build/web/"
 }
 


### PR DESCRIPTION
…optimization

The web build has been failing intermittently with exit code 143 (SIGTERM/OOM killed) since PR #169. Root cause: country_data.dart contains 65,398 inline Vector2 constructor calls (76K lines, 2.87 MB) which exhausts dart2js memory on the GitHub Actions runner (7GB RAM).

Two fixes applied:
- Add 8GB swap space to the build-web CI job so the runner has ~15GB virtual memory, preventing OOM kills during dart2js compilation
- Reduce dart2js optimization from O3 to O2 (safe production optimizations with minification, but without the memory-intensive unsafe type check elimination of O3/O4)

https://claude.ai/code/session_01JQP8GyD4Z5Jb4XthyrrBdM