### PR TITLE
fix: disable existing swapfile before resizing to avoid 'Text file busy'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,18 @@ jobs:
       - name: Get dependencies
         run: flutter pub get
 
-      - name: Add swap space
+      - name: Increase swap space
         run: |
+          # GitHub runners already have a swapfile; resize it for dart2js
+          sudo swapoff /swapfile || true
+          sudo rm -f /swapfile
           sudo fallocate -l 8G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile
-          echo "Swap enabled: $(swapon --show)"
+          echo "Swap enabled:"
+          swapon --show
+          free -h
 
       - name: Verify shader assets
         run: test -f shaders/globe.frag && echo "globe.frag OK"


### PR DESCRIPTION
GitHub Actions runners already have /swapfile mounted. Must swapoff and remove it before re-creating at 8GB for dart2js compilation headroom.

https://claude.ai/code/session_01JQP8GyD4Z5Jb4XthyrrBdM