### PR TITLE
fix: security hardening — atomic gifts + sanitize error messages

### DIFF
--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -87,8 +87,11 @@ class AuthService {
       }
     } on AuthException catch (e) {
       _state = _state.copyWith(isLoading: false, error: e.message);
-    } catch (e) {
-      _state = _state.copyWith(isLoading: false, error: e.toString());
+    } catch (_) {
+      _state = _state.copyWith(
+        isLoading: false,
+        error: 'Something went wrong. Please try again.',
+      );
     }
 
     return _state;
@@ -206,8 +209,11 @@ class AuthService {
       }
     } on AuthException catch (e) {
       _state = _state.copyWith(isLoading: false, error: e.message);
-    } catch (e) {
-      _state = _state.copyWith(isLoading: false, error: e.toString());
+    } catch (_) {
+      _state = _state.copyWith(
+        isLoading: false,
+        error: 'Something went wrong. Please try again.',
+      );
     }
 
     return _state;
@@ -243,8 +249,11 @@ class AuthService {
       }
     } on AuthException catch (e) {
       _state = _state.copyWith(isLoading: false, error: e.message);
-    } catch (e) {
-      _state = _state.copyWith(isLoading: false, error: e.toString());
+    } catch (_) {
+      _state = _state.copyWith(
+        isLoading: false,
+        error: 'Something went wrong. Please try again.',
+      );
     }
 
     return _state;


### PR DESCRIPTION
- Replace read-then-write gift operations with atomic RPC call (admin_increment_stat) to prevent race conditions
- Replace generic catch(e) { e.toString() } with safe error messages to prevent leaking Supabase internals to users
- Admin gift dialogs now catch PostgrestException separately for actionable error messages, with safe fallback for others

https://claude.ai/code/session_01Xqx7Xzs6oi2wiEQwoGruwy