### PR TITLE
Fix AuthService test: use non-const initial state

### DIFF
--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -57,7 +57,7 @@ class AuthState {
 /// Profiles are auto-created by a database trigger on sign-up.
 /// All players must have accounts — no guest mode.
 class AuthService {
-  AuthState _state = const AuthState();
+  AuthState _state = AuthState();
 
   AuthState get state => _state;
 


### PR DESCRIPTION
const AuthState() is canonicalized by Dart — all instances share the same object in memory, causing identical() to return true. Removing const gives each AuthService its own heap-allocated state object.

https://claude.ai/code/session_01LxJkZcNq43jShatjPpvUc9