### PR TITLE
Add TTL read cache for leaderboard and friends services

### DIFF
--- a/lib/data/services/ttl_cache.dart
+++ b/lib/data/services/ttl_cache.dart
@@ -1,0 +1,41 @@
+/// Lightweight in-memory TTL cache for reducing redundant Supabase reads.
+///
+/// Each entry expires after [ttl]. Designed for caching leaderboard and
+/// friends-list results where a few seconds of staleness is acceptable.
+class TtlCache<T> {
+  TtlCache(this.ttl);
+
+  final Duration ttl;
+  final _entries = <String, _CacheEntry<T>>{};
+
+  /// Returns the cached value for [key], or `null` if missing/expired.
+  T? get(String key) {
+    final entry = _entries[key];
+    if (entry == null) return null;
+    if (DateTime.now().isAfter(entry.expiry)) {
+      _entries.remove(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  /// Stores [value] under [key] with a fresh TTL.
+  void set(String key, T value) {
+    _entries[key] = _CacheEntry(value, DateTime.now().add(ttl));
+  }
+
+  /// Invalidate a single [key], or all entries if [key] is null.
+  void invalidate([String? key]) {
+    if (key != null) {
+      _entries.remove(key);
+    } else {
+      _entries.clear();
+    }
+  }
+}
+
+class _CacheEntry<T> {
+  _CacheEntry(this.value, this.expiry);
+  final T value;
+  final DateTime expiry;
+}

--- a/lib/data/services/user_preferences_service.dart
+++ b/lib/data/services/user_preferences_service.dart
@@ -10,6 +10,7 @@ import '../models/daily_result.dart';
 import '../models/daily_streak.dart';
 import '../models/pilot_license.dart';
 import '../models/player.dart';
+import 'leaderboard_service.dart';
 
 // ---------------------------------------------------------------------------
 // Offline write queue
@@ -416,6 +417,8 @@ class UserPreferencesService {
 
     try {
       await _client.from('scores').insert(data);
+      // New score is live — stale leaderboard caches must go.
+      LeaderboardService.instance.invalidateCache();
     } catch (e) {
       debugPrint(
         '[UserPreferencesService] saveGameResult failed, queuing for retry: $e',

--- a/supabase/migrations/20260221_performance_indexes.sql
+++ b/supabase/migrations/20260221_performance_indexes.sql
@@ -1,0 +1,19 @@
+-- Performance indexes for high-traffic read paths.
+-- Run in Supabase SQL Editor or via `supabase db push`.
+
+-- 1. Global leaderboard view scans ALL scores with no WHERE clause.
+--    The existing idx_scores_leaderboard leads with (region, ...) which is
+--    useless for the unfiltered global scan. This covers the ORDER BY.
+CREATE INDEX IF NOT EXISTS idx_scores_global_rank
+  ON public.scores (score DESC, time_ms ASC);
+
+-- 2. Daily leaderboard view filters WHERE region = 'daily' AND created_at >= today.
+--    Partial index keeps the B-tree small — only daily rows are indexed.
+CREATE INDEX IF NOT EXISTS idx_scores_daily_rank
+  ON public.scores (created_at, score DESC, time_ms ASC)
+  WHERE region = 'daily';
+
+-- 3. Username lookup for friend search (FriendsService.searchUser).
+--    Also enforces uniqueness at the DB level.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_profiles_username
+  ON public.profiles (username);


### PR DESCRIPTION
Client-side in-memory cache (30s competitive boards, 60s friends/hall-of-fame) eliminates redundant Supabase round-trips on screen open and tab switch. Mutations (score insert, friend add/remove) auto-invalidate the cache.

Also adds missing DB indexes: global score ranking, daily partial index, and unique username index for friend search.

https://claude.ai/code/session_017VbfxQgZhS1Lu2XJA5x3pN