### PR TITLE
fix: disable Vercel auto-deploy on PRs, gate deployment behind CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,32 @@ jobs:
             echo "Site is live and returning 200 OK."
           fi
 
+  # ── Deploy to Vercel (only after CI passes on main) ──
+  deploy-vercel:
+    name: Deploy Vercel
+    needs: [build-web, build-android]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Trigger Vercel production deployment
+        env:
+          VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$VERCEL_DEPLOY_HOOK" ]; then
+            echo "::warning::VERCEL_DEPLOY_HOOK secret not set — skipping Vercel deploy"
+            exit 0
+          fi
+
+          echo "Triggering Vercel production deployment (CI passed)..."
+          HTTP_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$VERCEL_DEPLOY_HOOK")
+
+          if [ "$HTTP_STATUS" -eq 200 ] || [ "$HTTP_STATUS" -eq 201 ]; then
+            echo "Vercel deployment triggered successfully (HTTP ${HTTP_STATUS})"
+          else
+            echo "::error::Vercel deploy hook returned HTTP ${HTTP_STATUS}"
+            exit 1
+          fi
+
   # ── Update App Version (v1.<PR_count>) ──
   update-version:
     name: Update Version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,8 @@
-name: Deploy Vercel (Scheduled)
+name: Deploy Vercel (Scheduled / Manual)
+
+# NOTE: Primary Vercel deployments are triggered by ci.yml after CI passes on main.
+# This workflow is only for scheduled re-deploys and manual triggers.
+# Automatic Git-based Vercel deployments are DISABLED in vercel.json.
 
 on:
   schedule:

--- a/vercel.json
+++ b/vercel.json
@@ -4,9 +4,7 @@
   "outputDirectory": "",
   "framework": null,
   "git": {
-    "deploymentEnabled": {
-      "main": true
-    }
+    "deploymentEnabled": false
   },
   "functions": {
     "api/errors/index.js": {


### PR DESCRIPTION
Vercel's GitHub integration was creating preview deployments for every commit on every PR. The previous `deploymentEnabled: { "main": true }` only controlled production deployments, not preview deployments.

Changes:
- Set `git.deploymentEnabled: false` in vercel.json to disable ALL automatic Git-triggered Vercel deployments (both preview and production)
- Add `deploy-vercel` job to ci.yml that triggers the Vercel deploy hook only after build-web and build-android both pass on main
- Vercel now only deploys on merge to main, after CI passes

https://claude.ai/code/session_01WfHEbZCXeHLTK4rawZU68Y