### PR TITLE
fix: force-add ignored logs file in fetch-errors workflow

### DIFF
--- a/.github/workflows/fetch-errors.yml
+++ b/.github/workflows/fetch-errors.yml
@@ -179,7 +179,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add logs/runtime-errors.jsonl
+          git add -f logs/runtime-errors.jsonl
 
           # Only commit if there are staged changes.
           if git diff --cached --quiet; then


### PR DESCRIPTION
git add fails with exit code 1 when the path is in .gitignore. Use -f flag to override since this is intentional (the workflow manages this file explicitly).

https://claude.ai/code/session_0118oC4Y12HcE459t3v3PPDN