### PR TITLE
Fix type error in fetchBestScoresByMode: cast Map<String, dynamic> to…

### DIFF
--- a/lib/data/services/leaderboard_service.dart
+++ b/lib/data/services/leaderboard_service.dart
@@ -608,8 +608,9 @@ class LeaderboardService {
     final cached = _historyCache.get(cacheKey);
     if (cached != null) {
       return {
-        'daily': cached.isNotEmpty ? cached[0] : null,
-        'training': cached.length > 1 ? cached[1] : null,
+        'daily': cached.isNotEmpty ? Map<String, int>.from(cached[0]) : null,
+        'training':
+            cached.length > 1 ? Map<String, int>.from(cached[1]) : null,
       };
     }
 


### PR DESCRIPTION
… Map<String, int>

The cached list elements are Map<String, dynamic> but the return type expects Map<String, int>?. Use Map<String, int>.from() to cast properly.

https://claude.ai/code/session_01686fPeGWTs4ykv7eKs5rUS