### PR TITLE
Fix friendship invites: add challenge status, friendship levels, H2H …

### DIFF
--- a/lib/data/models/friend.dart
+++ b/lib/data/models/friend.dart
@@ -114,6 +114,46 @@ class HeadToHead {
     return lastGameWon! ? 'Won' : 'Lost';
   }
 
+  /// Friendship level based on total H2H games played.
+  String get friendshipLevel {
+    if (totalChallenges >= 50) return 'Legendary';
+    if (totalChallenges >= 30) return 'Nemesis';
+    if (totalChallenges >= 15) return 'Rival';
+    if (totalChallenges >= 5) return 'Companion';
+    if (totalChallenges >= 1) return 'Acquaintance';
+    return 'New';
+  }
+
+  /// Star count for friendship level (1-5).
+  int get friendshipStars {
+    if (totalChallenges >= 50) return 5;
+    if (totalChallenges >= 30) return 4;
+    if (totalChallenges >= 15) return 3;
+    if (totalChallenges >= 5) return 2;
+    if (totalChallenges >= 1) return 1;
+    return 0;
+  }
+
+  /// Recent trend indicator: 1 = improving, -1 = declining, 0 = stable/neutral.
+  int get recentTrend {
+    if (last10Total == 0) return 0;
+    if (last10Wins > last10Losses) return 1;
+    if (last10Losses > last10Wins) return -1;
+    return 0;
+  }
+
+  /// Trend arrow character.
+  String get trendArrow {
+    switch (recentTrend) {
+      case 1:
+        return '\u25B2'; // ▲
+      case -1:
+        return '\u25BC'; // ▼
+      default:
+        return '\u2014'; // —
+    }
+  }
+
   Map<String, dynamic> toJson() => {
     'friend_id': friendId,
     'friend_name': friendName,

--- a/lib/data/services/challenge_service.dart
+++ b/lib/data/services/challenge_service.dart
@@ -65,6 +65,28 @@ class ChallengeService {
   // Fetch
   // ---------------------------------------------------------------------------
 
+  /// Fetch ALL active challenges (pending + in_progress) involving the current
+  /// user as either challenger or challenged.
+  ///
+  /// Used by the friends screen to show per-friend challenge status
+  /// (your turn, their turn, play, sent, etc.).
+  Future<List<Challenge>> fetchAllActiveChallenges() async {
+    if (_userId == null) return [];
+    try {
+      final data = await _client
+          .from('challenges')
+          .select()
+          .or('challenger_id.eq.$_userId,challenged_id.eq.$_userId')
+          .inFilter('status', ['pending', 'in_progress'])
+          .order('created_at', ascending: false);
+
+      return data.map((row) => _rowToChallenge(row)).toList();
+    } catch (e) {
+      debugPrint('[ChallengeService] fetchAllActiveChallenges failed: $e');
+      return [];
+    }
+  }
+
   /// Fetch incoming pending challenges (where current user is the challenged).
   Future<List<Challenge>> fetchPendingChallenges() async {
     if (_userId == null) return [];


### PR DESCRIPTION
…trends

Bugs fixed:
- In-progress challenges were invisible for the challenged player (only sent challenges were tracked, not received ones)
- No way to resume mid-game challenges from the friends screen
- Challenge status not integrated into friend tiles (separate INCOMING CHALLENGES section was disconnected from friend tiles)
- Sent request tiles showed unclear "Pending" label instead of "Invite Pending"

New features:
- Friendship level system based on H2H game count (New → Acquaintance → Companion → Rival → Nemesis → Legendary) with star badges
- Per-friend challenge status badges: YOUR TURN (tappable), THEIR TURN, PLAY! (tappable), SENT, CHALLENGE (tappable)
- H2H trend indicator (last 10 games with ▲/▼/— arrow)
- Tapping YOUR TURN or PLAY! navigates directly to the game
- Tapping CHALLENGE creates a new challenge (same flow as before)

Implementation:
- Added fetchAllActiveChallenges() to ChallengeService to get all pending + in_progress challenges for both sides (challenger and challenged)
- Added friendshipLevel, friendshipStars, recentTrend, trendArrow getters to HeadToHead model
- Redesigned _FriendTile with integrated level badge, H2H record + trend, and tappable challenge status badge
- Consolidated incoming challenges into friend tile status badges
- Updated _SentRequestTile and _FriendRequestTile with clear "Invite Pending"

https://claude.ai/code/session_01QqNaeG6BmF4jVjWPH3LPfE