### PR TITLE
Fix auth_service_test: use named parameters for signInWithEmail

### DIFF
--- a/test/unit/data/services/auth_service_test.dart
+++ b/test/unit/data/services/auth_service_test.dart
@@ -425,7 +425,7 @@ void main() {
       expect(b.state.isLoading, isFalse);
 
       // Trigger a local validation failure on only one service instance.
-      await a.signInWithEmail('invalid-email', 'password123');
+      await a.signInWithEmail(email: 'invalid-email', password: 'password123');
 
       expect(a.state.error, isNotNull);
       expect(b.state.error, isNull);


### PR DESCRIPTION
The signInWithEmail method uses named parameters ({required String email, required String password}), but the test was calling it with positional arguments, causing a compilation error.

https://claude.ai/code/session_01J5s6hYDxFCL3cgxAFwcYMD