### PR TITLE
fix: correct invite expiry from 30 days to 3 days

### DIFF
--- a/lib/data/services/friends_service.dart
+++ b/lib/data/services/friends_service.dart
@@ -45,7 +45,7 @@ class FriendsService {
         >
       >(const Duration(seconds: 60));
   // Product rule: friend invites (incoming + sent pending) expire after 3 days.
-  static const Duration _inviteExpiry = Duration(days: 30);
+  static const Duration _inviteExpiry = Duration(days: 3);
 
   /// Drop cached friends/pending data. Called automatically after mutations.
   void invalidateCache() {


### PR DESCRIPTION
The comment said "expire after 3 days" but the Duration constant was set to 30 days (typo — extra 0). This caused the expiry test to fail.

https://claude.ai/code/session_01UEP2unmoWzp8DBgLA1R5aL