### PR TITLE
fix: prevent signup crash from null JS error object on web

### DIFF
--- a/lib/core/services/error_service.dart
+++ b/lib/core/services/error_service.dart
@@ -255,6 +255,15 @@ class ErrorService {
     ErrorSeverity severity = ErrorSeverity.error,
     Map<String, String>? context,
   }) {
+    // On Flutter web, JS null/undefined can bypass Dart's non-null type
+    // system. Guard .toString() to avoid a secondary crash.
+    String errorString;
+    try {
+      final dynamic e = error;
+      errorString = e == null ? 'Unknown error (null)' : e.toString() as String;
+    } catch (_) {
+      errorString = 'Error (toString failed)';
+    }
     final captured = CapturedError(
       timestamp: DateTime.now(),
       sessionId: _sessionId,
@@ -262,7 +271,7 @@ class ErrorService {
       platform: _detectPlatform(),
       deviceInfo: _detectDeviceInfo(),
       severity: severity,
-      error: error.toString(),
+      error: errorString,
       stackTrace: stackTrace?.toString(),
       context: context,
     );

--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -170,6 +170,21 @@ class AuthService {
       );
 
       if (response.user != null) {
+        // Supabase returns a "fake" user with empty identities when email
+        // confirmation is enabled and the email is already registered (for
+        // security — to avoid revealing registered emails). Detect this and
+        // show a helpful error instead of a misleading "check your email".
+        final identities = response.user!.identities;
+        if (identities != null && identities.isEmpty) {
+          _state = _state.copyWith(
+            isLoading: false,
+            error:
+                'An account with this email may already exist. '
+                'Try signing in instead, or use a different email.',
+          );
+          return _state;
+        }
+
         // Update the profile row (created by trigger) with username.
         // This may fail if the user hasn't confirmed email yet and RLS
         // blocks unauthenticated writes — that's fine, we'll update on

--- a/lib/features/auth/login_screen.dart
+++ b/lib/features/auth/login_screen.dart
@@ -551,15 +551,24 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       _error = null;
     });
 
-    final result = await _authService.resetPassword(email: email);
+    try {
+      final result = await _authService.resetPassword(email: email);
 
-    if (mounted) {
-      setState(() => _isLoading = false);
+      if (mounted) {
+        setState(() => _isLoading = false);
 
-      if (result.error != null) {
-        setState(() => _error = result.error);
-      } else {
-        setState(() => _mode = _AuthMode.resetEmailSent);
+        if (result.error != null) {
+          setState(() => _error = result.error);
+        } else {
+          setState(() => _mode = _AuthMode.resetEmailSent);
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+          _error = 'Something went wrong. Please try again.';
+        });
       }
     }
   }
@@ -587,28 +596,37 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       _error = null;
     });
 
-    final result = await _authService.signUpWithEmail(
-      email: email,
-      password: password,
-      username: username,
-      displayName: _displayNameController.text.trim().isNotEmpty
-          ? _displayNameController.text.trim()
-          : null,
-    );
+    try {
+      final result = await _authService.signUpWithEmail(
+        email: email,
+        password: password,
+        username: username,
+        displayName: _displayNameController.text.trim().isNotEmpty
+            ? _displayNameController.text.trim()
+            : null,
+      );
 
-    if (mounted) {
-      setState(() => _isLoading = false);
+      if (mounted) {
+        setState(() => _isLoading = false);
 
-      if (result.needsEmailConfirmation) {
-        TextInput.finishAutofillContext();
-        setState(() => _mode = _AuthMode.confirmEmail);
-      } else if (result.isAuthenticated && result.player != null) {
-        TextInput.finishAutofillContext();
-        final notifier = ref.read(accountProvider.notifier);
-        await notifier.loadFromSupabase(result.player!.id);
-        if (mounted) _navigateToHome();
-      } else if (result.error != null) {
-        setState(() => _error = result.error);
+        if (result.needsEmailConfirmation) {
+          TextInput.finishAutofillContext();
+          setState(() => _mode = _AuthMode.confirmEmail);
+        } else if (result.isAuthenticated && result.player != null) {
+          TextInput.finishAutofillContext();
+          final notifier = ref.read(accountProvider.notifier);
+          await notifier.loadFromSupabase(result.player!.id);
+          if (mounted) _navigateToHome();
+        } else if (result.error != null) {
+          setState(() => _error = result.error);
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+          _error = 'Something went wrong. Please try again.';
+        });
       }
     }
   }
@@ -631,21 +649,30 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       _error = null;
     });
 
-    final result = await _authService.signInWithEmail(
-      email: email,
-      password: password,
-    );
+    try {
+      final result = await _authService.signInWithEmail(
+        email: email,
+        password: password,
+      );
 
-    if (mounted) {
-      setState(() => _isLoading = false);
+      if (mounted) {
+        setState(() => _isLoading = false);
 
-      if (result.isAuthenticated && result.player != null) {
-        TextInput.finishAutofillContext();
-        final notifier = ref.read(accountProvider.notifier);
-        await notifier.loadFromSupabase(result.player!.id);
-        if (mounted) _navigateToHome();
-      } else if (result.error != null) {
-        setState(() => _error = result.error);
+        if (result.isAuthenticated && result.player != null) {
+          TextInput.finishAutofillContext();
+          final notifier = ref.read(accountProvider.notifier);
+          await notifier.loadFromSupabase(result.player!.id);
+          if (mounted) _navigateToHome();
+        } else if (result.error != null) {
+          setState(() => _error = result.error);
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+          _error = 'Something went wrong. Please try again.';
+        });
       }
     }
   }

--- a/lib/features/avatar/avatar_compositor.dart
+++ b/lib/features/avatar/avatar_compositor.dart
@@ -221,8 +221,14 @@ class AvatarCompositor {
   // ---------------------------------------------------------------------------
 
   static String? _composeAdventurer(AvatarConfig config) {
-    final skinHex = config.colorOverride('skinColor', '#${config.skinColor.hex}');
-    final hairHex = config.colorOverride('hairColor', '#${config.hairColor.hex}');
+    final skinHex = config.colorOverride(
+      'skinColor',
+      '#${config.skinColor.hex}',
+    );
+    final hairHex = config.colorOverride(
+      'hairColor',
+      '#${config.hairColor.hex}',
+    );
 
     final base = adventurerBase.replaceAll('{{SKIN_COLOR}}', skinHex);
 
@@ -283,8 +289,14 @@ class AvatarCompositor {
   static String? _composeAvataaars(AvatarConfig config) {
     final sh = _stableHash(config);
     final strH = _structuralHash(config);
-    final skinHex = config.colorOverride('skinColor', '#${config.skinColor.hex}');
-    final hairHex = config.colorOverride('hairColor', '#${config.hairColor.hex}');
+    final skinHex = config.colorOverride(
+      'skinColor',
+      '#${config.skinColor.hex}',
+    );
+    final hairHex = config.colorOverride(
+      'hairColor',
+      '#${config.hairColor.hex}',
+    );
 
     final nose = _pick(avataaarsNose, strH, 1);
     final mouth = _pick(avataarsMouth, config.mouth.index, 2);
@@ -337,8 +349,14 @@ class AvatarCompositor {
   // ---------------------------------------------------------------------------
 
   static String? _composeBigEars(AvatarConfig config) {
-    final skinHex = config.colorOverride('skinColor', '#${config.skinColor.hex}');
-    final hairHex = config.colorOverride('hairColor', '#${config.hairColor.hex}');
+    final skinHex = config.colorOverride(
+      'skinColor',
+      '#${config.skinColor.hex}',
+    );
+    final hairHex = config.colorOverride(
+      'hairColor',
+      '#${config.hairColor.hex}',
+    );
     final strH = _structuralHash(config);
 
     final face = _pick(
@@ -433,8 +451,14 @@ class AvatarCompositor {
   static String? _composeLorelei(AvatarConfig config) {
     final sh = _stableHash(config);
     final strH = _structuralHash(config);
-    final skinHex = config.colorOverride('skinColor', '#${config.skinColor.hex}');
-    final hairHex = config.colorOverride('hairColor', '#${config.hairColor.hex}');
+    final skinHex = config.colorOverride(
+      'skinColor',
+      '#${config.skinColor.hex}',
+    );
+    final hairHex = config.colorOverride(
+      'hairColor',
+      '#${config.hairColor.hex}',
+    );
 
     final head = _pick(
       loreleiHead,
@@ -556,8 +580,14 @@ class AvatarCompositor {
 
   static String? _composeMicah(AvatarConfig config) {
     final strH = _structuralHash(config);
-    final skinHex = config.colorOverride('skinColor', '#${config.skinColor.hex}');
-    final hairHex = config.colorOverride('hairColor', '#${config.hairColor.hex}');
+    final skinHex = config.colorOverride(
+      'skinColor',
+      '#${config.skinColor.hex}',
+    );
+    final hairHex = config.colorOverride(
+      'hairColor',
+      '#${config.hairColor.hex}',
+    );
     // Pick a natural eye color that varies with the eyes selection only.
     final eyeColor = config.colorOverride(
       'eyesColor',
@@ -654,8 +684,14 @@ class AvatarCompositor {
   static String? _composePixelArt(AvatarConfig config) {
     final sh = _stableHash(config);
     final strH = _structuralHash(config);
-    final skinHex = config.colorOverride('skinColor', '#${config.skinColor.hex}');
-    final hairHex = config.colorOverride('hairColor', '#${config.hairColor.hex}');
+    final skinHex = config.colorOverride(
+      'skinColor',
+      '#${config.skinColor.hex}',
+    );
+    final hairHex = config.colorOverride(
+      'hairColor',
+      '#${config.hairColor.hex}',
+    );
     final eyeColor = config.colorOverride(
       'eyesColor',
       _hashColor(config.eyes.index * 41, 33),
@@ -843,7 +879,10 @@ class AvatarCompositor {
   static String? _composeOpenPeeps(AvatarConfig config) {
     final sh = _stableHash(config);
     final strH = _structuralHash(config);
-    final skinHex = config.colorOverride('skinColor', '#${config.skinColor.hex}');
+    final skinHex = config.colorOverride(
+      'skinColor',
+      '#${config.skinColor.hex}',
+    );
     final contrastHex = _darkenHex(skinHex, 0.8);
     final clothingColor = config.colorOverride(
       'clothingColor',
@@ -865,9 +904,7 @@ class AvatarCompositor {
         : _pick(openpeepsAccessories, config.glasses.index, 4);
     // Mask variant directly controlled via extras.
     final maskIdx = config.extra('mask');
-    final mask = maskIdx > 0
-        ? _pickDirect(openpeepsMask, maskIdx - 1)
-        : '';
+    final mask = maskIdx > 0 ? _pickDirect(openpeepsMask, maskIdx - 1) : '';
 
     // Open Peeps body base (bust silhouette).
     // Centered under the head at matrix(.99789 0 0 1 156 62).


### PR DESCRIPTION
On Flutter web, JavaScript null/undefined can bypass Dart's non-null type system when exceptions cross the JS-Dart boundary. During signup, if the Supabase JS SDK throws an unusual error, it can reach the global error handlers as null, causing a secondary crash when .toString() is called: "TypeError: null is not an object (evaluating 'e.toString')".

Changes:
- Add _safeErrorString() helper and make _isNonFatalError() null-safe by casting to dynamic before calling .toString() (main.dart)
- Guard ErrorService.reportError() against null error objects on web (error_service.dart)
- Wrap _signUp(), _signIn(), and _resetPassword() in try-catch so uncaught exceptions show a user-friendly message instead of crashing (login_screen.dart)
- Detect duplicate email signups (Supabase returns fake user with empty identities) and show helpful error instead of misleading "check your email" message (auth_service.dart)
- Format fix in avatar_compositor.dart (pre-existing)

https://claude.ai/code/session_01XYsckmnUwEH6qDE4GFVXqD