### PR TITLE
fix: redesign friendship matchmaking — fix RLS, add cancel, passive match detection

### DIFF
--- a/sql/003_fix_matchmaking_rls.sql
+++ b/sql/003_fix_matchmaking_rls.sql
@@ -1,0 +1,40 @@
+-- 003_fix_matchmaking_rls.sql
+-- Fix matchmaking_pool RLS policies for proper cross-user matching and entry cancellation
+--
+-- Fixes:
+-- 1. UPDATE policy: Add explicit WITH CHECK (true) so the matcher can set
+--    matched_at on an opponent's entry without the new row failing the
+--    implicit USING re-check.
+-- 2. DELETE policy: Allow users to delete their own unmatched entries
+--    (cancel matchmaking).
+--
+-- NOTE: Idempotent — safe to re-run.
+
+-- Fix the UPDATE policy: drop the old one and recreate with WITH CHECK.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'matchmaking_pool'
+    AND policyname = 'Users can update own entries on match'
+  ) THEN
+    DROP POLICY "Users can update own entries on match" ON public.matchmaking_pool;
+  END IF;
+
+  CREATE POLICY "Users can update own entries on match"
+    ON public.matchmaking_pool FOR UPDATE
+    USING (auth.uid() = user_id OR matched_at IS NULL)
+    WITH CHECK (true);
+END $$;
+
+-- Add DELETE policy for cancellation.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'matchmaking_pool'
+    AND policyname = 'Users can delete own unmatched entries'
+  ) THEN
+    CREATE POLICY "Users can delete own unmatched entries"
+      ON public.matchmaking_pool FOR DELETE
+      USING (auth.uid() = user_id AND matched_at IS NULL);
+  END IF;
+END $$;


### PR DESCRIPTION
Root causes of matchmaking never working:
1. Challenge INSERT set challenger_id to the opponent, violating RLS policy
   (auth.uid() = challenger_id). Swapped challenger/challenged so the current
   user is always the challenger on INSERT.
2. matchmaking_pool UPDATE policy had no explicit WITH CHECK, so after setting
   matched_at on an opponent's entry, the new row failed the implicit USING
   re-check. Added WITH CHECK (true).

Root cause of pending invites not showing:
3. sendFriendRequest didn't check for existing accepted friendships in the
   reverse direction, causing duplicate rows (phantom "sent requests") and
   UNIQUE constraint failures from _autoFriend after matchmaking.

New features:
- Cancel matchmaking: cancelPoolEntry/cancelAllPoolEntries service methods,
  DELETE RLS policy on matchmaking_pool, cancel buttons in UI
- Passive match detection: checkForExistingMatches() checks if someone else
  already matched your pool entry while you were away
- Two-phase CHECK AGAIN: first detects passive matches, then searches for
  new opponents (previously only searched, missing existing matches)
- Pool entries now show individual cancel (X) buttons
- Waiting/searching states show cancel button

DB migration: sql/003_fix_matchmaking_rls.sql (idempotent, safe to re-run)

https://claude.ai/code/session_01QSRfFp3mzYc47QyjGnVwYa