### PR TITLE
fix: leaderboard avatar, emoji rendering, and pilot card consistency

### DIFF
--- a/lib/data/models/leaderboard_entry.dart
+++ b/lib/data/models/leaderboard_entry.dart
@@ -7,6 +7,7 @@ class LeaderboardEntry {
     required this.time,
     required this.score,
     this.avatarUrl,
+    this.avatarConfigJson,
     this.countryCode,
     this.timestamp,
     this.roundEmojis,
@@ -21,6 +22,11 @@ class LeaderboardEntry {
   final Duration time;
   final int score;
   final String? avatarUrl;
+
+  /// Raw avatar config JSON from `account_state.avatar_config`.
+  /// Used for offline avatar composition when [avatarUrl] is unavailable.
+  final Map<String, dynamic>? avatarConfigJson;
+
   final String? countryCode;
   final DateTime? timestamp;
   final String? roundEmojis;
@@ -31,21 +37,25 @@ class LeaderboardEntry {
   final String? equippedPlaneId;
   final int? level;
 
-  LeaderboardEntry copyWith({int? rank, String? equippedPlaneId}) =>
-      LeaderboardEntry(
-        rank: rank ?? this.rank,
-        playerId: playerId,
-        playerName: playerName,
-        time: time,
-        score: score,
-        avatarUrl: avatarUrl,
-        countryCode: countryCode,
-        timestamp: timestamp,
-        roundEmojis: roundEmojis,
-        roundDetails: roundDetails,
-        equippedPlaneId: equippedPlaneId ?? this.equippedPlaneId,
-        level: level,
-      );
+  LeaderboardEntry copyWith({
+    int? rank,
+    String? equippedPlaneId,
+    Map<String, dynamic>? avatarConfigJson,
+  }) => LeaderboardEntry(
+    rank: rank ?? this.rank,
+    playerId: playerId,
+    playerName: playerName,
+    time: time,
+    score: score,
+    avatarUrl: avatarUrl,
+    avatarConfigJson: avatarConfigJson ?? this.avatarConfigJson,
+    countryCode: countryCode,
+    timestamp: timestamp,
+    roundEmojis: roundEmojis,
+    roundDetails: roundDetails,
+    equippedPlaneId: equippedPlaneId ?? this.equippedPlaneId,
+    level: level,
+  );
 
   Map<String, dynamic> toJson() => {
     'rank': rank,
@@ -54,6 +64,7 @@ class LeaderboardEntry {
     'time_ms': time.inMilliseconds,
     'score': score,
     'avatar_url': avatarUrl,
+    'avatar_config': avatarConfigJson,
     'country_code': countryCode,
     'timestamp': timestamp?.toIso8601String(),
     'round_emojis': roundEmojis,
@@ -70,6 +81,7 @@ class LeaderboardEntry {
         time: Duration(milliseconds: json['time_ms'] as int),
         score: json['score'] as int,
         avatarUrl: json['avatar_url'] as String?,
+        avatarConfigJson: json['avatar_config'] as Map<String, dynamic>?,
         countryCode: json['country_code'] as String?,
         timestamp: json['timestamp'] != null
             ? DateTime.parse(json['timestamp'] as String)


### PR DESCRIPTION
- Avatar: fetch avatar_config from account_state for offline SVG
  composition instead of relying on empty profiles.avatar_url
- Emojis: add fontFamilyFallback (Apple Color Emoji, Segoe UI Emoji,
  Noto Color Emoji) to all emoji Text widgets so rank medals and
  round circles render as coloured glyphs on all platforms
- Pilot card: redesign bottom sheet to use the same credit-card
  layout as LicenseScreen (rarity border, shimmer animation, plane
  preview, stat bars) for visual consistency

https://claude.ai/code/session_01AkS5Si5mp9gajkPbf3j4qs