### PR TITLE
fix: add direct FK constraints from friendships → profiles for PostgREST joins

### DIFF
--- a/lib/data/services/account_management_service.dart
+++ b/lib/data/services/account_management_service.dart
@@ -144,8 +144,8 @@ class AccountManagementService {
           .from('friendships')
           .select(
             'status, created_at, '
-            'requester:profiles!friendships_requester_id_fkey(username, display_name), '
-            'addressee:profiles!friendships_addressee_id_fkey(username, display_name)',
+            'requester:profiles!fk_friendships_requester_profiles(username, display_name), '
+            'addressee:profiles!fk_friendships_addressee_profiles(username, display_name)',
           )
           .eq('status', 'accepted')
           .or('requester_id.eq.$userId,addressee_id.eq.$userId');

--- a/lib/data/services/friends_service.dart
+++ b/lib/data/services/friends_service.dart
@@ -268,8 +268,8 @@ class FriendsService {
           .from('friendships')
           .select(
             'id, requester_id, addressee_id, status, created_at, '
-            'requester:profiles!friendships_requester_id_fkey(id, username, display_name, avatar_url), '
-            'addressee:profiles!friendships_addressee_id_fkey(id, username, display_name, avatar_url)',
+            'requester:profiles!fk_friendships_requester_profiles(id, username, display_name, avatar_url), '
+            'addressee:profiles!fk_friendships_addressee_profiles(id, username, display_name, avatar_url)',
           )
           .eq('status', 'accepted')
           .or('requester_id.eq.$_userId,addressee_id.eq.$_userId');
@@ -322,7 +322,7 @@ class FriendsService {
           .from('friendships')
           .select(
             'id, requester_id, created_at, '
-            'requester:profiles!friendships_requester_id_fkey(id, username, display_name, avatar_url)',
+            'requester:profiles!fk_friendships_requester_profiles(id, username, display_name, avatar_url)',
           )
           .eq('addressee_id', _userId!)
           .eq('status', 'pending');
@@ -395,7 +395,7 @@ class FriendsService {
           .from('friendships')
           .select(
             'id, addressee_id, created_at, '
-            'addressee:profiles!friendships_addressee_id_fkey(id, username, display_name, avatar_url)',
+            'addressee:profiles!fk_friendships_addressee_profiles(id, username, display_name, avatar_url)',
           )
           .eq('requester_id', _userId!)
           .eq('status', 'pending');

--- a/sql/004_fix_friendships_fk.sql
+++ b/sql/004_fix_friendships_fk.sql
@@ -1,0 +1,39 @@
+-- 004_fix_friendships_fk.sql
+-- Add direct FK constraints from friendships → profiles so PostgREST can
+-- resolve embedded resource joins (e.g. profiles!fk_friendships_requester_profiles)
+-- without needing to traverse through auth.users.
+--
+-- This mirrors the existing pattern used for the scores table (fk_scores_profiles).
+--
+-- Without these FKs, fetchFriends / fetchPendingRequests / fetchSentRequests all
+-- fail silently because PostgREST cannot join profiles through an auth.users FK.
+--
+-- NOTE: Idempotent — safe to re-run.
+
+-- FK: friendships.requester_id → profiles.id
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'fk_friendships_requester_profiles'
+      AND table_schema = 'public'
+      AND table_name = 'friendships'
+  ) THEN
+    ALTER TABLE public.friendships
+      ADD CONSTRAINT fk_friendships_requester_profiles
+      FOREIGN KEY (requester_id) REFERENCES public.profiles(id);
+  END IF;
+END $$;
+
+-- FK: friendships.addressee_id → profiles.id
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'fk_friendships_addressee_profiles'
+      AND table_schema = 'public'
+      AND table_name = 'friendships'
+  ) THEN
+    ALTER TABLE public.friendships
+      ADD CONSTRAINT fk_friendships_addressee_profiles
+      FOREIGN KEY (addressee_id) REFERENCES public.profiles(id);
+  END IF;
+END $$;

--- a/supabase/rebuild.sql
+++ b/supabase/rebuild.sql
@@ -413,6 +413,35 @@ DO $$ BEGIN
   END IF;
 END $$;
 
+-- Direct FKs from friendships → profiles so PostgREST can resolve embedded
+-- resource joins (e.g. profiles!fk_friendships_requester_profiles) without
+-- needing to traverse through auth.users.  Same pattern as fk_scores_profiles.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'fk_friendships_requester_profiles'
+      AND table_schema = 'public'
+      AND table_name = 'friendships'
+  ) THEN
+    ALTER TABLE public.friendships
+      ADD CONSTRAINT fk_friendships_requester_profiles
+      FOREIGN KEY (requester_id) REFERENCES public.profiles(id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'fk_friendships_addressee_profiles'
+      AND table_schema = 'public'
+      AND table_name = 'friendships'
+  ) THEN
+    ALTER TABLE public.friendships
+      ADD CONSTRAINT fk_friendships_addressee_profiles
+      FOREIGN KEY (addressee_id) REFERENCES public.profiles(id);
+  END IF;
+END $$;
+
 
 -- ---------------------------------------------------------------------------
 -- 7. CHALLENGES — H2H dogfight matches


### PR DESCRIPTION
The friends system never worked because friendships.requester_id and
addressee_id had FK constraints pointing to auth.users(id), but the Dart
code used PostgREST embedded joins targeting profiles. PostgREST cannot
resolve profiles through an auth.users FK, so fetchFriends(),
fetchPendingRequests(), and fetchSentRequests() all silently failed,
returning empty lists.

Fix: add direct FK constraints (fk_friendships_requester_profiles and
fk_friendships_addressee_profiles) from friendships → profiles, matching
the existing pattern used for scores (fk_scores_profiles). Update all 6
FK hint strings across friends_service.dart and
account_management_service.dart.

https://claude.ai/code/session_01NR5SUe1anMkPP5ndTxxpXj