### PR TITLE
feat: score-based challenge results with hint emojis and clue labels

### DIFF
--- a/lib/data/models/friend.dart
+++ b/lib/data/models/friend.dart
@@ -189,6 +189,12 @@ class RoundOutcome {
     required this.roundNumber,
     required this.yourTimeMs,
     required this.theirTimeMs,
+    this.yourScore,
+    this.theirScore,
+    this.yourHintsUsed,
+    this.theirHintsUsed,
+    this.countryName,
+    this.clueType,
   });
 
   final int roundNumber;
@@ -197,14 +203,53 @@ class RoundOutcome {
   final int? yourTimeMs;
   final int? theirTimeMs;
 
+  /// Round score (0-10000). Null for legacy rounds that only tracked time.
+  final int? yourScore;
+  final int? theirScore;
+
+  /// Hint tiers used (0-4). Null for legacy rounds.
+  final int? yourHintsUsed;
+  final int? theirHintsUsed;
+
+  /// Country name (e.g. "Brazil") and clue type (e.g. "borders").
+  final String? countryName;
+  final String? clueType;
+
   bool get isComplete => yourTimeMs != null && theirTimeMs != null;
 
   /// True if you won this round, false if they won, null if draw or incomplete.
+  /// Prefers score comparison; falls back to time.
   bool? get youWon {
     if (!isComplete) return null;
+    // Score-based (higher wins).
+    if (yourScore != null && theirScore != null) {
+      if (yourScore! > theirScore!) return true;
+      if (theirScore! > yourScore!) return false;
+      return null; // draw
+    }
+    // Fallback: time-based (lower wins).
     if (yourTimeMs! < theirTimeMs!) return true;
     if (theirTimeMs! < yourTimeMs!) return false;
     return null; // draw
+  }
+
+  /// Hint-usage emoji (matches daily challenge style).
+  String get yourHintEmoji => _hintEmoji(yourHintsUsed);
+  String get theirHintEmoji => _hintEmoji(theirHintsUsed);
+
+  static String _hintEmoji(int? hints) {
+    if (hints == null) return '';
+    if (hints == 0) return '\u{1F7E2}'; // green
+    if (hints <= 2) return '\u{1F7E1}'; // yellow
+    if (hints <= 4) return '\u{1F7E0}'; // orange
+    return '\u{1F534}'; // red
+  }
+
+  /// Formatted clue label e.g. "Brazil (borders)".
+  String get clueLabel {
+    if (countryName == null) return '';
+    if (clueType != null) return '$countryName ($clueType)';
+    return countryName!;
   }
 }
 

--- a/lib/data/services/friends_service.dart
+++ b/lib/data/services/friends_service.dart
@@ -605,10 +605,21 @@ class FriendsService {
           final yourMs = isChallenger ? challengerMs : challengedMs;
           final theirMs = isChallenger ? challengedMs : challengerMs;
 
+          final challengerScore = round['challenger_score'] as int?;
+          final challengedScore = round['challenged_score'] as int?;
+          final challengerHints = round['challenger_hints_used'] as int?;
+          final challengedHints = round['challenged_hints_used'] as int?;
+
           final outcome = RoundOutcome(
             roundNumber: round['round_number'] as int? ?? 0,
             yourTimeMs: yourMs,
             theirTimeMs: theirMs,
+            yourScore: isChallenger ? challengerScore : challengedScore,
+            theirScore: isChallenger ? challengedScore : challengerScore,
+            yourHintsUsed: isChallenger ? challengerHints : challengedHints,
+            theirHintsUsed: isChallenger ? challengedHints : challengerHints,
+            countryName: round['country_name'] as String?,
+            clueType: round['clue_type'] as String?,
           );
           rounds.add(outcome);
 

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -624,6 +624,10 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
             challengeId: widget.challengeId!,
             roundIndex: _currentRound - 1,
             timeMs: _elapsed.inMilliseconds,
+            score: _session?.score,
+            hintsUsed: _hintTier,
+            clueTypeName: _session?.clue.type.name,
+            countryName: _session?.targetName,
           )
           .catchError((Object e) {
             _log.warning('challenge', 'Failed to submit round result: $e');
@@ -757,6 +761,10 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
             challengeId: widget.challengeId!,
             roundIndex: _currentRound - 1,
             timeMs: _elapsed.inMilliseconds,
+            score: _session?.score,
+            hintsUsed: _hintTier,
+            clueTypeName: _session?.clue.type.name,
+            countryName: _session?.targetName,
           )
           .then(
             (_) => ChallengeService.instance.tryCompleteChallenge(
@@ -1241,6 +1249,10 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
         challengeId: widget.challengeId!,
         roundIndex: _currentRound - 1,
         timeMs: _elapsed.inMilliseconds,
+        score: 0,
+        hintsUsed: _hintTier,
+        clueTypeName: _session?.clue.type.name,
+        countryName: _session?.targetName,
       );
     }
 


### PR DESCRIPTION
Replace time-based round comparison with score-based scoring across the entire challenge pipeline. Scores (0-10000) properly account for hint usage and fuel, giving fairer comparisons than raw time.

- ChallengeRound: add score, hintsUsed, countryName fields; winner getter prefers score comparison with time fallback for legacy data
- ChallengeService: submitRoundResult accepts score, hintsUsed, clueTypeName, countryName; persists clue metadata once per round
- PlayScreen: all 3 submit call sites pass score, hints, clue info
- RoundOutcome (friend.dart): add score/hint/clue fields with emoji getters matching daily challenge style (green/yellow/orange/red)
- Friends screen: round rows show score|emoji|clue(type)|emoji|score
- Challenge result screen: redesign round breakdown with same layout, total score row with legacy time fallback

https://claude.ai/code/session_016bdgHHcNTaxEbV6rquLWqZ