### PR TITLE
fix: add missing countryCode and rawScore to _advanceRound constructor

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -605,9 +605,11 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
       _roundResults.add(
         _RoundResult(
           countryName: _session!.targetName,
+          countryCode: _session!.targetCountry.code,
           clueType: _session!.clue.type,
           elapsed: _elapsed,
           score: _session!.score,
+          rawScore: _session!.rawScore,
           hintsUsed: _hintTier,
           completed: true,
         ),


### PR DESCRIPTION
The _advanceRound() call site at line 606 was missed when adding the required countryCode and rawScore fields to _RoundResult. All 4 constructor call sites are now updated.

https://claude.ai/code/session_01G32jV2jDTL4C5ipsgubqHr