### PR TITLE
fix: resolve 8 failing unit tests from compilation and logic errors

### DIFF
--- a/lib/data/services/app_config_service.dart
+++ b/lib/data/services/app_config_service.dart
@@ -89,15 +89,14 @@ class AppConfigService {
     _cacheTime = null;
   }
 
-  /// Parse a version string like 'v1.2.3' into a comparable number.
-  /// Returns major * 10000 + minor * 100 + patch, 0 for unparseable.
+  /// Parse a version string like 'v1.228' into a comparable number.
+  /// Returns major * 10000 + minor, 0 for unparseable.
   static int _versionToNumber(String version) {
     final cleaned = version.replaceAll(RegExp(r'[^0-9.]'), '');
     final parts = cleaned.split('.');
     final major = int.tryParse(parts.isNotEmpty ? parts[0] : '0') ?? 0;
     final minor = int.tryParse(parts.length > 1 ? parts[1] : '0') ?? 0;
-    final patch = int.tryParse(parts.length > 2 ? parts[2] : '0') ?? 0;
-    return major * 10000 + minor * 100 + patch;
+    return major * 10000 + minor;
   }
 
   /// Exposed for unit tests only — wraps [_versionToNumber].

--- a/lib/data/services/leaderboard_service.dart
+++ b/lib/data/services/leaderboard_service.dart
@@ -37,6 +37,9 @@ class LeaderboardService {
     const Duration(seconds: 30),
   );
   final _rankCache = TtlCache<LeaderboardEntry?>(const Duration(seconds: 30));
+  final _bestScoresCache = TtlCache<Map<String, Map<String, int>?>>(
+    const Duration(seconds: 30),
+  );
 
   /// Drop every cached result. Call after the current user submits a score.
   void invalidateCache() {
@@ -46,6 +49,7 @@ class LeaderboardService {
     _playerCountCache.invalidate();
     _historyCache.invalidate();
     _rankCache.invalidate();
+    _bestScoresCache.invalidate();
   }
 
   // ---------------------------------------------------------------------------
@@ -274,11 +278,12 @@ class LeaderboardService {
 
       final response = await _client
           .from('scores')
-          .select('*', const FetchOptions(count: CountOption.exact, head: true))
+          .select('*')
           .eq('region', 'daily')
-          .gte('created_at', startOfDay.toIso8601String());
+          .gte('created_at', startOfDay.toIso8601String())
+          .count(CountOption.exact);
 
-      final count = response.count ?? 0;
+      final count = response.count;
       _playerCountCache.set(cacheKey, count);
       return count;
     } catch (e) {
@@ -691,8 +696,8 @@ class LeaderboardService {
     String userId,
   ) async {
     final cacheKey = 'best_modes_$userId';
-    final cached = _historyCache.get(cacheKey);
-    if (cached != null) return Map<String, Map<String, int>?>.from(cached);
+    final cached = _bestScoresCache.get(cacheKey);
+    if (cached != null) return cached;
 
     try {
       // Best daily score.
@@ -732,7 +737,12 @@ class LeaderboardService {
         };
       }
 
-      return {'daily': daily, 'training': training};
+      final result = <String, Map<String, int>?>{
+        'daily': daily,
+        'training': training,
+      };
+      _bestScoresCache.set(cacheKey, result);
+      return result;
     } catch (e) {
       debugPrint('[LeaderboardService] fetchBestScoresByMode failed: $e');
       return {'daily': null, 'training': null};


### PR DESCRIPTION
- leaderboard_service: replace removed FetchOptions with .count() chain
- leaderboard_service: fix fetchBestScoresByMode cache type mismatch (_historyCache stores List but method returns Map; add _bestScoresCache)
- app_config_service: fix _versionToNumber formula overflow (minor*100 overflows into major range for large minor versions; use major*10000+minor instead)

https://claude.ai/code/session_01EheNRnErU82GWSM7VRpddP