### PR TITLE
fix: realistic day/night cycle, organic clouds, night toggle

### DIFF
--- a/lib/core/services/game_settings.dart
+++ b/lib/core/services/game_settings.dart
@@ -85,6 +85,7 @@ class GameSettings extends ChangeNotifier {
       turnSensitivity: _turnSensitivity,
       invertControls: _invertControls,
       enableNight: _enableNight,
+      enableClouds: _enableClouds,
       mapStyle: _mapStyle.name,
       englishLabels: _englishLabels,
       difficulty: _difficulty.name,
@@ -108,6 +109,7 @@ class GameSettings extends ChangeNotifier {
     required double turnSensitivity,
     required bool invertControls,
     required bool enableNight,
+    required bool enableClouds,
     required bool englishLabels,
     required MapStyle mapStyle,
     required GameDifficulty difficulty,
@@ -122,6 +124,7 @@ class GameSettings extends ChangeNotifier {
       this.turnSensitivity = turnSensitivity;
       this.invertControls = invertControls;
       this.enableNight = enableNight;
+      this.enableClouds = enableClouds;
       this.englishLabels = englishLabels;
       this.mapStyle = mapStyle;
       this.difficulty = difficulty;
@@ -147,6 +150,7 @@ class GameSettings extends ChangeNotifier {
         'turn_sensitivity': _turnSensitivity,
         'invert_controls': _invertControls,
         'enable_night': _enableNight,
+        'enable_clouds': _enableClouds,
         'map_style': _mapStyle.name,
         'english_labels': _englishLabels,
         'difficulty': _difficulty.name,
@@ -180,6 +184,7 @@ class GameSettings extends ChangeNotifier {
           (data['turn_sensitivity'] as num?)?.toDouble() ?? _turnSensitivity;
       _invertControls = data['invert_controls'] as bool? ?? _invertControls;
       _enableNight = data['enable_night'] as bool? ?? _enableNight;
+      _enableClouds = data['enable_clouds'] as bool? ?? _enableClouds;
       final mapStyleName = data['map_style'] as String?;
       if (mapStyleName != null) {
         _mapStyle = MapStyle.values.firstWhere(
@@ -263,6 +268,16 @@ class GameSettings extends ChangeNotifier {
 
   set enableNight(bool value) {
     _enableNight = value;
+    notifyListeners();
+  }
+
+  /// Whether procedural clouds are rendered on the globe.
+  bool _enableClouds = true;
+
+  bool get enableClouds => _enableClouds;
+
+  set enableClouds(bool value) {
+    _enableClouds = value;
     notifyListeners();
   }
 

--- a/lib/core/widgets/settings_sheet.dart
+++ b/lib/core/widgets/settings_sheet.dart
@@ -164,6 +164,16 @@ class _SettingsSheetContentState extends State<_SettingsSheetContent> {
       ),
       const Divider(color: FlitColors.cardBorder, height: 1),
       _SettingsToggle(
+        label: 'Clouds',
+        icon: Icons.cloud_outlined,
+        value: GameSettings.instance.enableClouds,
+        onChanged: (value) {
+          GameSettings.instance.enableClouds = value;
+          setState(() {});
+        },
+      ),
+      const Divider(color: FlitColors.cardBorder, height: 1),
+      _SettingsToggle(
         label: 'English Labels',
         icon: Icons.translate,
         value: GameSettings.instance.englishLabels,

--- a/lib/data/providers/account_provider.dart
+++ b/lib/data/providers/account_provider.dart
@@ -417,6 +417,7 @@ class AccountNotifier extends StateNotifier<AccountState> {
         turnSensitivity: snapshot.turnSensitivity,
         invertControls: snapshot.invertControls,
         enableNight: snapshot.enableNight,
+        enableClouds: snapshot.enableClouds,
         englishLabels: snapshot.englishLabels,
         mapStyle: MapStyle.values.firstWhere(
           (s) => s.name == snapshot.mapStyle,

--- a/lib/data/services/user_preferences_service.dart
+++ b/lib/data/services/user_preferences_service.dart
@@ -374,6 +374,7 @@ class UserPreferencesService {
     required double turnSensitivity,
     required bool invertControls,
     required bool enableNight,
+    required bool enableClouds,
     required String mapStyle,
     required bool englishLabels,
     required String difficulty,
@@ -390,6 +391,7 @@ class UserPreferencesService {
       'turn_sensitivity': turnSensitivity,
       'invert_controls': invertControls,
       'enable_night': enableNight,
+      'enable_clouds': enableClouds,
       'map_style': mapStyle,
       'english_labels': englishLabels,
       'difficulty': difficulty,
@@ -1152,6 +1154,10 @@ class UserPreferencesSnapshot {
 
   bool get enableNight {
     return settings?['enable_night'] as bool? ?? true;
+  }
+
+  bool get enableClouds {
+    return settings?['enable_clouds'] as bool? ?? true;
   }
 
   String get mapStyle {

--- a/lib/game/rendering/globe_renderer.dart
+++ b/lib/game/rendering/globe_renderer.dart
@@ -38,14 +38,13 @@ class GlobeRenderer extends Component with HasGameRef<FlitGame> {
   /// Elapsed time in seconds, fed to the shader for animations.
   double _time = 0.0;
 
-  /// Current sun direction (normalized), rotated slowly for day/night cycle.
+  /// Current sun direction (normalized), computed from real UTC time.
   double _sunDirX = 1.0;
   double _sunDirY = 0.3;
   double _sunDirZ = 0.0;
 
-  /// Rate at which the sun rotates around the globe (radians per second).
-  /// One full day/night cycle every ~120 seconds of game time.
-  static const double _sunRotationRate = 2 * pi / 120.0;
+  /// Earth's axial tilt in radians (23.44 degrees).
+  static const double _axialTilt = 23.44 * pi / 180.0;
 
   /// Cached screen size from the last render pass.
   Size _lastSize = Size.zero;
@@ -101,11 +100,26 @@ class GlobeRenderer extends Component with HasGameRef<FlitGame> {
       altitudeFraction: plane.continuousAltitude,
     );
 
-    // -- Rotate the sun direction for day/night cycle --
-    final sunAngle = _time * _sunRotationRate;
-    _sunDirX = cos(sunAngle);
-    _sunDirY = 0.3; // slight tilt above the equatorial plane
-    _sunDirZ = sin(sunAngle);
+    // -- Compute sun direction from real UTC time --
+    // The subsolar point (where the sun is directly overhead) moves with
+    // Earth's rotation. At UTC 12:00 it sits over the Prime Meridian (0°).
+    final now = DateTime.now().toUtc();
+    final utcHours = now.hour + now.minute / 60.0 + now.second / 3600.0;
+
+    // Subsolar longitude (radians). At UTC 12:00 → 0° (Prime Meridian).
+    final subSolarLonRad = pi - utcHours * pi / 12.0;
+
+    // Day of year (1-based) for solar declination.
+    final dayOfYear = now.difference(DateTime.utc(now.year, 1, 1)).inDays + 1;
+
+    // Solar declination — Earth's axial tilt creates seasonal variation.
+    // ≈ +23.44° at June solstice, −23.44° at December solstice.
+    final declinationRad = -_axialTilt * cos(2 * pi / 365.0 * (dayOfYear + 10));
+
+    // Convert subsolar point to shader world-space direction.
+    _sunDirX = cos(declinationRad) * cos(subSolarLonRad);
+    _sunDirY = sin(declinationRad);
+    _sunDirZ = cos(declinationRad) * sin(subSolarLonRad);
 
     // Normalize the sun direction vector.
     final sunLen = sqrt(

--- a/lib/game/rendering/shader_manager.dart
+++ b/lib/game/rendering/shader_manager.dart
@@ -30,6 +30,7 @@ final _log = GameLog.instance;
 /// Index 14  : uFOV (field of view radians)
 /// Index 15  : uEnableShading (0.0 = raw texture, 1.0 = full shading)
 /// Index 16  : uEnableNight   (0.0 = always day,  1.0 = day/night cycle)
+/// Index 17  : uEnableClouds  (0.0 = no clouds,   1.0 = clouds on)
 /// ```
 /// Plus 4 image samplers: uSatellite, uHeightmap, uShoreDist, uCityLights
 class ShaderManager {
@@ -183,7 +184,10 @@ class ShaderManager {
     // All textures are optional - the game will run with black fallback
     // textures if any fail to load.
     final textureResults = await Future.wait<Map<String, dynamic>>([
-      _loadImage('assets/textures/blue_marble.png')
+      _loadImageWithFallback(
+            'assets/textures/blue_marble.jpg',
+            'assets/textures/blue_marble.png',
+          )
           .then((img) => <String, dynamic>{'name': 'satellite', 'image': img})
           .catchError(
             (e, st) => <String, dynamic>{
@@ -212,7 +216,10 @@ class ShaderManager {
               'stack': st,
             },
           ),
-      _loadImage('assets/textures/city_lights.png')
+      _loadImageWithFallback(
+            'assets/textures/city_lights.jpg',
+            'assets/textures/city_lights.png',
+          )
           .then((img) => <String, dynamic>{'name': 'city_lights', 'image': img})
           .catchError(
             (e, st) => <String, dynamic>{
@@ -410,6 +417,9 @@ class ShaderManager {
       // uEnableNight (0.0 = always day, 1.0 = day/night cycle)
       s.setFloat(16, GameSettings.instance.enableNight ? 1.0 : 0.0);
 
+      // uEnableClouds (0.0 = no clouds, 1.0 = clouds on)
+      s.setFloat(17, GameSettings.instance.enableClouds ? 1.0 : 0.0);
+
       // -- Image samplers (indices 0-3) --
       // Always bind all 4 samplers to prevent shader errors on platforms that
       // require all declared samplers to be bound. Each uses an appropriate
@@ -513,6 +523,23 @@ class ShaderManager {
         '- Unsupported image format\n'
         '- iOS Safari storage quota exceeded',
       );
+    }
+  }
+
+  /// Try loading an image from [primaryPath], falling back to [fallbackPath]
+  /// if the primary fails (e.g., .jpg vs .png).
+  Future<ui.Image> _loadImageWithFallback(
+    String primaryPath,
+    String fallbackPath,
+  ) async {
+    try {
+      return await _loadImage(primaryPath);
+    } catch (_) {
+      _log.debug(
+        'shader',
+        'Primary texture $primaryPath failed, trying fallback $fallbackPath',
+      );
+      return _loadImage(fallbackPath);
     }
   }
 

--- a/shaders/globe.frag
+++ b/shaders/globe.frag
@@ -29,6 +29,7 @@ uniform float uCloudRadius;  // Index 13:   cloud shell radius (> globe)
 uniform float uFOV;          // Index 14:   field of view (radians)
 uniform float uEnableShading; // Index 15:  0.0 = raw texture, 1.0 = full shading
 uniform float uEnableNight;   // Index 16:  0.0 = always day,  1.0 = day/night cycle
+uniform float uEnableClouds;  // Index 17:  0.0 = no clouds,   1.0 = clouds on
 
 // ---------------------------------------------------------------------------
 // Samplers — maximum 4 per shader pass
@@ -81,13 +82,25 @@ const float ATMO_THICKNESS     = 0.05;
 const float RIM_INTENSITY      = 0.35;
 const float HAZE_STRENGTH      = 0.15;
 
-// Clouds
-const float CLOUD_COVERAGE     = 0.42;
-const float CLOUD_SOFTNESS     = 0.25;
-const float CLOUD_DRIFT_SPEED  = 0.008;
+// Clouds — multi-layer organic
+const float CLOUD_DRIFT_SPEED  = 0.006;
 const float CLOUD_BRIGHTNESS   = 1.0;
-const float CLOUD_SHADOW_STR   = 0.15;
+const float CLOUD_SHADOW_STR   = 0.08;
 const int   FBM_OCTAVES        = 4;
+
+// Cirrus (high, thin, wispy streaks)
+const float CIRRUS_THRESHOLD   = 0.48;
+const float CIRRUS_OPACITY     = 0.15;
+
+// Cumulus / stratus (mid-level, puffy patches)
+const float CUMULUS_COVERAGE    = 0.56;
+const float CUMULUS_SOFTNESS    = 0.12;
+const float CUMULUS_OPACITY     = 0.45;
+
+// Cumulonimbus (isolated dramatic towers)
+const float CB_THRESHOLD        = 0.72;
+const float CB_SOFTNESS         = 0.08;
+const float CB_OPACITY          = 0.65;
 
 // Day/night cycle
 const float TERMINATOR_SOFT    = -0.1;
@@ -488,7 +501,10 @@ void main() {
     bool isOcean = heightVal < SEA_LEVEL;
 
     // ----- Diffuse lighting ------------------------------------------------
-    float NdotL    = dot(normal, uSunDir);
+    // When night is disabled, force full lighting everywhere (no dark side).
+    float NdotL    = uEnableNight > 0.5
+        ? dot(normal, uSunDir)
+        : 1.0;
     float diffuse  = max(NdotL, 0.0);
 
     // =======================================================================
@@ -643,10 +659,10 @@ void main() {
     }
 
     // =======================================================================
-    // V5: CLOUD LAYER
+    // V5: CLOUD LAYER — multi-layer organic clouds
     // =======================================================================
 
-    {
+    if (uEnableClouds > 0.5) {
         // Intersect the cloud shell
         float tC = tCloud;
         // If tCloud is behind the globe surface, skip
@@ -655,45 +671,92 @@ void main() {
             vec3 cloudNormal = normalize(cloudHit - GLOBE_ORIGIN);
             vec2 cloudUV = equirectangularUV(cloudHit);
 
-            // Animate cloud drift
-            vec3 cloudSamplePos = cloudHit * 3.0;
+            // ── Weather system: large-scale pattern creating clear/cloudy zones ──
+            // Slowly drifting 2D noise makes some regions clear, others cloudy
+            float weatherNoise = noise(cloudUV * 2.5 + uTime * 0.0008);
+            float weatherPattern = smoothstep(0.32, 0.68, weatherNoise);
+
+            // ── Base FBM density (shared by cumulus + cumulonimbus) ──
+            vec3 cloudSamplePos = cloudHit * 3.5;
             cloudSamplePos.x += uTime * CLOUD_DRIFT_SPEED;
             cloudSamplePos.z += uTime * CLOUD_DRIFT_SPEED * 0.7;
+            float baseDensity = fbm(cloudSamplePos);
 
-            // FBM for cloud density
-            float density = fbm(cloudSamplePos);
+            // ── Cirrus: thin wispy streaks (cheap 2D noise, stretched) ──
+            vec2 cirrusUV = cloudUV * 18.0;
+            cirrusUV.x *= 3.0; // stretch horizontally for streaky appearance
+            cirrusUV += uTime * vec2(0.004, 0.001);
+            float cirrusDensity = noise(cirrusUV);
+            float cirrusMask = smoothstep(CIRRUS_THRESHOLD, CIRRUS_THRESHOLD + 0.18, cirrusDensity)
+                             * weatherPattern;
 
-            // Coverage threshold with smooth edges
-            float cloudMask = smoothstep(CLOUD_COVERAGE - CLOUD_SOFTNESS, CLOUD_COVERAGE + CLOUD_SOFTNESS, density);
+            // ── Cumulus / stratus: puffy patches ──
+            float cumulusMask = smoothstep(
+                CUMULUS_COVERAGE - CUMULUS_SOFTNESS,
+                CUMULUS_COVERAGE + CUMULUS_SOFTNESS,
+                baseDensity
+            ) * weatherPattern;
 
-            if (cloudMask > 0.01) {
-                // Cloud lighting from sun direction (bright tops, dark bottoms)
-                float cloudNdotL = dot(cloudNormal, uSunDir);
+            // ── Cumulonimbus: isolated dramatic towers (sparse) ──
+            float cbMask = smoothstep(
+                CB_THRESHOLD - CB_SOFTNESS,
+                CB_THRESHOLD + CB_SOFTNESS,
+                baseDensity
+            ) * step(0.55, weatherPattern);
+
+            // ── Combine layers by weighted opacity ──
+            float totalAlpha = 1.0 - (1.0 - cirrusMask * CIRRUS_OPACITY)
+                                   * (1.0 - cumulusMask * CUMULUS_OPACITY)
+                                   * (1.0 - cbMask * CB_OPACITY);
+
+            if (totalAlpha > 0.01) {
+                // Cloud lighting from sun direction
+                float cloudNdotL = uEnableNight > 0.5
+                    ? dot(cloudNormal, uSunDir)
+                    : 1.0;
                 float cloudLight = smoothstep(-0.3, 1.0, cloudNdotL);
-                float cloudDayFactor = smoothstep(TERMINATOR_SOFT, TERMINATOR_HARD, cloudNdotL);
+                float cloudDayFactor = uEnableNight > 0.5
+                    ? smoothstep(TERMINATOR_SOFT, TERMINATOR_HARD, cloudNdotL)
+                    : 1.0;
 
                 // Cloud colour: bright white in sun, grey in shadow
-                vec3 cloudColor = mix(vec3(0.25, 0.27, 0.35), vec3(CLOUD_BRIGHTNESS), cloudLight);
+                vec3 cloudColor = mix(vec3(0.30, 0.32, 0.40), vec3(CLOUD_BRIGHTNESS), cloudLight);
 
-                // Night-side clouds are faintly visible (moonlight)
+                // Night-side clouds: faintly visible (moonlight)
                 cloudColor = mix(vec3(0.03, 0.04, 0.06), cloudColor, max(cloudDayFactor, 0.05));
 
                 // Terminator warm glow on clouds
-                float cloudTerminator = smoothstep(-0.15, 0.0, cloudNdotL) * smoothstep(0.25, 0.05, cloudNdotL);
+                float cloudTerminator = smoothstep(-0.15, 0.0, cloudNdotL)
+                                      * smoothstep(0.25, 0.05, cloudNdotL);
                 cloudColor += TERMINATOR_WARM * cloudTerminator * 0.3;
 
-                // Blend cloud on top of surface
-                surfaceColor = mix(surfaceColor, cloudColor, cloudMask * 0.9);
+                // Cumulonimbus are brighter (towering white tops)
+                vec3 cbColor = mix(cloudColor, vec3(CLOUD_BRIGHTNESS) * cloudLight, 0.3);
+                // Weighted blend of cloud types
+                float cbWeight = cbMask * CB_OPACITY;
+                float cuWeight = cumulusMask * CUMULUS_OPACITY;
+                float ciWeight = cirrusMask * CIRRUS_OPACITY;
+                float totalWeight = cbWeight + cuWeight + ciWeight + 0.001;
+                vec3 blendedCloud = (cbColor * cbWeight + cloudColor * cuWeight + cloudColor * ciWeight)
+                                  / totalWeight;
+
+                // Composite cloud over surface
+                surfaceColor = mix(surfaceColor, blendedCloud, totalAlpha);
             }
         }
 
-        // Cloud shadows on terrain (approximate — darken terrain where clouds would be overhead)
-        // Uses the globe normal as an approximation of "looking up" to the cloud layer
-        vec3 shadowSamplePos = hitPoint * 3.0;
+        // Cloud shadows on terrain (approximate)
+        vec3 shadowSamplePos = hitPoint * 3.5;
         shadowSamplePos.x += uTime * CLOUD_DRIFT_SPEED;
         shadowSamplePos.z += uTime * CLOUD_DRIFT_SPEED * 0.7;
         float shadowDensity = fbm(shadowSamplePos);
-        float shadowMask = smoothstep(CLOUD_COVERAGE - CLOUD_SOFTNESS, CLOUD_COVERAGE + CLOUD_SOFTNESS, shadowDensity);
+        float shadowWeather = noise(equirectangularUV(hitPoint) * 2.5 + uTime * 0.0008);
+        float shadowPattern = smoothstep(0.32, 0.68, shadowWeather);
+        float shadowMask = smoothstep(
+            CUMULUS_COVERAGE - CUMULUS_SOFTNESS,
+            CUMULUS_COVERAGE + CUMULUS_SOFTNESS,
+            shadowDensity
+        ) * shadowPattern;
         surfaceColor *= 1.0 - shadowMask * CLOUD_SHADOW_STR * dayFactor;
     }
 

--- a/test/unit/data/services/user_preferences_service_test.dart
+++ b/test/unit/data/services/user_preferences_service_test.dart
@@ -642,6 +642,10 @@ void main() {
       expect(snapshotNoSettings.enableNight, isTrue);
     });
 
+    test('enableClouds defaults to true when no settings', () {
+      expect(snapshotNoSettings.enableClouds, isTrue);
+    });
+
     test('mapStyle defaults to "standard" when no settings', () {
       expect(snapshotNoSettings.mapStyle, equals('standard'));
     });
@@ -669,6 +673,7 @@ void main() {
           'turn_sensitivity': 0.8,
           'invert_controls': true,
           'enable_night': false,
+          'enable_clouds': false,
           'map_style': 'satellite',
           'english_labels': false,
           'difficulty': 'hard',
@@ -681,6 +686,7 @@ void main() {
       expect(snapshot.turnSensitivity, closeTo(0.8, 0.001));
       expect(snapshot.invertControls, isTrue);
       expect(snapshot.enableNight, isFalse);
+      expect(snapshot.enableClouds, isFalse);
       expect(snapshot.mapStyle, equals('satellite'));
       expect(snapshot.englishLabels, isFalse);
       expect(snapshot.difficulty, equals('hard'));


### PR DESCRIPTION
- Sun position now computed from real UTC time with solar declination, so the terminator matches actual Earth day/night boundaries
- enableNight toggle now forces full lighting when off (previously only disabled terminator effects but still had dark diffuse side)
- Replaced uniform FBM cloud layer with 3-layer organic system: cirrus (thin wispy streaks), cumulus (puffy patches), and cumulonimbus (isolated dramatic towers), all modulated by a weather pattern that creates natural clear/cloudy zones
- Added enableClouds setting with toggle in Display settings
- Shader manager now prefers JPG textures (blue_marble.jpg, city_lights.jpg) with PNG fallback
- Added uEnableClouds uniform at shader index 17
- Cloud coverage reduced from ~50% opaque to ~20-30% translucent

https://claude.ai/code/session_01D7oLrWxZwYksAKjcjCs1Tt