### PR TITLE
fix: admin maintenance bypass, error telemetry, game load resilience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,11 +129,17 @@ jobs:
         run: test -f shaders/globe.frag && echo "globe.frag OK"
 
       - name: Build web release
+        env:
+          VERCEL_ERRORS_API_KEY: ${{ secrets.VERCEL_ERRORS_API_KEY }}
         run: |
           set -o pipefail
+          DART_DEFINES=""
+          if [ -n "$VERCEL_ERRORS_API_KEY" ]; then
+            DART_DEFINES="--dart-define=VERCEL_ERRORS_API_KEY=$VERCEL_ERRORS_API_KEY"
+          fi
           for attempt in 1 2; do
             echo "Build web attempt ${attempt}/2"
-            if flutter build web --release --dart2js-optimization=O2 --base-href "/flit/" 2>&1 | tee flutter-build.log; then
+            if flutter build web --release --dart2js-optimization=O2 --base-href "/flit/" $DART_DEFINES 2>&1 | tee flutter-build.log; then
               break
             fi
             if [ "$attempt" -eq 2 ]; then
@@ -204,7 +210,14 @@ jobs:
         run: flutter pub get
 
       - name: Build APK
-        run: flutter build apk --release
+        env:
+          VERCEL_ERRORS_API_KEY: ${{ secrets.VERCEL_ERRORS_API_KEY }}
+        run: |
+          DART_DEFINES=""
+          if [ -n "$VERCEL_ERRORS_API_KEY" ]; then
+            DART_DEFINES="--dart-define=VERCEL_ERRORS_API_KEY=$VERCEL_ERRORS_API_KEY"
+          fi
+          flutter build apk --release $DART_DEFINES
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4

--- a/lib/core/services/app_version.dart
+++ b/lib/core/services/app_version.dart
@@ -1,4 +1,0 @@
-/// Single source of truth for the application version string.
-///
-/// Import this wherever the app version is needed to avoid duplication.
-const String kAppVersion = 'v1.252';

--- a/lib/core/services/error_service.dart
+++ b/lib/core/services/error_service.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 
-import 'app_version.dart';
+import '../app_version.dart';
 
 /// Severity levels for reported errors.
 enum ErrorSeverity {
@@ -130,8 +130,8 @@ class ErrorService {
   late final String _sessionId;
 
   /// Application version reported with every error payload.
-  /// Sourced from the single-source-of-truth in [kAppVersion].
-  static const String appVersion = kAppVersion;
+  /// Sourced from the canonical [appVersion] in `core/app_version.dart`.
+  static String get errorAppVersion => appVersion;
 
   // ---------------------------------------------------------------------------
   // Queue

--- a/lib/core/widgets/report_bug_button.dart
+++ b/lib/core/widgets/report_bug_button.dart
@@ -246,7 +246,7 @@ class ReportBugButton extends StatelessWidget {
         'recentErrors': recentErrorsSummary,
         'platform': platform,
         'deviceInfo': deviceInfo,
-        'appVersion': ErrorService.appVersion,
+        'appVersion': ErrorService.errorAppVersion,
       },
     );
   }

--- a/lib/data/services/app_config_service.dart
+++ b/lib/data/services/app_config_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/app_version.dart';
+import '../../core/config/admin_config.dart';
 import '../models/app_remote_config.dart';
 
 /// Fetches and caches the remote app configuration.
@@ -43,10 +44,13 @@ class AppConfigService {
   }
 
   /// Check if the current app version is compatible.
+  ///
+  /// Admins (by email bootstrap) bypass maintenance mode so they can
+  /// access the admin panel and toggle it off.
   Future<AppCompatibility> checkCompatibility() async {
     final config = await fetchConfig();
 
-    if (config.maintenanceMode) {
+    if (config.maintenanceMode && !AdminConfig.isCurrentUserAdmin) {
       return AppCompatibility.maintenance;
     }
 

--- a/lib/data/services/matchmaking_service.dart
+++ b/lib/data/services/matchmaking_service.dart
@@ -51,7 +51,7 @@ class MatchmakingService {
   /// Current gameplay version — tied to the app version from ErrorService.
   /// When mechanics change (scoring, flight speed, clues), bump this to
   /// invalidate stale pool entries.
-  String get _gameplayVersion => ErrorService.appVersion;
+  String get _gameplayVersion => ErrorService.errorAppVersion;
 
   // ---------------------------------------------------------------------------
   // ELO estimation

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -249,7 +249,17 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
       // spinning forever. The timer is cancelled in _onGameReady or dispose.
       _gameReadyTimeout = Timer(const Duration(seconds: 20), () {
         if (mounted && !_gameReady && _error == null) {
-          _log.error('screen', 'Game ready timeout (20s)');
+          const msg = 'Game engine failed to start (20s timeout)';
+          _log.error('screen', msg);
+          ErrorService.instance.reportCritical(
+            msg,
+            StackTrace.current,
+            context: {
+              'screen': 'PlayScreen',
+              'action': 'gameReadyTimeout',
+              'region': widget.region.name,
+            },
+          );
           setState(() {
             _error =
                 'Game engine failed to start.\n\nPlease go back and try '
@@ -318,6 +328,9 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
     setState(() {
       _gameReady = true;
     });
+    // Start background music (fire-and-forget; safe if disabled or on web
+    // before user gesture).
+    AudioManager.instance.startMusic();
     // Start the game session on the next frame so it is decoupled from the
     // Flame onLoad() future – any exception here won't break the engine.
     SchedulerBinding.instance.addPostFrameCallback((_) {

--- a/lib/game/rendering/shader_manager.dart
+++ b/lib/game/rendering/shader_manager.dart
@@ -484,16 +484,37 @@ class ShaderManager {
     }
   }
 
+  /// Per-texture load timeout to prevent stalled network/decode from
+  /// hanging the entire shader initialization (and thus the game).
+  static const _textureTimeout = Duration(seconds: 15);
+
   /// Load an image from the asset bundle, decode it, and return the first
-  /// frame as a [ui.Image].
+  /// frame as a [ui.Image]. Times out after [_textureTimeout] to avoid
+  /// hanging the game if a network request or decode stalls.
   Future<ui.Image> _loadImage(String assetPath) async {
     _log.debug('shader', 'Loading texture: $assetPath');
     try {
-      final data = await rootBundle.load(assetPath);
+      final data = await rootBundle
+          .load(assetPath)
+          .timeout(
+            _textureTimeout,
+            onTimeout: () => throw TimeoutException(
+              'Texture load timed out: $assetPath',
+              _textureTimeout,
+            ),
+          );
       final sizeBytes = data.lengthInBytes;
       _log.debug('shader', 'Texture loaded: $assetPath ($sizeBytes bytes)');
 
-      final codec = await ui.instantiateImageCodec(data.buffer.asUint8List());
+      final codec = await ui
+          .instantiateImageCodec(data.buffer.asUint8List())
+          .timeout(
+            _textureTimeout,
+            onTimeout: () => throw TimeoutException(
+              'Texture decode timed out: $assetPath',
+              _textureTimeout,
+            ),
+          );
       final frame = await codec.getNextFrame();
       final image = frame.image;
 
@@ -521,7 +542,8 @@ class ShaderManager {
         '- Network failure (web platform)\n'
         '- Corrupted image file\n'
         '- Unsupported image format\n'
-        '- iOS Safari storage quota exceeded',
+        '- iOS Safari storage quota exceeded\n'
+        '- Load/decode timed out',
       );
     }
   }


### PR DESCRIPTION
1. Maintenance mode admin bypass: admins (by email bootstrap) now skip the maintenance gate so they can access the admin panel to toggle it off — previously all users including owners were locked out.

2. Error telemetry fixes:
   - Delete stale lib/core/services/app_version.dart (v1.252) that ErrorService was importing instead of the canonical v1.263
   - ErrorService now imports from lib/core/app_version.dart (the CI auto-updated source of truth)
   - CI now injects VERCEL_ERRORS_API_KEY via --dart-define for both web and APK builds so errors are authenticated to the Vercel endpoint (was silently failing with empty API key)

3. Game load resilience:
   - Add 15s per-texture load timeout in ShaderManager._loadImage() to prevent stalled network/decode from hanging Future.wait indefinitely (the most likely cause of "game load crash" on slow connections)
   - Game ready 20s timeout now reports to ErrorService as critical (previously only showed on-screen, never sent to Vercel)

4. Start background music when game engine is ready (was never called).

https://claude.ai/code/session_01By71S8oeGRsuFzY2UgRppM