### PR TITLE
fix: maintenance banner, detailed logging, game crash resilience

### DIFF
--- a/lib/features/auth/login_screen.dart
+++ b/lib/features/auth/login_screen.dart
@@ -50,11 +50,16 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
     // Check app config gates (maintenance mode, force update) before anything.
     try {
+      // Fetch config first so we can pass the maintenance message to the screen.
+      final config = await AppConfigService.instance.fetchConfig();
       final compat = await AppConfigService.instance.checkCompatibility();
       if (!mounted) return;
       if (compat == AppCompatibility.maintenance) {
         Navigator.of(context).pushReplacement(
-          MaterialPageRoute<void>(builder: (_) => const MaintenanceScreen()),
+          MaterialPageRoute<void>(
+            builder: (_) =>
+                MaintenanceScreen(message: config.maintenanceMessage),
+          ),
         );
         return;
       }

--- a/lib/features/auth/maintenance_screen.dart
+++ b/lib/features/auth/maintenance_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../data/models/app_remote_config.dart';
 import '../../data/services/app_config_service.dart';
+import 'login_screen.dart';
 
 /// Full-screen display when the server is in maintenance mode.
 class MaintenanceScreen extends StatefulWidget {
@@ -24,8 +25,12 @@ class _MaintenanceScreenState extends State<MaintenanceScreen> {
       if (!mounted) return;
       if (compat == AppCompatibility.ok ||
           compat == AppCompatibility.updateRecommended) {
-        // Maintenance is over — pop back to let the auth flow continue.
-        Navigator.of(context).pop();
+        // Maintenance is over — navigate back to login to restart the
+        // auth flow. (LoginScreen was replaced via pushReplacement, so
+        // pop() would crash with an empty navigator stack.)
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute<void>(builder: (_) => const LoginScreen()),
+        );
       } else {
         setState(() => _checking = false);
       }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -7,6 +7,7 @@ import '../../core/app_version.dart';
 import '../../data/providers/account_provider.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../data/models/challenge.dart';
+import '../../data/services/app_config_service.dart';
 import '../../data/services/challenge_service.dart';
 import '../../data/services/feature_flag_service.dart';
 import '../../data/services/friends_service.dart';
@@ -41,6 +42,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   bool _matchmakingEnabled = true;
   bool _dailyScrambleEnabled = true;
 
+  /// Whether the server is currently in maintenance mode. Admins bypass the
+  /// gate but this banner warns them it's still on.
+  bool _maintenanceMode = false;
+  String? _maintenanceMessage;
+
   @override
   void initState() {
     super.initState();
@@ -49,6 +55,20 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       duration: const Duration(seconds: 20),
     )..repeat();
     _loadFeatureFlags();
+    _checkMaintenanceMode();
+  }
+
+  Future<void> _checkMaintenanceMode() async {
+    try {
+      final config = await AppConfigService.instance.fetchConfig();
+      if (!mounted) return;
+      setState(() {
+        _maintenanceMode = config.maintenanceMode;
+        _maintenanceMessage = config.maintenanceMessage;
+      });
+    } catch (_) {
+      // Network failure — assume not in maintenance.
+    }
   }
 
   Future<void> _loadFeatureFlags() async {
@@ -85,10 +105,56 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         // Animated map background
         _AnimatedMapBackground(animation: _animController),
 
+        // Maintenance mode admin banner — red alert at the very top so the
+        // admin knows maintenance is active (they bypassed the gate).
+        if (_maintenanceMode && ref.watch(accountProvider).isAdmin)
+          Positioned(
+            top: MediaQuery.of(context).padding.top,
+            left: 0,
+            right: 0,
+            child: Material(
+              color: FlitColors.error,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.warning_amber_rounded,
+                      color: Colors.white,
+                      size: 18,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        _maintenanceMessage != null &&
+                                _maintenanceMessage!.isNotEmpty
+                            ? 'MAINTENANCE ON: $_maintenanceMessage'
+                            : 'MAINTENANCE MODE IS ON — players are locked out',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+
         // Announcement banner — floats at the top of the safe area above the
         // menu column, but below the globe so it feels part of the HUD layer.
         Positioned(
-          top: MediaQuery.of(context).padding.top + 12,
+          top:
+              MediaQuery.of(context).padding.top +
+              12 +
+              (_maintenanceMode && ref.watch(accountProvider).isAdmin ? 36 : 0),
           left: 16,
           right: 16,
           child: const AnnouncementBanner(),

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -217,8 +217,8 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
   @override
   void initState() {
     super.initState();
-    _sessionSeedRandom = Random(widget.dailySeed);
     try {
+      _sessionSeedRandom = Random(widget.dailySeed);
       _log.info(
         'screen',
         'PlayScreen.initState',
@@ -1530,9 +1530,12 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
                     'region': widget.region.name,
                   },
                 );
-                // Schedule state update so the error-only build path takes
-                // over on the next frame, completely removing the GameWidget.
-                SchedulerBinding.instance.addPostFrameCallback((_) {
+                // Use Future.microtask instead of addPostFrameCallback — it
+                // fires before the next frame and doesn't depend on the
+                // scheduler state. addPostFrameCallback can be skipped if the
+                // widget unmounts between now and the next frame, leaving the
+                // user on a permanent black screen.
+                Future.microtask(() {
                   if (mounted && _error == null) {
                     setState(() {
                       _error = 'Game engine failed to load.\n\nError: $err';

--- a/lib/features/play/region_select_screen.dart
+++ b/lib/features/play/region_select_screen.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/services/error_service.dart';
 import '../../core/services/game_settings.dart';
 import '../../core/theme/flit_colors.dart';
+import '../../core/utils/game_log.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/map/region.dart';
 import 'play_screen.dart';
+
+final _log = GameLog.instance;
 
 /// Screen for selecting which region to play.
 class RegionSelectScreen extends ConsumerWidget {
@@ -27,6 +31,59 @@ class RegionSelectScreen extends ConsumerWidget {
         return 2000; // Level 7
       case GameRegion.ireland:
         return 5000; // Level 10
+    }
+  }
+
+  /// Read cosmetic/account state and launch PlayScreen for [region].
+  ///
+  /// Wrapped in try/catch so a corrupt provider state doesn't silently
+  /// kill the navigation (the exception was previously lost in Flutter's
+  /// gesture error handler with no visible feedback).
+  void _launchPlay(BuildContext context, WidgetRef ref, GameRegion region) {
+    try {
+      final planeId = ref.read(equippedPlaneIdProvider);
+      final plane = CosmeticCatalog.getById(planeId);
+      final account = ref.read(accountProvider);
+      final companion = account.avatar.companion;
+      final fuelBoost = ref.read(accountProvider.notifier).fuelBoostMultiplier;
+      final license = account.license;
+      final contrailId = ref.read(accountProvider).equippedContrailId;
+      final contrail = CosmeticCatalog.getById(contrailId);
+      final contrailPrimary = contrail?.colorScheme?['primary'];
+      final contrailSecondary = contrail?.colorScheme?['secondary'];
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute<void>(
+          builder: (context) => PlayScreen(
+            region: region,
+            planeColorScheme: plane?.colorScheme,
+            planeWingSpan: plane?.wingSpan,
+            equippedPlaneId: planeId,
+            companionType: companion,
+            fuelBoostMultiplier: fuelBoost,
+            clueChance: license.clueChance,
+            preferredClueType: license.preferredClueType,
+            planeHandling: plane?.handling ?? 1.0,
+            planeSpeed: plane?.speed ?? 1.0,
+            planeFuelEfficiency: plane?.fuelEfficiency ?? 1.0,
+            contrailPrimaryColor: contrailPrimary != null
+                ? Color(contrailPrimary)
+                : null,
+            contrailSecondaryColor: contrailSecondary != null
+                ? Color(contrailSecondary)
+                : null,
+          ),
+        ),
+      );
+    } catch (e, st) {
+      _log.error('screen', 'Failed to launch play', error: e, stackTrace: st);
+      ErrorService.instance.reportCritical(
+        e,
+        st,
+        context: {'screen': 'RegionSelectScreen', 'region': region.name},
+      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Failed to start game: $e')));
     }
   }
 
@@ -108,50 +165,7 @@ class RegionSelectScreen extends ConsumerWidget {
                 if (isAdmin) {
                   // Admin: full existing behaviour.
                   tapHandler = isUnlocked
-                      ? () {
-                          final planeId = ref.read(equippedPlaneIdProvider);
-                          final plane = CosmeticCatalog.getById(planeId);
-                          final account = ref.read(accountProvider);
-                          final companion = account.avatar.companion;
-                          final fuelBoost = ref
-                              .read(accountProvider.notifier)
-                              .fuelBoostMultiplier;
-                          final license = account.license;
-                          final contrailId = ref
-                              .read(accountProvider)
-                              .equippedContrailId;
-                          final contrail = CosmeticCatalog.getById(contrailId);
-                          final contrailPrimary =
-                              contrail?.colorScheme?['primary'];
-                          final contrailSecondary =
-                              contrail?.colorScheme?['secondary'];
-                          Navigator.of(context).pushReplacement(
-                            MaterialPageRoute<void>(
-                              builder: (context) => PlayScreen(
-                                region: region,
-                                planeColorScheme: plane?.colorScheme,
-                                planeWingSpan: plane?.wingSpan,
-                                equippedPlaneId: planeId,
-                                companionType: companion,
-                                fuelBoostMultiplier: fuelBoost,
-
-                                clueChance: license.clueChance,
-                                preferredClueType: license.preferredClueType,
-                                planeHandling: plane?.handling ?? 1.0,
-                                planeSpeed: plane?.speed ?? 1.0,
-                                planeFuelEfficiency:
-                                    plane?.fuelEfficiency ?? 1.0,
-                                contrailPrimaryColor: contrailPrimary != null
-                                    ? Color(contrailPrimary)
-                                    : null,
-                                contrailSecondaryColor:
-                                    contrailSecondary != null
-                                    ? Color(contrailSecondary)
-                                    : null,
-                              ),
-                            ),
-                          );
-                        }
+                      ? () => _launchPlay(context, ref, region)
                       : null;
                   buyHandler = (!isUnlocked && canAfford)
                       ? () => _showUnlockDialog(context, ref, region, cost)
@@ -159,50 +173,7 @@ class RegionSelectScreen extends ConsumerWidget {
                 } else if (isWorld) {
                   // Regular user, World region: normal play flow (always unlocked).
                   tapHandler = isUnlocked
-                      ? () {
-                          final planeId = ref.read(equippedPlaneIdProvider);
-                          final plane = CosmeticCatalog.getById(planeId);
-                          final account = ref.read(accountProvider);
-                          final companion = account.avatar.companion;
-                          final fuelBoost = ref
-                              .read(accountProvider.notifier)
-                              .fuelBoostMultiplier;
-                          final license = account.license;
-                          final contrailId = ref
-                              .read(accountProvider)
-                              .equippedContrailId;
-                          final contrail = CosmeticCatalog.getById(contrailId);
-                          final contrailPrimary =
-                              contrail?.colorScheme?['primary'];
-                          final contrailSecondary =
-                              contrail?.colorScheme?['secondary'];
-                          Navigator.of(context).pushReplacement(
-                            MaterialPageRoute<void>(
-                              builder: (context) => PlayScreen(
-                                region: region,
-                                planeColorScheme: plane?.colorScheme,
-                                planeWingSpan: plane?.wingSpan,
-                                equippedPlaneId: planeId,
-                                companionType: companion,
-                                fuelBoostMultiplier: fuelBoost,
-
-                                clueChance: license.clueChance,
-                                preferredClueType: license.preferredClueType,
-                                planeHandling: plane?.handling ?? 1.0,
-                                planeSpeed: plane?.speed ?? 1.0,
-                                planeFuelEfficiency:
-                                    plane?.fuelEfficiency ?? 1.0,
-                                contrailPrimaryColor: contrailPrimary != null
-                                    ? Color(contrailPrimary)
-                                    : null,
-                                contrailSecondaryColor:
-                                    contrailSecondary != null
-                                    ? Color(contrailSecondary)
-                                    : null,
-                              ),
-                            ),
-                          );
-                        }
+                      ? () => _launchPlay(context, ref, region)
                       : null;
                   // World is always unlocked so buyHandler stays null.
                 } else {

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -736,7 +736,11 @@ class FlitGame extends FlameGame
         st,
         context: {'source': 'FlitGame', 'action': 'onLoad'},
       );
-      rethrow;
+      // Surface the error to PlayScreen via the onError callback instead of
+      // rethrowing. Flame's errorBuilder path is unreliable — the scheduled
+      // setState can be skipped if the widget unmounts before the next frame,
+      // resulting in a permanent black screen with no error shown.
+      onError?.call(e, st);
     }
   }
 

--- a/lib/game/rendering/shader_manager.dart
+++ b/lib/game/rendering/shader_manager.dart
@@ -80,9 +80,16 @@ class ShaderManager {
   /// Load the fragment shader program and all texture images.
   ///
   /// Safe to call multiple times; subsequent calls are no-ops if already
-  /// initialized or currently loading.
+  /// initialized or currently loading. If a previous attempt left [_loading]
+  /// stuck true (e.g. the widget was disposed mid-init), the flag is reset
+  /// so this attempt can proceed.
   Future<void> initialize() async {
-    if (_initialized || _loading) return;
+    if (_initialized) return;
+    if (_loading) {
+      // Previous init may have stalled — reset and retry.
+      _log.warning('shader', 'ShaderManager._loading stuck true, resetting');
+      _loading = false;
+    }
     _loading = true;
 
     _log.info('shader', 'ShaderManager.initialize() starting');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -60,26 +60,37 @@ String? _fatalError;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  _log.info('app', 'Flit starting up');
 
   // Load cached settings immediately (before Supabase, which may be slow).
   // This ensures the user sees their real settings on the first frame even
   // when the network is unavailable or the Supabase response is delayed.
+  _log.info('app', 'Loading cached settings...');
   await GameSettings.instance.loadFromLocal();
+  _log.info('app', 'Settings loaded');
 
   // Initialize Supabase (auth session auto-restores from local storage).
+  _log.info('app', 'Initializing Supabase...');
   await Supabase.initialize(
     url: SupabaseConfig.url,
     anonKey: SupabaseConfig.anonKey,
   );
+  _log.info('app', 'Supabase initialized');
 
   // Initialize the error telemetry service (V0).
   final errorService = ErrorService.instance;
+  final apiKey = const String.fromEnvironment('VERCEL_ERRORS_API_KEY');
   errorService.initialize(
     apiEndpoint: const String.fromEnvironment(
       'ERROR_ENDPOINT',
       defaultValue: 'https://flit-olive.vercel.app/api/errors',
     ),
-    apiKey: const String.fromEnvironment('VERCEL_ERRORS_API_KEY'),
+    apiKey: apiKey,
+  );
+  _log.info(
+    'app',
+    'ErrorService initialized',
+    data: {'hasApiKey': apiKey.isNotEmpty},
   );
 
   // Register the cross-platform HTTP sender so flush() can POST errors.
@@ -89,7 +100,9 @@ Future<void> main() async {
   Timer.periodic(_flushInterval, (_) => errorService.flush());
 
   // Initialize audio system (fire-and-forget; errors handled internally).
+  _log.info('app', 'Initializing audio...');
   AudioManager.instance.initialize();
+  _log.info('audio', 'AudioManager initialized');
 
   // Register beforeunload flush for web — last-chance safety net for iOS
   // Safari PWA kills where AppLifecycleState.hidden never fires.
@@ -100,7 +113,7 @@ Future<void> main() async {
     ]);
   });
 
-  _log.info('app', 'Flit starting up');
+  _log.info('app', 'Startup init complete, launching UI');
 
   // ── NUCLEAR ERROR BOUNDARY ──
   // Override ErrorWidget.builder so that ANY widget build failure shows a


### PR DESCRIPTION
1. Admin maintenance banner: red banner at top of HomeScreen when maintenance mode is active — shows the maintenance message so admins know players are locked out and what message they see.

2. Maintenance message propagation: LoginScreen now passes the maintenanceMessage from AppRemoteConfig to MaintenanceScreen (was previously creating `const MaintenanceScreen()` without it). Also fixed MaintenanceScreen._retry() pop crash — it used pop() but the login screen was replaced via pushReplacement, so there was nothing to pop back to. Now uses pushReplacement to LoginScreen.

3. Detailed startup logging: main.dart now logs each init step (settings, Supabase, ErrorService, audio) with timing context. Also logs whether the API key was injected so we know if telemetry will work before the first error occurs.

4. Game crash resilience (5 fixes): a) Moved _sessionSeedRandom init inside try/catch in PlayScreen.initState b) Replaced rethrow in FlitGame.onLoad catch with onError callback — Flame's errorBuilder path is unreliable (setState can be skipped if widget unmounts before next frame, causing permanent black screen) c) GameWidget.errorBuilder now uses Future.microtask instead of addPostFrameCallback — fires sooner and more reliably d) Wrapped RegionSelectScreen tap handlers in try/catch — provider reads (accountProvider, equippedPlaneIdProvider) were unguarded and exceptions were silently lost in Flutter's gesture error handler e) ShaderManager.initialize() now resets stuck _loading flag from abandoned previous init attempts instead of returning early

https://claude.ai/code/session_01By71S8oeGRsuFzY2UgRppM