### PR TITLE
fix: revert ShaderManager _loading reset (caused race condition crash)

### DIFF
--- a/lib/game/rendering/shader_manager.dart
+++ b/lib/game/rendering/shader_manager.dart
@@ -80,16 +80,9 @@ class ShaderManager {
   /// Load the fragment shader program and all texture images.
   ///
   /// Safe to call multiple times; subsequent calls are no-ops if already
-  /// initialized or currently loading. If a previous attempt left [_loading]
-  /// stuck true (e.g. the widget was disposed mid-init), the flag is reset
-  /// so this attempt can proceed.
+  /// initialized or currently loading.
   Future<void> initialize() async {
-    if (_initialized) return;
-    if (_loading) {
-      // Previous init may have stalled — reset and retry.
-      _log.warning('shader', 'ShaderManager._loading stuck true, resetting');
-      _loading = false;
-    }
+    if (_initialized || _loading) return;
     _loading = true;
 
     _log.info('shader', 'ShaderManager.initialize() starting');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -100,9 +100,9 @@ Future<void> main() async {
   Timer.periodic(_flushInterval, (_) => errorService.flush());
 
   // Initialize audio system (fire-and-forget; errors handled internally).
+  // AudioManager logs its own 'AudioManager initialized' when done.
   _log.info('app', 'Initializing audio...');
   AudioManager.instance.initialize();
-  _log.info('audio', 'AudioManager initialized');
 
   // Register beforeunload flush for web — last-chance safety net for iOS
   // Safari PWA kills where AppLifecycleState.hidden never fires.


### PR DESCRIPTION
My previous change removed the concurrent-call guard from ShaderManager.initialize() — if called twice (e.g. widget unmounts and remounts during navigation), both calls would run simultaneously, causing a double-init crash. Reverted to the original safe pattern: `if (_initialized || _loading) return;`

The _loading flag is already properly reset in all error paths (lines 114, 178, 346) so it cannot get permanently stuck.

Also removed duplicate "AudioManager initialized" log — AudioManager already logs internally when init completes.

https://claude.ai/code/session_01By71S8oeGRsuFzY2UgRppM