### PR TITLE
feat: cloud settings sliders, fix cloud toggle, fix audio, hide high-…

### DIFF
--- a/lib/core/services/audio_manager.dart
+++ b/lib/core/services/audio_manager.dart
@@ -76,6 +76,11 @@ class AudioManager {
       _failedAssets.clear();
       // Restart background music if it was previously playing.
       startMusic();
+      // Restart engine if we were in-game when audio was toggled off.
+      if (_lastPlaneId != null) {
+        _currentEngine = null; // Force re-start
+        startEngine(_lastPlaneId!);
+      }
     }
   }
 
@@ -93,11 +98,12 @@ class AudioManager {
   /// Currently active engine type (null = none playing).
   EngineType? _currentEngine;
 
-  /// Base volume for the engine (before turn modulation).
-  static const double _engineBaseVolume = 0.12;
+  /// Last plane ID passed to [startEngine], used to restart the engine
+  /// when audio is re-enabled mid-game.
+  String? _lastPlaneId;
 
-  /// Maximum additional volume added during full turn.
-  static const double _engineTurnBoost = 0.08;
+  /// Constant engine rumble volume (no turn modulation — just a steady hum).
+  static const double _engineBaseVolume = 0.06;
 
   /// Default background music volume.
   static const double _defaultMusicVolume = 0.25;
@@ -323,6 +329,7 @@ class AudioManager {
   /// Automatically selects the correct engine sound based on [planeId].
   /// If an engine is already playing for a different type, crossfades.
   Future<void> startEngine(String planeId) async {
+    _lastPlaneId = planeId;
     if (!_enabled) return;
 
     final type = engineTypeForPlane(planeId);
@@ -352,21 +359,19 @@ class AudioManager {
   /// Stop the engine loop.
   Future<void> stopEngine() async {
     _currentEngine = null;
+    _lastPlaneId = null;
     await _enginePlayer.stop();
   }
 
-  /// Update engine volume based on turn intensity.
+  /// Update engine volume (constant low rumble).
   ///
   /// Call this every frame from the game update loop.
-  /// [turnAmount] should be the absolute value of the turn direction (0..1).
+  /// [turnAmount] is accepted for API compatibility but ignored — the engine
+  /// plays at a constant low volume for an unobtrusive ambient hum.
   Future<void> updateEngineVolume(double turnAmount) async {
     if (!_enabled || _currentEngine == null) return;
 
-    final volume =
-        ((_engineBaseVolume +
-                    _engineTurnBoost * turnAmount.abs().clamp(0.0, 1.0)) *
-                _effectsVolume)
-            .clamp(0.0, 1.0);
+    final volume = (_engineBaseVolume * _effectsVolume).clamp(0.0, 1.0);
 
     try {
       await _enginePlayer.setVolume(volume);

--- a/lib/core/services/game_settings.dart
+++ b/lib/core/services/game_settings.dart
@@ -86,6 +86,8 @@ class GameSettings extends ChangeNotifier {
       invertControls: _invertControls,
       enableNight: _enableNight,
       enableClouds: _enableClouds,
+      cloudCoverage: _cloudCoverage,
+      cloudOpacity: _cloudOpacity,
       mapStyle: _mapStyle.name,
       englishLabels: _englishLabels,
       difficulty: _difficulty.name,
@@ -110,6 +112,8 @@ class GameSettings extends ChangeNotifier {
     required bool invertControls,
     required bool enableNight,
     required bool enableClouds,
+    double? cloudCoverage,
+    double? cloudOpacity,
     required bool englishLabels,
     required MapStyle mapStyle,
     required GameDifficulty difficulty,
@@ -125,6 +129,8 @@ class GameSettings extends ChangeNotifier {
       this.invertControls = invertControls;
       this.enableNight = enableNight;
       this.enableClouds = enableClouds;
+      if (cloudCoverage != null) this.cloudCoverage = cloudCoverage;
+      if (cloudOpacity != null) this.cloudOpacity = cloudOpacity;
       this.englishLabels = englishLabels;
       this.mapStyle = mapStyle;
       this.difficulty = difficulty;
@@ -151,6 +157,8 @@ class GameSettings extends ChangeNotifier {
         'invert_controls': _invertControls,
         'enable_night': _enableNight,
         'enable_clouds': _enableClouds,
+        'cloud_coverage': _cloudCoverage,
+        'cloud_opacity': _cloudOpacity,
         'map_style': _mapStyle.name,
         'english_labels': _englishLabels,
         'difficulty': _difficulty.name,
@@ -185,6 +193,10 @@ class GameSettings extends ChangeNotifier {
       _invertControls = data['invert_controls'] as bool? ?? _invertControls;
       _enableNight = data['enable_night'] as bool? ?? _enableNight;
       _enableClouds = data['enable_clouds'] as bool? ?? _enableClouds;
+      _cloudCoverage =
+          (data['cloud_coverage'] as num?)?.toDouble() ?? _cloudCoverage;
+      _cloudOpacity =
+          (data['cloud_opacity'] as num?)?.toDouble() ?? _cloudOpacity;
       final mapStyleName = data['map_style'] as String?;
       if (mapStyleName != null) {
         _mapStyle = MapStyle.values.firstWhere(
@@ -280,6 +292,34 @@ class GameSettings extends ChangeNotifier {
     _enableClouds = value;
     notifyListeners();
   }
+
+  /// Cloud coverage threshold (0.0 = fully covered, 1.0 = clear sky).
+  /// Higher values mean fewer clouds. Default 0.42.
+  double _cloudCoverage = 0.42;
+
+  double get cloudCoverage => _cloudCoverage;
+
+  set cloudCoverage(double value) {
+    _cloudCoverage = value.clamp(0.0, 1.0);
+    notifyListeners();
+  }
+
+  /// Human-readable label for the cloud coverage slider.
+  String get cloudCoverageLabel => '${((_cloudCoverage) * 100).round()}%';
+
+  /// Cloud blend opacity (0.0 = transparent, 1.0 = fully opaque).
+  /// Default 0.9 (90% opaque).
+  double _cloudOpacity = 0.9;
+
+  double get cloudOpacity => _cloudOpacity;
+
+  set cloudOpacity(double value) {
+    _cloudOpacity = value.clamp(0.0, 1.0);
+    notifyListeners();
+  }
+
+  /// Human-readable label for the cloud opacity slider.
+  String get cloudOpacityLabel => '${(_cloudOpacity * 100).round()}%';
 
   /// Map tile style for descent mode (OSM, dark, voyager, topo).
   MapStyle _mapStyle = MapStyle.standard;

--- a/lib/core/widgets/settings_sheet.dart
+++ b/lib/core/widgets/settings_sheet.dart
@@ -172,6 +172,34 @@ class _SettingsSheetContentState extends State<_SettingsSheetContent> {
           setState(() {});
         },
       ),
+      if (GameSettings.instance.enableClouds) ...[
+        const Divider(color: FlitColors.cardBorder, height: 1),
+        _SettingsSlider(
+          label: 'Cloud Coverage',
+          icon: Icons.cloud_queue_outlined,
+          value: GameSettings.instance.cloudCoverage,
+          min: 0.1,
+          max: 0.8,
+          valueLabel: GameSettings.instance.cloudCoverageLabel,
+          onChanged: (value) {
+            GameSettings.instance.cloudCoverage = value;
+            setState(() {});
+          },
+        ),
+        const Divider(color: FlitColors.cardBorder, height: 1),
+        _SettingsSlider(
+          label: 'Cloud Opacity',
+          icon: Icons.opacity,
+          value: GameSettings.instance.cloudOpacity,
+          min: 0.1,
+          max: 1.0,
+          valueLabel: GameSettings.instance.cloudOpacityLabel,
+          onChanged: (value) {
+            GameSettings.instance.cloudOpacity = value;
+            setState(() {});
+          },
+        ),
+      ],
       const Divider(color: FlitColors.cardBorder, height: 1),
       _SettingsToggle(
         label: 'English Labels',

--- a/lib/data/providers/account_provider.dart
+++ b/lib/data/providers/account_provider.dart
@@ -418,6 +418,8 @@ class AccountNotifier extends StateNotifier<AccountState> {
         invertControls: snapshot.invertControls,
         enableNight: snapshot.enableNight,
         enableClouds: snapshot.enableClouds,
+        cloudCoverage: snapshot.cloudCoverage,
+        cloudOpacity: snapshot.cloudOpacity,
         englishLabels: snapshot.englishLabels,
         mapStyle: MapStyle.values.firstWhere(
           (s) => s.name == snapshot.mapStyle,

--- a/lib/data/services/user_preferences_service.dart
+++ b/lib/data/services/user_preferences_service.dart
@@ -375,6 +375,8 @@ class UserPreferencesService {
     required bool invertControls,
     required bool enableNight,
     required bool enableClouds,
+    double? cloudCoverage,
+    double? cloudOpacity,
     required String mapStyle,
     required bool englishLabels,
     required String difficulty,
@@ -392,6 +394,8 @@ class UserPreferencesService {
       'invert_controls': invertControls,
       'enable_night': enableNight,
       'enable_clouds': enableClouds,
+      if (cloudCoverage != null) 'cloud_coverage': cloudCoverage,
+      if (cloudOpacity != null) 'cloud_opacity': cloudOpacity,
       'map_style': mapStyle,
       'english_labels': englishLabels,
       'difficulty': difficulty,
@@ -1158,6 +1162,14 @@ class UserPreferencesSnapshot {
 
   bool get enableClouds {
     return settings?['enable_clouds'] as bool? ?? true;
+  }
+
+  double get cloudCoverage {
+    return (settings?['cloud_coverage'] as num?)?.toDouble() ?? 0.42;
+  }
+
+  double get cloudOpacity {
+    return (settings?['cloud_opacity'] as num?)?.toDouble() ?? 0.9;
   }
 
   String get mapStyle {

--- a/lib/game/components/city_label_overlay.dart
+++ b/lib/game/components/city_label_overlay.dart
@@ -23,34 +23,6 @@ class CityLabelOverlay extends Component with HasGameRef<FlitGame> {
   /// Cached TextPainters to avoid recreating every frame (Safari crash cause).
   final Map<String, TextPainter> _textCache = {};
 
-  /// Maximum number of capital cities to show at high altitude.
-  static const int _maxHighAltCapitals = kIsWeb ? 4 : 8;
-
-  /// Major world capitals to show at high altitude (largest by population).
-  static const Set<String> _majorCapitals = {
-    'Washington D.C.',
-    'Ottawa',
-    'Mexico City',
-    'Brasília',
-    'Buenos Aires',
-    'London',
-    'Paris',
-    'Berlin',
-    'Madrid',
-    'Rome',
-    'Moscow',
-    'Tokyo',
-    'Beijing',
-    'New Delhi',
-    'Seoul',
-    'Jakarta',
-    'Bangkok',
-    'Cairo',
-    'Nairobi',
-    'Pretoria',
-    'Canberra',
-  };
-
   @override
   void render(Canvas canvas) {
     super.render(canvas);
@@ -66,11 +38,9 @@ class CityLabelOverlay extends Component with HasGameRef<FlitGame> {
       // Get continuous altitude from plane (0.0 = low, 1.0 = high)
       final continuousAlt = gameRef.plane.continuousAltitude;
 
-      // At high altitude, show only major capitals (small dots, no labels)
-      if (continuousAlt >= 0.6) {
-        _renderHighAltCapitals(canvas, continuousAlt);
-        return;
-      }
+      // At high altitude, skip city labels — the shader globe provides
+      // enough visual context and the tiny dots are distracting.
+      if (continuousAlt >= 0.6) return;
 
       // Calculate opacity based on altitude (0.6 = transparent, 0.0 = opaque)
       final opacity = (1.0 - continuousAlt / 0.6).clamp(0.0, 1.0);
@@ -237,114 +207,6 @@ class CityLabelOverlay extends Component with HasGameRef<FlitGame> {
       } catch (_) {
         // If even error reporting fails, there's nothing more we can do.
       }
-    }
-  }
-
-  /// Render major world capitals at high altitude as small labeled dots.
-  void _renderHighAltCapitals(Canvas canvas, double altitude) {
-    try {
-      // Fade in from altitude 0.95 down to 0.6 (fully visible at 0.6-0.85)
-      final opacity = altitude > 0.95
-          ? (1.0 - altitude) / 0.05
-          : altitude < 0.6
-          ? 1.0
-          : 0.7;
-
-      final dotPaint = Paint()
-        ..color = FlitColors.cityCapital.withOpacity(opacity.clamp(0.0, 1.0));
-
-      final centerX = gameRef.size.x / 2;
-      final centerY = gameRef.size.y / 2;
-
-      final visible = <({double distance, Offset screenPos, dynamic city})>[];
-
-      for (final city in CountryData.majorCities) {
-        if (!city.isCapital || !_majorCapitals.contains(city.name)) continue;
-
-        try {
-          // Validate city location
-          if (!city.location.x.isFinite || !city.location.y.isFinite) {
-            continue;
-          }
-
-          final screenPos = gameRef.worldToScreenGlobe(city.location);
-          if (!screenPos.x.isFinite ||
-              !screenPos.y.isFinite ||
-              screenPos.x < -20 ||
-              screenPos.x > gameRef.size.x + 20 ||
-              screenPos.y < -20 ||
-              screenPos.y > gameRef.size.y + 20) {
-            continue;
-          }
-
-          final dx = screenPos.x - centerX;
-          final dy = screenPos.y - centerY;
-          final distanceSquared = dx * dx + dy * dy;
-
-          if (!distanceSquared.isFinite || distanceSquared < 0) {
-            continue;
-          }
-
-          visible.add((
-            distance: math.sqrt(distanceSquared),
-            screenPos: Offset(screenPos.x, screenPos.y),
-            city: city,
-          ));
-        } catch (_) {
-          continue;
-        }
-      }
-
-      visible.sort((a, b) => a.distance.compareTo(b.distance));
-
-      for (final entry in visible.take(_maxHighAltCapitals)) {
-        try {
-          canvas.drawCircle(entry.screenPos, 3.0, dotPaint);
-
-          // Small label for high altitude capitals
-          final cacheKey = '${entry.city.name}_hialt';
-          var tp = _textCache[cacheKey];
-          if (tp == null) {
-            tp = TextPainter(
-              text: TextSpan(
-                text: entry.city.name,
-                style: const TextStyle(
-                  color: FlitColors.textPrimary,
-                  fontSize: 7,
-                  fontWeight: FontWeight.w500,
-                  shadows: kIsWeb
-                      ? null
-                      : [
-                          Shadow(
-                            offset: Offset(1, 1),
-                            blurRadius: 2,
-                            color: Color(0x60000000),
-                          ),
-                        ],
-                ),
-              ),
-              textDirection: TextDirection.ltr,
-            )..layout();
-            _textCache[cacheKey] = tp;
-          }
-          tp.paint(
-            canvas,
-            Offset(entry.screenPos.dx + 5, entry.screenPos.dy - tp.height / 2),
-          );
-        } catch (_) {
-          continue;
-        }
-      }
-    } catch (e, st) {
-      // Silently fail high-alt labels but report to telemetry for debugging.
-      final log = GameLog.instance;
-      log.error(
-        'city_overlay',
-        'High altitude city rendering failed',
-        error: e,
-        stackTrace: st,
-        data: {'altitude': altitude.toStringAsFixed(2)},
-      );
     }
   }
 }

--- a/lib/game/rendering/shader_manager.dart
+++ b/lib/game/rendering/shader_manager.dart
@@ -30,6 +30,9 @@ final _log = GameLog.instance;
 /// Index 14  : uFOV (field of view radians)
 /// Index 15  : uEnableShading (0.0 = raw texture, 1.0 = full shading)
 /// Index 16  : uEnableNight   (0.0 = always day,  1.0 = day/night cycle)
+/// Index 17  : uEnableClouds  (0.0 = no clouds,   1.0 = clouds on)
+/// Index 18  : uCloudCoverage (cloud coverage threshold, 0.0–1.0)
+/// Index 19  : uCloudOpacity  (cloud blend opacity, 0.0–1.0)
 /// ```
 /// Plus 4 image samplers: uSatellite, uHeightmap, uShoreDist, uCityLights
 class ShaderManager {
@@ -409,6 +412,15 @@ class ShaderManager {
 
       // uEnableNight (0.0 = always day, 1.0 = day/night cycle)
       s.setFloat(16, GameSettings.instance.enableNight ? 1.0 : 0.0);
+
+      // uEnableClouds (0.0 = no clouds, 1.0 = clouds on)
+      s.setFloat(17, GameSettings.instance.enableClouds ? 1.0 : 0.0);
+
+      // uCloudCoverage (cloud coverage threshold, 0.0–1.0)
+      s.setFloat(18, GameSettings.instance.cloudCoverage);
+
+      // uCloudOpacity (cloud blend opacity, 0.0–1.0)
+      s.setFloat(19, GameSettings.instance.cloudOpacity);
 
       // -- Image samplers (indices 0-3) --
       // Always bind all 4 samplers to prevent shader errors on platforms that

--- a/shaders/globe.frag
+++ b/shaders/globe.frag
@@ -29,6 +29,9 @@ uniform float uCloudRadius;  // Index 13:   cloud shell radius (> globe)
 uniform float uFOV;          // Index 14:   field of view (radians)
 uniform float uEnableShading; // Index 15:  0.0 = raw texture, 1.0 = full shading
 uniform float uEnableNight;   // Index 16:  0.0 = always day,  1.0 = day/night cycle
+uniform float uEnableClouds;  // Index 17:  0.0 = no clouds,   1.0 = clouds on
+uniform float uCloudCoverage; // Index 18:  cloud coverage threshold (0.0–1.0)
+uniform float uCloudOpacity;  // Index 19:  cloud blend opacity (0.0–1.0)
 
 // ---------------------------------------------------------------------------
 // Samplers — maximum 4 per shader pass
@@ -643,10 +646,10 @@ void main() {
     }
 
     // =======================================================================
-    // V5: CLOUD LAYER
+    // V5: CLOUD LAYER (gated by uEnableClouds)
     // =======================================================================
 
-    {
+    if (uEnableClouds > 0.5) {
         // Intersect the cloud shell
         float tC = tCloud;
         // If tCloud is behind the globe surface, skip
@@ -663,8 +666,8 @@ void main() {
             // FBM for cloud density
             float density = fbm(cloudSamplePos);
 
-            // Coverage threshold with smooth edges
-            float cloudMask = smoothstep(CLOUD_COVERAGE - CLOUD_SOFTNESS, CLOUD_COVERAGE + CLOUD_SOFTNESS, density);
+            // Coverage threshold with smooth edges (driven by uCloudCoverage)
+            float cloudMask = smoothstep(uCloudCoverage - CLOUD_SOFTNESS, uCloudCoverage + CLOUD_SOFTNESS, density);
 
             if (cloudMask > 0.01) {
                 // Cloud lighting from sun direction (bright tops, dark bottoms)
@@ -682,18 +685,17 @@ void main() {
                 float cloudTerminator = smoothstep(-0.15, 0.0, cloudNdotL) * smoothstep(0.25, 0.05, cloudNdotL);
                 cloudColor += TERMINATOR_WARM * cloudTerminator * 0.3;
 
-                // Blend cloud on top of surface
-                surfaceColor = mix(surfaceColor, cloudColor, cloudMask * 0.9);
+                // Blend cloud on top of surface (opacity driven by uCloudOpacity)
+                surfaceColor = mix(surfaceColor, cloudColor, cloudMask * uCloudOpacity);
             }
         }
 
         // Cloud shadows on terrain (approximate — darken terrain where clouds would be overhead)
-        // Uses the globe normal as an approximation of "looking up" to the cloud layer
         vec3 shadowSamplePos = hitPoint * 3.0;
         shadowSamplePos.x += uTime * CLOUD_DRIFT_SPEED;
         shadowSamplePos.z += uTime * CLOUD_DRIFT_SPEED * 0.7;
         float shadowDensity = fbm(shadowSamplePos);
-        float shadowMask = smoothstep(CLOUD_COVERAGE - CLOUD_SOFTNESS, CLOUD_COVERAGE + CLOUD_SOFTNESS, shadowDensity);
+        float shadowMask = smoothstep(uCloudCoverage - CLOUD_SOFTNESS, uCloudCoverage + CLOUD_SOFTNESS, shadowDensity);
         surfaceColor *= 1.0 - shadowMask * CLOUD_SHADOW_STR * dayFactor;
     }
 


### PR DESCRIPTION
…alt city labels

Cloud settings:
- Add uEnableClouds, uCloudCoverage, uCloudOpacity shader uniforms so the cloud toggle actually controls cloud rendering
- Add cloud coverage slider (controls how much sky is cloudy)
- Add cloud opacity slider (controls cloud transparency)
- Sliders appear below the cloud toggle when clouds are enabled
- Settings persist locally and sync to Supabase

City labels:
- Remove high-altitude capital dots/labels (distracting at globe view)
- Low-altitude city labels still render during descent

Audio fixes:
- Engine sound now constant low rumble (volume 0.06, no turn modulation) instead of variable "vacuum cleaner" effect
- Sound toggle re-enables engine immediately (stores last plane ID)
- stopEngine clears state so re-enable doesn't play stale engine

https://claude.ai/code/session_017JpWFLAVVdCVmZXHSaRdFX