### PR TITLE
fix: globe texture tracking, error toast details, engine audio jitter

### DIFF
--- a/lib/core/services/audio_manager.dart
+++ b/lib/core/services/audio_manager.dart
@@ -105,6 +105,11 @@ class AudioManager {
   /// Constant engine rumble volume (no turn modulation — just a steady hum).
   static const double _engineBaseVolume = 0.06;
 
+  /// Last volume actually applied to the engine player. Tracked to avoid
+  /// redundant setVolume() calls every frame, which causes audio jitter
+  /// on web/Safari from the underlying player re-interpolating volume.
+  double _lastAppliedEngineVolume = -1.0;
+
   /// Default background music volume.
   static const double _defaultMusicVolume = 0.25;
 
@@ -137,6 +142,7 @@ class AudioManager {
 
   set effectsVolume(double value) {
     _effectsVolume = value.clamp(0.0, 1.0);
+    _lastAppliedEngineVolume = -1.0; // Force next updateEngineVolume to apply
     // Immediately update the playing engine volume.
     if (_enabled && _currentEngine != null) {
       _applyEngineVolume();
@@ -343,6 +349,7 @@ class AudioManager {
     if (_failedAssets.contains(asset)) return;
 
     _currentEngine = type;
+    _lastAppliedEngineVolume = -1.0; // Force volume apply on next update
 
     try {
       await _enginePlayer.stop();
@@ -360,6 +367,7 @@ class AudioManager {
   Future<void> stopEngine() async {
     _currentEngine = null;
     _lastPlaneId = null;
+    _lastAppliedEngineVolume = -1.0;
     await _enginePlayer.stop();
   }
 
@@ -368,10 +376,19 @@ class AudioManager {
   /// Call this every frame from the game update loop.
   /// [turnAmount] is accepted for API compatibility but ignored — the engine
   /// plays at a constant low volume for an unobtrusive ambient hum.
+  ///
+  /// Skips the actual setVolume() call if the volume hasn't changed since
+  /// the last application. Calling setVolume() 60 times per second with the
+  /// same value causes audio jitter on web/Safari.
   Future<void> updateEngineVolume(double turnAmount) async {
     if (!_enabled || _currentEngine == null) return;
 
     final volume = (_engineBaseVolume * _effectsVolume).clamp(0.0, 1.0);
+
+    // Skip if volume hasn't meaningfully changed (avoids 60x/sec setVolume
+    // calls that cause audio jitter on web platforms).
+    if ((volume - _lastAppliedEngineVolume).abs() < 0.001) return;
+    _lastAppliedEngineVolume = volume;
 
     try {
       await _enginePlayer.setVolume(volume);

--- a/lib/core/widgets/error_overlay_manager.dart
+++ b/lib/core/widgets/error_overlay_manager.dart
@@ -58,7 +58,7 @@ class _ErrorOverlayManagerState extends State<ErrorOverlayManager> {
 
     switch (event.severity) {
       case ErrorSeverity.error:
-        ErrorToast.show(context);
+        ErrorToast.show(context, message: event.error.error);
 
       case ErrorSeverity.critical:
         if (!_dialogVisible) {

--- a/lib/core/widgets/error_toast.dart
+++ b/lib/core/widgets/error_toast.dart
@@ -1,48 +1,89 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../theme/flit_colors.dart';
 
 /// A brief auto-dismiss toast for `error`-severity errors.
 ///
 /// Displayed via [ScaffoldMessenger.showSnackBar] when an error is surfaced
-/// through [ErrorService.userFacingErrors]. Auto-dismisses after 3 seconds.
+/// through [ErrorService.userFacingErrors]. Shows error details and can be
+/// tapped to expand / copy the full message.
 ///
 /// This widget is not directly instantiated — use [ErrorToast.show] to
 /// display a toast from any context that has a [ScaffoldMessenger].
 abstract final class ErrorToast {
-  /// Show a brief error toast that auto-dismisses after 3 seconds.
+  /// Show an error toast with the error message.
   ///
-  /// Uses Material [SnackBar] for cross-platform consistency.
+  /// Tap the toast to copy the full error to the clipboard.
+  /// Auto-dismisses after 5 seconds (longer than before so users can read it).
   static void show(BuildContext context, {String? message}) {
     final messenger = ScaffoldMessenger.maybeOf(context);
     if (messenger == null) return;
 
+    final displayMessage = message ?? 'Something went wrong';
+
     messenger.clearSnackBars();
     messenger.showSnackBar(
       SnackBar(
-        content: Row(
-          children: [
-            const Icon(
-              Icons.warning_amber_rounded,
-              color: FlitColors.textPrimary,
-              size: 20,
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                message ?? 'Something went wrong',
-                style: const TextStyle(
-                  color: FlitColors.textPrimary,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
+        content: GestureDetector(
+          onTap: () {
+            // Copy full error to clipboard on tap
+            Clipboard.setData(ClipboardData(text: displayMessage));
+            messenger.clearSnackBars();
+            messenger.showSnackBar(
+              SnackBar(
+                content: const Text(
+                  'Error copied to clipboard',
+                  style: TextStyle(color: FlitColors.textPrimary, fontSize: 13),
                 ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
+                duration: const Duration(seconds: 2),
+                behavior: SnackBarBehavior.floating,
+                backgroundColor: const Color(0xE6444444),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                margin: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
+                ),
               ),
-            ),
-          ],
+            );
+          },
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(
+                    Icons.warning_amber_rounded,
+                    color: FlitColors.textPrimary,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      displayMessage,
+                      style: const TextStyle(
+                        color: FlitColors.textPrimary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              const Text(
+                'Tap to copy full error',
+                style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
+              ),
+            ],
+          ),
         ),
-        duration: const Duration(seconds: 3),
+        duration: const Duration(seconds: 5),
         behavior: SnackBarBehavior.floating,
         backgroundColor: const Color(0xE6CC4444),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),

--- a/lib/game/rendering/globe_renderer.dart
+++ b/lib/game/rendering/globe_renderer.dart
@@ -43,10 +43,7 @@ class GlobeRenderer extends Component with HasGameRef<FlitGame> {
   double _sunDirY = 0.5;
   double _sunDirZ = 0.0;
 
-  /// Cached shader Paint — reused every frame to avoid per-frame allocation.
-  final Paint _shaderPaint = Paint();
-
-  /// Cached fallback Paint — reused every frame to avoid per-frame allocation.
+  /// Cached fallback Paint.
   static final Paint _fallbackPaint = Paint()..color = FlitColors.space;
 
   /// Cached screen size from the last render pass.
@@ -148,7 +145,7 @@ class GlobeRenderer extends Component with HasGameRef<FlitGame> {
       final shaderOpacity = alt >= 0.6
           ? 1.0
           : ((alt - 0.3) / 0.3).clamp(0.0, 1.0);
-      _shaderPaint.shader = shader;
+      final paint = Paint()..shader = shader;
       if (shaderOpacity < 1.0) {
         canvas.saveLayer(
           Rect.fromLTWH(0, 0, _lastSize.width, _lastSize.height),
@@ -157,7 +154,7 @@ class GlobeRenderer extends Component with HasGameRef<FlitGame> {
       }
       canvas.drawRect(
         Rect.fromLTWH(0, 0, _lastSize.width, _lastSize.height),
-        _shaderPaint,
+        paint,
       );
       if (shaderOpacity < 1.0) {
         canvas.restore();

--- a/lib/game/rendering/shader_manager.dart
+++ b/lib/game/rendering/shader_manager.dart
@@ -44,7 +44,6 @@ class ShaderManager {
   // -- Cached assets --
 
   ui.FragmentProgram? _program;
-  ui.FragmentShader? _cachedShader;
   ui.Image? _satelliteTexture;
   ui.Image? _cityLightsTexture;
 
@@ -318,8 +317,7 @@ class ShaderManager {
     if (!_initialized || _program == null) return null;
 
     try {
-      _cachedShader ??= _program!.fragmentShader();
-      final s = _cachedShader!;
+      final s = _program!.fragmentShader();
 
       // -- Float uniforms (indices 0-14) --
       // uResolution (vec2)
@@ -526,7 +524,6 @@ class ShaderManager {
     _satelliteTexture = null;
     _cityLightsTexture = null;
     _blackTexture = null;
-    _cachedShader = null;
     _program = null;
     _initialized = false;
     _loading = false;


### PR DESCRIPTION
Globe rendering:
- Revert FragmentShader caching — some Flutter backends (CanvasKit/Impeller) use shader object identity as a GPU cache key, causing uniforms to appear stale when the same object is reused across frames
- Use fresh Paint per frame for the shader draw call

Error toast:
- Show actual error message in the red banner (was generic "Something went wrong")
- Increase duration to 5s so users can read it
- Show up to 3 lines of the error
- Tap toast to copy full error to clipboard
- Pass error.error from ErrorOverlayManager to ErrorToast.show()

Engine audio:
- Guard updateEngineVolume() against redundant setVolume() calls — was calling setVolume(0.06) on every frame (60x/sec) even when volume hadn't changed, causing audio jitter/wavering on web/Safari from the underlying player re-interpolating volume each call
- Track _lastAppliedEngineVolume and skip if delta < 0.001
- Reset tracked volume on startEngine/stopEngine/effectsVolume change

https://claude.ai/code/session_017JpWFLAVVdCVmZXHSaRdFX