### PR TITLE
feat: expand Flight School to multi-region system with H2H, type-in m…

### DIFF
--- a/lib/data/models/h2h_challenge.dart
+++ b/lib/data/models/h2h_challenge.dart
@@ -1,0 +1,303 @@
+import '../../game/quiz/quiz_category.dart';
+import '../../game/quiz/quiz_difficulty.dart';
+
+/// Status of a Head-to-Head Flight School challenge.
+enum H2HStatus {
+  pending('pending'),
+  inProgress('in_progress'),
+  completed('completed'),
+  declined('declined'),
+  expired('expired');
+
+  const H2HStatus(this.dbName);
+
+  final String dbName;
+
+  static H2HStatus fromDb(String value) => H2HStatus.values.firstWhere(
+    (s) => s.dbName == value,
+    orElse: () => H2HStatus.pending,
+  );
+}
+
+/// A single round in a best-of-3 H2H Flight School challenge.
+///
+/// Each round specifies a flight school level, quiz category, and difficulty.
+/// Both players play with the same [seed] so they get identical questions.
+class H2HRound {
+  const H2HRound({
+    required this.levelId,
+    required this.levelName,
+    required this.category,
+    required this.difficulty,
+    required this.seed,
+    this.challengerScore,
+    this.challengedScore,
+    this.challengerTimeMs,
+    this.challengedTimeMs,
+    this.challengerCorrect,
+    this.challengedCorrect,
+    this.challengerWrong,
+    this.challengedWrong,
+  });
+
+  /// Flight school level ID (e.g. 'europe', 'us_states').
+  final String levelId;
+
+  /// Human-readable level name (e.g. 'Europe', 'United States').
+  final String levelName;
+
+  /// Quiz category for this round.
+  final QuizCategory category;
+
+  /// Quiz difficulty for this round.
+  final QuizDifficulty difficulty;
+
+  /// Deterministic seed so both players get the same questions.
+  final int seed;
+
+  /// Challenger's total score for this round (null if not yet played).
+  final int? challengerScore;
+
+  /// Challenged player's total score (null if not yet played).
+  final int? challengedScore;
+
+  /// Challenger's time in milliseconds.
+  final int? challengerTimeMs;
+
+  /// Challenged player's time in milliseconds.
+  final int? challengedTimeMs;
+
+  /// Challenger's correct answer count.
+  final int? challengerCorrect;
+
+  /// Challenged player's correct answer count.
+  final int? challengedCorrect;
+
+  /// Challenger's wrong answer count.
+  final int? challengerWrong;
+
+  /// Challenged player's wrong answer count.
+  final int? challengedWrong;
+
+  /// Whether the challenger has completed this round.
+  bool get challengerPlayed => challengerScore != null;
+
+  /// Whether the challenged player has completed this round.
+  bool get challengedPlayed => challengedScore != null;
+
+  /// Whether both players have completed this round.
+  bool get isComplete => challengerPlayed && challengedPlayed;
+
+  /// Determine the round winner. Returns 'challenger', 'challenged', or 'draw'.
+  /// Returns null if not yet complete.
+  String? get winner {
+    if (!isComplete) return null;
+    if (challengerScore! > challengedScore!) return 'challenger';
+    if (challengedScore! > challengerScore!) return 'challenged';
+    return 'draw';
+  }
+
+  Map<String, dynamic> toJson() => {
+    'level_id': levelId,
+    'level_name': levelName,
+    'category': category.name,
+    'difficulty': difficulty.name,
+    'seed': seed,
+    if (challengerScore != null) 'challenger_score': challengerScore,
+    if (challengedScore != null) 'challenged_score': challengedScore,
+    if (challengerTimeMs != null) 'challenger_time_ms': challengerTimeMs,
+    if (challengedTimeMs != null) 'challenged_time_ms': challengedTimeMs,
+    if (challengerCorrect != null) 'challenger_correct': challengerCorrect,
+    if (challengedCorrect != null) 'challenged_correct': challengedCorrect,
+    if (challengerWrong != null) 'challenger_wrong': challengerWrong,
+    if (challengedWrong != null) 'challenged_wrong': challengedWrong,
+  };
+
+  factory H2HRound.fromJson(Map<String, dynamic> json) => H2HRound(
+    levelId: json['level_id'] as String? ?? '',
+    levelName: json['level_name'] as String? ?? '',
+    category: QuizCategory.values.firstWhere(
+      (c) => c.name == json['category'],
+      orElse: () => QuizCategory.mixed,
+    ),
+    difficulty: QuizDifficulty.values.firstWhere(
+      (d) => d.name == json['difficulty'],
+      orElse: () => QuizDifficulty.medium,
+    ),
+    seed: json['seed'] as int? ?? 0,
+    challengerScore: json['challenger_score'] as int?,
+    challengedScore: json['challenged_score'] as int?,
+    challengerTimeMs: json['challenger_time_ms'] as int?,
+    challengedTimeMs: json['challenged_time_ms'] as int?,
+    challengerCorrect: json['challenger_correct'] as int?,
+    challengedCorrect: json['challenged_correct'] as int?,
+    challengerWrong: json['challenger_wrong'] as int?,
+    challengedWrong: json['challenged_wrong'] as int?,
+  );
+
+  H2HRound copyWith({
+    String? levelId,
+    String? levelName,
+    QuizCategory? category,
+    QuizDifficulty? difficulty,
+    int? seed,
+    int? challengerScore,
+    int? challengedScore,
+    int? challengerTimeMs,
+    int? challengedTimeMs,
+    int? challengerCorrect,
+    int? challengedCorrect,
+    int? challengerWrong,
+    int? challengedWrong,
+  }) => H2HRound(
+    levelId: levelId ?? this.levelId,
+    levelName: levelName ?? this.levelName,
+    category: category ?? this.category,
+    difficulty: difficulty ?? this.difficulty,
+    seed: seed ?? this.seed,
+    challengerScore: challengerScore ?? this.challengerScore,
+    challengedScore: challengedScore ?? this.challengedScore,
+    challengerTimeMs: challengerTimeMs ?? this.challengerTimeMs,
+    challengedTimeMs: challengedTimeMs ?? this.challengedTimeMs,
+    challengerCorrect: challengerCorrect ?? this.challengerCorrect,
+    challengedCorrect: challengedCorrect ?? this.challengedCorrect,
+    challengerWrong: challengerWrong ?? this.challengerWrong,
+    challengedWrong: challengedWrong ?? this.challengedWrong,
+  );
+}
+
+/// A Head-to-Head Flight School challenge (best of 3 rounds).
+///
+/// The challenger picks 3 rounds (level + category + difficulty), each with
+/// a deterministic seed. The challenged player accepts and plays all 3 rounds.
+/// Whoever wins 2+ rounds wins the challenge.
+class H2HChallenge {
+  const H2HChallenge({
+    required this.id,
+    required this.challengerId,
+    required this.challengerName,
+    required this.challengedId,
+    required this.challengedName,
+    required this.rounds,
+    required this.status,
+    required this.createdAt,
+    this.completedAt,
+    this.winnerId,
+  });
+
+  final String id;
+  final String challengerId;
+  final String challengerName;
+  final String challengedId;
+  final String challengedName;
+
+  /// Exactly 3 rounds.
+  final List<H2HRound> rounds;
+  final H2HStatus status;
+  final DateTime createdAt;
+  final DateTime? completedAt;
+  final String? winnerId;
+
+  /// Total rounds (always 3 for H2H).
+  static const int totalRounds = 3;
+
+  /// Wins required to win the challenge (2 out of 3).
+  static const int winsRequired = 2;
+
+  /// Coin rewards.
+  static const int winnerCoins = 75;
+  static const int roundWinCoins = 15;
+  static const int loserCoins = 10;
+  static const int participationCoins = 5;
+
+  int get challengerWins =>
+      rounds.where((r) => r.isComplete && r.winner == 'challenger').length;
+
+  int get challengedWins =>
+      rounds.where((r) => r.isComplete && r.winner == 'challenged').length;
+
+  /// Index of the next round to play (for the challenged player), or -1 if all
+  /// rounds are complete.
+  int get nextUnplayedRoundIndex {
+    for (var i = 0; i < rounds.length; i++) {
+      if (!rounds[i].isComplete) return i;
+    }
+    return -1;
+  }
+
+  /// Whether someone has clinched the majority of rounds.
+  bool get isClinched =>
+      challengerWins >= winsRequired || challengedWins >= winsRequired;
+
+  /// Whether all rounds are complete or someone has clinched.
+  bool get isComplete => isClinched || rounds.every((r) => r.isComplete);
+
+  /// The winner's name, or null if draw or not complete.
+  String? get winnerName {
+    if (winnerId == challengerId) return challengerName;
+    if (winnerId == challengedId) return challengedName;
+    return null;
+  }
+
+  /// Score text like "2 - 1".
+  String get scoreText => '$challengerWins - $challengedWins';
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'challenger_id': challengerId,
+    'challenger_name': challengerName,
+    'challenged_id': challengedId,
+    'challenged_name': challengedName,
+    'rounds': rounds.map((r) => r.toJson()).toList(),
+    'status': status.dbName,
+    'created_at': createdAt.toIso8601String(),
+    if (completedAt != null) 'completed_at': completedAt!.toIso8601String(),
+    if (winnerId != null) 'winner_id': winnerId,
+  };
+
+  factory H2HChallenge.fromJson(Map<String, dynamic> json) {
+    final roundsList = json['rounds'] as List? ?? [];
+    return H2HChallenge(
+      id: json['id'] as String,
+      challengerId: json['challenger_id'] as String,
+      challengerName: json['challenger_name'] as String? ?? '',
+      challengedId: json['challenged_id'] as String,
+      challengedName: json['challenged_name'] as String? ?? '',
+      rounds: roundsList
+          .map((r) => H2HRound.fromJson(r as Map<String, dynamic>))
+          .toList(),
+      status: H2HStatus.fromDb(json['status'] as String? ?? 'pending'),
+      createdAt: json['created_at'] != null
+          ? DateTime.parse(json['created_at'] as String)
+          : DateTime.now(),
+      completedAt: json['completed_at'] != null
+          ? DateTime.tryParse(json['completed_at'] as String)
+          : null,
+      winnerId: json['winner_id'] as String?,
+    );
+  }
+
+  H2HChallenge copyWith({
+    String? id,
+    String? challengerId,
+    String? challengerName,
+    String? challengedId,
+    String? challengedName,
+    List<H2HRound>? rounds,
+    H2HStatus? status,
+    DateTime? createdAt,
+    DateTime? completedAt,
+    String? winnerId,
+  }) => H2HChallenge(
+    id: id ?? this.id,
+    challengerId: challengerId ?? this.challengerId,
+    challengerName: challengerName ?? this.challengerName,
+    challengedId: challengedId ?? this.challengedId,
+    challengedName: challengedName ?? this.challengedName,
+    rounds: rounds ?? this.rounds,
+    status: status ?? this.status,
+    createdAt: createdAt ?? this.createdAt,
+    completedAt: completedAt ?? this.completedAt,
+    winnerId: winnerId ?? this.winnerId,
+  );
+}

--- a/lib/data/models/leaderboard_entry.dart
+++ b/lib/data/models/leaderboard_entry.dart
@@ -128,6 +128,34 @@ extension GameModeTabExtension on GameModeTab {
   }
 }
 
+/// Top-level leaderboard mode tab.
+enum LeaderboardMode { dailyScramble, trainingFlight, flightBriefing }
+
+extension LeaderboardModeExtension on LeaderboardMode {
+  String get displayName {
+    switch (this) {
+      case LeaderboardMode.dailyScramble:
+        return 'DAILY SCRAMBLE';
+      case LeaderboardMode.trainingFlight:
+        return 'TRAINING FLIGHT';
+      case LeaderboardMode.flightBriefing:
+        return 'FLIGHT BRIEFING';
+    }
+  }
+
+  /// The region filter value used in the `scores` table.
+  String? get regionFilter {
+    switch (this) {
+      case LeaderboardMode.dailyScramble:
+        return 'daily';
+      case LeaderboardMode.trainingFlight:
+        return null; // neq 'daily' and neq 'briefing'
+      case LeaderboardMode.flightBriefing:
+        return 'briefing';
+    }
+  }
+}
+
 /// Time period sub-tab.
 enum TimeframeTab { today, lastMonth, allTime }
 

--- a/lib/data/providers/account_provider.dart
+++ b/lib/data/providers/account_provider.dart
@@ -7,6 +7,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/services/game_settings.dart';
 import '../../game/map/region.dart';
+import '../../game/quiz/flight_school_level.dart';
 import '../models/avatar_config.dart';
 import '../models/daily_result.dart';
 import '../models/daily_streak.dart';
@@ -34,6 +35,7 @@ class AccountState {
     this.lastDailyResult,
     this.freeFlightCoinsToday = 0,
     this.freeFlightCoinDate,
+    this.flightSchoolProgress = const {},
   }) : avatar = avatar ?? const AvatarConfig(),
        license = license ?? PilotLicense.random();
 
@@ -90,6 +92,9 @@ class AccountState {
   /// YYYY-MM-DD date string for the free flight daily cap tracking.
   final String? freeFlightCoinDate;
 
+  /// Flight school progress per level ID.
+  final Map<String, FlightSchoolProgress> flightSchoolProgress;
+
   static String _todayStr() {
     final today = DateTime.now().toUtc();
     return '${today.year}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
@@ -144,6 +149,7 @@ class AccountState {
     Object? lastDailyResult = _sentinel,
     int? freeFlightCoinsToday,
     Object? freeFlightCoinDate = _sentinel,
+    Map<String, FlightSchoolProgress>? flightSchoolProgress,
   }) => AccountState(
     currentPlayer: currentPlayer ?? this.currentPlayer,
     unlockedRegions: unlockedRegions ?? this.unlockedRegions,
@@ -167,6 +173,7 @@ class AccountState {
     freeFlightCoinDate: freeFlightCoinDate == _sentinel
         ? this.freeFlightCoinDate
         : freeFlightCoinDate as String?,
+    flightSchoolProgress: flightSchoolProgress ?? this.flightSchoolProgress,
   );
 }
 
@@ -403,6 +410,7 @@ class AccountNotifier extends StateNotifier<AccountState> {
       lastDailyResult: snapshot.toLastDailyResult(),
       freeFlightCoinsToday: snapshot.freeFlightCoinsToday,
       freeFlightCoinDate: snapshot.freeFlightCoinDate,
+      flightSchoolProgress: snapshot.toFlightSchoolProgress(),
     );
 
     // Mark Supabase data as loaded — enables writes. Must happen AFTER
@@ -569,6 +577,7 @@ class AccountNotifier extends StateNotifier<AccountState> {
       lastDailyResult: state.lastDailyResult,
       freeFlightCoinsToday: state.freeFlightCoinsToday,
       freeFlightCoinDate: state.freeFlightCoinDate,
+      flightSchoolProgress: state.flightSchoolProgress,
     );
   }
 
@@ -707,6 +716,50 @@ class AccountNotifier extends StateNotifier<AccountState> {
   bool isRegionUnlocked(GameRegion region) {
     if (state.currentPlayer.level >= region.requiredLevel) return true;
     return state.unlockedRegions.contains(region.name);
+  }
+
+  /// Unlock a flight school level with coins (early unlock).
+  /// Returns true if successful, false if insufficient funds.
+  bool unlockFlightSchoolLevel(String levelId, int cost) {
+    if (!spendCoins(cost, source: 'flight_school_unlock')) return false;
+    state = state.copyWith(
+      unlockedRegions: {...state.unlockedRegions, levelId},
+    );
+    _syncAccountState();
+    return true;
+  }
+
+  /// Check if a flight school level is accessible (by player level or purchase).
+  bool isFlightSchoolLevelUnlocked(FlightSchoolLevel level) {
+    if (state.currentPlayer.level >= level.requiredLevel) return true;
+    return state.unlockedRegions.contains(level.id);
+  }
+
+  /// Update flight school progress for a given level.
+  void updateFlightSchoolProgress({
+    required String levelId,
+    required int score,
+    required int timeMs,
+    required bool completed,
+  }) {
+    final current =
+        state.flightSchoolProgress[levelId] ?? const FlightSchoolProgress();
+
+    final updated = current.copyWith(
+      bestScore: score > current.bestScore ? score : null,
+      bestTimeMs:
+          (timeMs > 0 &&
+              (current.bestTimeMs == 0 || timeMs < current.bestTimeMs))
+          ? timeMs
+          : null,
+      completions: completed ? current.completions + 1 : null,
+      attempts: current.attempts + 1,
+    );
+
+    state = state.copyWith(
+      flightSchoolProgress: {...state.flightSchoolProgress, levelId: updated},
+    );
+    _syncAccountState();
   }
 
   /// Add XP and handle level ups

--- a/lib/data/services/challenge_service.dart
+++ b/lib/data/services/challenge_service.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:flame/components.dart';
 
 import '../models/challenge.dart';
+import '../models/h2h_challenge.dart';
 import '../../game/clues/clue_types.dart';
 import '../../game/quiz/quiz_category.dart';
 import '../../game/quiz/quiz_session.dart';
@@ -456,6 +457,265 @@ class ChallengeService {
     }
     return coins;
   }
+
+  // ===========================================================================
+  // H2H Flight School Challenges (best-of-3)
+  // ===========================================================================
+
+  /// Create a new H2H Flight School challenge.
+  ///
+  /// [challengedUsername] is looked up in the profiles table.
+  /// [rounds] contains the 3 round configurations (level, category, difficulty).
+  /// Returns the challenge ID on success, or null on failure.
+  Future<String?> createH2HChallenge({
+    required String challengedUsername,
+    required String challengerName,
+    required List<H2HRound> rounds,
+  }) async {
+    if (_userId == null) return null;
+    if (rounds.length != H2HChallenge.totalRounds) return null;
+
+    try {
+      // Look up the challenged user by username.
+      final profile = await _client
+          .from('profiles')
+          .select('id, username, display_name')
+          .eq('username', challengedUsername)
+          .neq('id', _userId!)
+          .maybeSingle();
+
+      if (profile == null) return null;
+
+      final challengedId = profile['id'] as String;
+      final challengedName =
+          (profile['display_name'] as String?) ??
+          (profile['username'] as String? ?? '');
+
+      final roundsJson = rounds.map((r) => r.toJson()).toList();
+
+      final data = await _client
+          .from('h2h_challenges')
+          .insert({
+            'challenger_id': _userId,
+            'challenger_name': challengerName,
+            'challenged_id': challengedId,
+            'challenged_name': challengedName,
+            'rounds': roundsJson,
+            'status': 'pending',
+          })
+          .select('id')
+          .single();
+
+      return data['id'] as String;
+    } catch (e) {
+      debugPrint('[ChallengeService] createH2HChallenge failed: $e');
+      return null;
+    }
+  }
+
+  /// Accept a pending H2H challenge (marks it as in_progress).
+  Future<bool> acceptH2HChallenge(String challengeId) async {
+    if (_userId == null) return false;
+    try {
+      await _client
+          .from('h2h_challenges')
+          .update({'status': 'in_progress'})
+          .eq('id', challengeId)
+          .eq('challenged_id', _userId!)
+          .eq('status', 'pending');
+      return true;
+    } catch (e) {
+      debugPrint('[ChallengeService] acceptH2HChallenge failed: $e');
+      return false;
+    }
+  }
+
+  /// Decline a pending H2H challenge.
+  Future<bool> declineH2HChallenge(String challengeId) async {
+    if (_userId == null) return false;
+    try {
+      await _client
+          .from('h2h_challenges')
+          .update({'status': 'declined'})
+          .eq('id', challengeId)
+          .eq('challenged_id', _userId!)
+          .eq('status', 'pending');
+      return true;
+    } catch (e) {
+      debugPrint('[ChallengeService] declineH2HChallenge failed: $e');
+      return false;
+    }
+  }
+
+  /// Submit a round score for an H2H challenge.
+  ///
+  /// [roundIndex] is 0-based. The method reads the current rounds JSONB,
+  /// updates the appropriate field, and writes it back.
+  Future<bool> submitH2HRoundScore({
+    required String challengeId,
+    required int roundIndex,
+    required int score,
+    required int timeMs,
+    required int correctCount,
+    required int wrongCount,
+  }) async {
+    if (_userId == null) return false;
+
+    for (var attempt = 0; attempt <= _maxRetries; attempt++) {
+      try {
+        final row = await _client
+            .from('h2h_challenges')
+            .select('challenger_id, challenged_id, rounds, status')
+            .eq('id', challengeId)
+            .single();
+
+        final isChallenger = row['challenger_id'] == _userId;
+        final rounds = List<Map<String, dynamic>>.from(
+          (row['rounds'] as List).map(
+            (r) => Map<String, dynamic>.from(r as Map),
+          ),
+        );
+
+        if (roundIndex < 0 || roundIndex >= rounds.length) return false;
+
+        final prefix = isChallenger ? 'challenger' : 'challenged';
+        rounds[roundIndex]['${prefix}_score'] = score;
+        rounds[roundIndex]['${prefix}_time_ms'] = timeMs;
+        rounds[roundIndex]['${prefix}_correct'] = correctCount;
+        rounds[roundIndex]['${prefix}_wrong'] = wrongCount;
+
+        // Move to in_progress if still pending.
+        final newStatus = row['status'] == 'pending'
+            ? 'in_progress'
+            : row['status'];
+
+        await _client
+            .from('h2h_challenges')
+            .update({'rounds': rounds, 'status': newStatus})
+            .eq('id', challengeId);
+
+        return true;
+      } catch (e) {
+        debugPrint(
+          '[ChallengeService] submitH2HRoundScore failed '
+          '(attempt ${attempt + 1}/${_maxRetries + 1}): $e',
+        );
+        if (attempt < _maxRetries) {
+          await Future<void>.delayed(Duration(seconds: 1 << attempt));
+        }
+      }
+    }
+    return false;
+  }
+
+  /// Check if the H2H challenge is complete and determine the winner.
+  ///
+  /// If one player has won 2+ rounds or all rounds are done, marks the
+  /// challenge as completed and sets the winner.
+  Future<H2HChallenge?> tryCompleteH2HChallenge(String challengeId) async {
+    if (_userId == null) return null;
+
+    for (var attempt = 0; attempt <= _maxRetries; attempt++) {
+      try {
+        final row = await _client
+            .from('h2h_challenges')
+            .select()
+            .eq('id', challengeId)
+            .single();
+
+        final challenge = H2HChallenge.fromJson(row);
+
+        if (!challenge.isComplete) return null;
+
+        String? winnerId;
+        if (challenge.challengerWins > challenge.challengedWins) {
+          winnerId = challenge.challengerId;
+        } else if (challenge.challengedWins > challenge.challengerWins) {
+          winnerId = challenge.challengedId;
+        }
+
+        await _client
+            .from('h2h_challenges')
+            .update({
+              'status': 'completed',
+              'winner_id': winnerId,
+              'completed_at': DateTime.now().toUtc().toIso8601String(),
+            })
+            .eq('id', challengeId);
+
+        return challenge.copyWith(
+          status: H2HStatus.completed,
+          winnerId: winnerId,
+          completedAt: DateTime.now().toUtc(),
+        );
+      } catch (e) {
+        debugPrint(
+          '[ChallengeService] tryCompleteH2HChallenge failed '
+          '(attempt ${attempt + 1}/${_maxRetries + 1}): $e',
+        );
+        if (attempt < _maxRetries) {
+          await Future<void>.delayed(Duration(seconds: 1 << attempt));
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Fetch pending H2H challenges where the current user is challenged.
+  Future<List<H2HChallenge>> fetchPendingH2HChallenges() async {
+    if (_userId == null) return [];
+    try {
+      final data = await _client
+          .from('h2h_challenges')
+          .select()
+          .eq('challenged_id', _userId!)
+          .eq('status', 'pending')
+          .order('created_at', ascending: false);
+
+      return data.map((row) => H2HChallenge.fromJson(row)).toList();
+    } catch (e) {
+      debugPrint('[ChallengeService] fetchPendingH2HChallenges failed: $e');
+      return [];
+    }
+  }
+
+  /// Fetch all H2H challenges involving the current user.
+  Future<List<H2HChallenge>> fetchMyH2HChallenges({int limit = 50}) async {
+    if (_userId == null) return [];
+    try {
+      final data = await _client
+          .from('h2h_challenges')
+          .select()
+          .or('challenger_id.eq.$_userId,challenged_id.eq.$_userId')
+          .order('created_at', ascending: false)
+          .limit(limit);
+
+      return data.map((row) => H2HChallenge.fromJson(row)).toList();
+    } catch (e) {
+      debugPrint('[ChallengeService] fetchMyH2HChallenges failed: $e');
+      return [];
+    }
+  }
+
+  /// Fetch a single H2H challenge by ID.
+  Future<H2HChallenge?> fetchH2HChallenge(String challengeId) async {
+    if (_userId == null) return null;
+    try {
+      final data = await _client
+          .from('h2h_challenges')
+          .select()
+          .eq('id', challengeId)
+          .single();
+      return H2HChallenge.fromJson(data);
+    } catch (e) {
+      debugPrint('[ChallengeService] fetchH2HChallenge failed: $e');
+      return null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
 
   Challenge _rowToChallenge(Map<String, dynamic> row) {
     final roundsList = row['rounds'] as List? ?? [];

--- a/lib/data/services/leaderboard_service.dart
+++ b/lib/data/services/leaderboard_service.dart
@@ -475,8 +475,14 @@ class LeaderboardService {
   Future<LeaderboardEntry?> fetchPlayerRank(
     String userId, {
     bool isDailyScramble = true,
+    LeaderboardMode? mode,
   }) async {
-    final cacheKey = 'rank_${userId}_$isDailyScramble';
+    final effectiveMode =
+        mode ??
+        (isDailyScramble
+            ? LeaderboardMode.dailyScramble
+            : LeaderboardMode.trainingFlight);
+    final cacheKey = 'rank_${userId}_${effectiveMode.name}';
     final cached = _rankCache.get(cacheKey);
     if (cached != null) return cached;
 
@@ -484,17 +490,10 @@ class LeaderboardService {
       // Compute rank from the scores table directly so we aren't limited to
       // the daily-only leaderboard_global view.
       PostgrestFilterBuilder<List<Map<String, dynamic>>> query;
-      if (isDailyScramble) {
-        query = _client
-            .from('scores')
-            .select('score, time_ms, user_id, created_at')
-            .eq('region', 'daily');
-      } else {
-        query = _client
-            .from('scores')
-            .select('score, time_ms, user_id, created_at')
-            .neq('region', 'daily');
-      }
+      query = _applyModeFilter(
+        _client.from('scores').select('score, time_ms, user_id, created_at'),
+        effectiveMode,
+      );
 
       // Get the player's best score in this mode.
       final playerBest = await query
@@ -510,38 +509,15 @@ class LeaderboardService {
       final bestTime = playerBest['time_ms'] as int? ?? 0;
 
       // Count how many distinct scores rank above this one.
-      // A score ranks higher if it has a higher score, or the same score with
-      // a lower time.
-      PostgrestFilterBuilder<List<Map<String, dynamic>>> countQuery;
-      if (isDailyScramble) {
-        countQuery = _client
-            .from('scores')
-            .select('user_id')
-            .eq('region', 'daily');
-      } else {
-        countQuery = _client
-            .from('scores')
-            .select('user_id')
-            .neq('region', 'daily');
-      }
-      final aboveData = await countQuery.gt('score', bestScore).limit(10000);
+      final aboveData = await _applyModeFilter(
+        _client.from('scores').select('user_id'),
+        effectiveMode,
+      ).gt('score', bestScore).limit(10000);
       // Also count those with same score but faster time.
-      PostgrestFilterBuilder<List<Map<String, dynamic>>> tieQuery;
-      if (isDailyScramble) {
-        tieQuery = _client
-            .from('scores')
-            .select('user_id')
-            .eq('region', 'daily');
-      } else {
-        tieQuery = _client
-            .from('scores')
-            .select('user_id')
-            .neq('region', 'daily');
-      }
-      final tieData = await tieQuery
-          .eq('score', bestScore)
-          .lt('time_ms', bestTime)
-          .limit(10000);
+      final tieData = await _applyModeFilter(
+        _client.from('scores').select('user_id'),
+        effectiveMode,
+      ).eq('score', bestScore).lt('time_ms', bestTime).limit(10000);
 
       // Rank = number of distinct users above + 1.
       final usersAbove = <String>{
@@ -578,17 +554,39 @@ class LeaderboardService {
   // Mode-based leaderboard (Daily Scramble / Training Flight)
   // ---------------------------------------------------------------------------
 
+  /// Apply the mode-based region filter to a query.
+  PostgrestFilterBuilder<List<Map<String, dynamic>>> _applyModeFilter(
+    PostgrestFilterBuilder<List<Map<String, dynamic>>> query,
+    LeaderboardMode mode,
+  ) {
+    switch (mode) {
+      case LeaderboardMode.dailyScramble:
+        return query.eq('region', 'daily');
+      case LeaderboardMode.flightBriefing:
+        return query.eq('region', 'briefing');
+      case LeaderboardMode.trainingFlight:
+        return query.neq('region', 'daily').neq('region', 'briefing');
+    }
+  }
+
   /// Fetch leaderboard entries filtered by game mode and timeframe.
   ///
   /// Daily Scramble entries have `region = 'daily'`; Training Flight entries
-  /// have any other region value. Each flight is its own entry — no
-  /// deduplication.
+  /// have any other region value; Flight Briefing entries have
+  /// `region = 'briefing'`. Each flight is its own entry — no deduplication.
   Future<List<LeaderboardEntry>> fetchModeLeaderboard({
-    required bool isDailyScramble,
+    bool isDailyScramble = true,
+    LeaderboardMode? mode,
     required TimeframeTab timeframe,
     int limit = 50,
   }) async {
-    final cacheKey = 'mode_${isDailyScramble}_${timeframe.name}_$limit';
+    // Support both old bool API and new enum API
+    final effectiveMode =
+        mode ??
+        (isDailyScramble
+            ? LeaderboardMode.dailyScramble
+            : LeaderboardMode.trainingFlight);
+    final cacheKey = 'mode_${effectiveMode.name}_${timeframe.name}_$limit';
     final cached = _boardCache.get(cacheKey);
     if (cached != null) return cached;
 
@@ -603,10 +601,16 @@ class LeaderboardService {
 
       // Filter by game mode.
       PostgrestFilterBuilder<List<Map<String, dynamic>>> filtered;
-      if (isDailyScramble) {
-        filtered = query.eq('region', 'daily');
-      } else {
-        filtered = query.neq('region', 'daily');
+      switch (effectiveMode) {
+        case LeaderboardMode.dailyScramble:
+          filtered = query.eq('region', 'daily');
+          break;
+        case LeaderboardMode.flightBriefing:
+          filtered = query.eq('region', 'briefing');
+          break;
+        case LeaderboardMode.trainingFlight:
+          filtered = query.neq('region', 'daily').neq('region', 'briefing');
+          break;
       }
 
       // Filter by time period.

--- a/lib/data/services/user_preferences_service.dart
+++ b/lib/data/services/user_preferences_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../../game/quiz/flight_school_level.dart';
 import '../models/avatar_config.dart';
 import '../models/daily_result.dart';
 import '../models/daily_streak.dart';
@@ -425,6 +426,7 @@ class UserPreferencesService {
     DailyResult? lastDailyResult,
     int freeFlightCoinsToday = 0,
     String? freeFlightCoinDate,
+    Map<String, FlightSchoolProgress> flightSchoolProgress = const {},
   }) {
     _accountStateWriteVersion++;
     _accountStateDirty = true;
@@ -444,6 +446,9 @@ class UserPreferencesService {
       'last_daily_result': lastDailyResult?.toJson(),
       'free_flight_coins_today': freeFlightCoinsToday,
       'free_flight_coin_date': freeFlightCoinDate,
+      'flight_school_progress': flightSchoolProgress.map(
+        (k, v) => MapEntry(k, v.toJson()),
+      ),
     };
     _cacheLocally(_kLocalAccountState, _pendingAccountState!);
     _scheduleSave();
@@ -1144,6 +1149,27 @@ class UserPreferencesSnapshot {
       }
     }
     return null;
+  }
+
+  Map<String, FlightSchoolProgress> toFlightSchoolProgress() {
+    final data = accountState;
+    if (data == null) return {};
+    final json = data['flight_school_progress'];
+    if (json is Map<String, dynamic>) {
+      try {
+        return json.map(
+          (k, v) => MapEntry(
+            k,
+            v is Map<String, dynamic>
+                ? FlightSchoolProgress.fromJson(v)
+                : const FlightSchoolProgress(),
+          ),
+        );
+      } catch (_) {
+        return {};
+      }
+    }
+    return {};
   }
 
   // ── Settings helpers ─────────────────────────────────────────────────

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -26,6 +26,8 @@ import '../debug/avatar_preview_screen.dart';
 import '../debug/country_preview_screen.dart';
 import '../debug/plane_preview_screen.dart';
 import 'admin_stats_screen.dart';
+import 'flight_school_admin_screen.dart';
+import 'gold_management_screen.dart';
 
 /// Admin panel — visible to users with a non-null `admin_role`.
 ///
@@ -2253,6 +2255,34 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                 ),
               ],
             ],
+            const SizedBox(height: 24),
+          ],
+
+          // ── Flight School Config (owner only) ──
+          if (_can(state, AdminPermission.editEarnings)) ...[
+            const _SectionHeader(title: 'Flight School'),
+            const SizedBox(height: 8),
+            _AdminActionCard(
+              icon: Icons.school,
+              iconColor: FlitColors.oceanHighlight,
+              label: 'Flight School Config',
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const FlightSchoolAdminScreen(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            _AdminActionCard(
+              icon: Icons.monetization_on,
+              iconColor: FlitColors.gold,
+              label: 'Gold Management',
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const GoldManagementScreen(),
+                ),
+              ),
+            ),
             const SizedBox(height: 24),
           ],
 

--- a/lib/features/admin/flight_school_admin_screen.dart
+++ b/lib/features/admin/flight_school_admin_screen.dart
@@ -1,0 +1,605 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../../game/quiz/flight_school_level.dart';
+import '../../game/quiz/quiz_category.dart';
+import '../../game/quiz/quiz_difficulty.dart';
+
+/// Admin screen for managing Flight School configuration.
+///
+/// Allows editing per-level, per-category difficulty multipliers,
+/// coin rewards, unlock costs, and required level overrides.
+/// All overrides are persisted to a `flight_school_config` JSONB
+/// in the Supabase `remote_config` table.
+class FlightSchoolAdminScreen extends StatefulWidget {
+  const FlightSchoolAdminScreen({super.key});
+
+  @override
+  State<FlightSchoolAdminScreen> createState() =>
+      _FlightSchoolAdminScreenState();
+}
+
+class _FlightSchoolAdminScreenState extends State<FlightSchoolAdminScreen> {
+  SupabaseClient get _client => Supabase.instance.client;
+
+  bool _loading = true;
+  String? _error;
+  int _selectedLevelIndex = 0;
+
+  /// Remote overrides keyed by level id.
+  /// Structure:
+  /// ```json
+  /// {
+  ///   "europe": {
+  ///     "categoryMultipliers": { "stateName": 1.1, ... },
+  ///     "coinReward": 50,
+  ///     "unlockCostOverride": 500,
+  ///     "requiredLevelOverride": 3
+  ///   },
+  ///   ...
+  /// }
+  /// ```
+  Map<String, dynamic> _config = {};
+
+  /// Per-row controllers for editable multiplier fields.
+  final Map<String, TextEditingController> _multiplierControllers = {};
+
+  /// Level-specific setting controllers.
+  final TextEditingController _coinRewardController = TextEditingController();
+  final TextEditingController _unlockCostController = TextEditingController();
+  final TextEditingController _requiredLevelController =
+      TextEditingController();
+
+  FlightSchoolLevel get _selectedLevel =>
+      flightSchoolLevels[_selectedLevelIndex];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadConfig();
+  }
+
+  @override
+  void dispose() {
+    for (final c in _multiplierControllers.values) {
+      c.dispose();
+    }
+    _coinRewardController.dispose();
+    _unlockCostController.dispose();
+    _requiredLevelController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadConfig() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final row = await _client
+          .from('remote_config')
+          .select('value')
+          .eq('key', 'flight_school_config')
+          .maybeSingle();
+
+      if (row != null && row['value'] != null) {
+        final raw = row['value'];
+        if (raw is Map<String, dynamic>) {
+          _config = Map<String, dynamic>.from(raw);
+        } else if (raw is String) {
+          _config = jsonDecode(raw) as Map<String, dynamic>;
+        }
+      }
+
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+      });
+      _syncControllersForLevel();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = 'Failed to load config: $e';
+      });
+    }
+  }
+
+  void _syncControllersForLevel() {
+    final levelId = _selectedLevel.id;
+    final levelConfig =
+        (_config[levelId] as Map<String, dynamic>?) ?? <String, dynamic>{};
+    final multipliers =
+        (levelConfig['categoryMultipliers'] as Map<String, dynamic>?) ??
+        <String, dynamic>{};
+
+    // Dispose old controllers
+    for (final c in _multiplierControllers.values) {
+      c.dispose();
+    }
+    _multiplierControllers.clear();
+
+    // Create controllers for each category
+    for (final cat in QuizCategory.values) {
+      final defaultVal = clueDifficultyMultiplier(cat);
+      final overrideVal = multipliers[cat.name];
+      final value = overrideVal != null
+          ? (overrideVal as num).toDouble()
+          : defaultVal;
+      _multiplierControllers[cat.name] = TextEditingController(
+        text: value.toStringAsFixed(2),
+      );
+    }
+
+    // Level settings
+    final coinReward = levelConfig['coinReward'] as int? ?? 50;
+    final unlockCost =
+        levelConfig['unlockCostOverride'] as int? ?? _selectedLevel.unlockCost;
+    final reqLevel =
+        levelConfig['requiredLevelOverride'] as int? ??
+        _selectedLevel.requiredLevel;
+
+    _coinRewardController.text = coinReward.toString();
+    _unlockCostController.text = unlockCost.toString();
+    _requiredLevelController.text = reqLevel.toString();
+
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _saveCategoryMultiplier(QuizCategory category) async {
+    final controller = _multiplierControllers[category.name];
+    if (controller == null) return;
+
+    final value = double.tryParse(controller.text);
+    if (value == null || value < 0.1 || value > 5.0) {
+      _showSnackBar('Invalid multiplier (0.1 - 5.0)', isError: true);
+      return;
+    }
+
+    final levelId = _selectedLevel.id;
+    _config[levelId] ??= <String, dynamic>{};
+    final levelConfig = _config[levelId] as Map<String, dynamic>;
+    levelConfig['categoryMultipliers'] ??= <String, dynamic>{};
+    final multipliers =
+        levelConfig['categoryMultipliers'] as Map<String, dynamic>;
+    multipliers[category.name] = value;
+
+    await _persistConfig();
+    _showSnackBar(
+      '${category.displayName} multiplier saved: ${value.toStringAsFixed(2)}',
+    );
+  }
+
+  Future<void> _saveLevelSettings() async {
+    final coinReward = int.tryParse(_coinRewardController.text);
+    final unlockCost = int.tryParse(_unlockCostController.text);
+    final reqLevel = int.tryParse(_requiredLevelController.text);
+
+    if (coinReward == null || coinReward < 0) {
+      _showSnackBar('Invalid coin reward', isError: true);
+      return;
+    }
+    if (unlockCost == null || unlockCost < 0) {
+      _showSnackBar('Invalid unlock cost', isError: true);
+      return;
+    }
+    if (reqLevel == null || reqLevel < 0) {
+      _showSnackBar('Invalid required level', isError: true);
+      return;
+    }
+
+    final levelId = _selectedLevel.id;
+    _config[levelId] ??= <String, dynamic>{};
+    final levelConfig = _config[levelId] as Map<String, dynamic>;
+    levelConfig['coinReward'] = coinReward;
+    levelConfig['unlockCostOverride'] = unlockCost;
+    levelConfig['requiredLevelOverride'] = reqLevel;
+
+    await _persistConfig();
+    _showSnackBar('Level settings saved for ${_selectedLevel.name}');
+  }
+
+  Future<void> _persistConfig() async {
+    try {
+      await _client.from('remote_config').upsert({
+        'key': 'flight_school_config',
+        'value': _config,
+      }, onConflict: 'key');
+    } catch (e) {
+      _showSnackBar('Save failed: $e', isError: true);
+    }
+  }
+
+  void _showSnackBar(String message, {bool isError = false}) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError ? FlitColors.error : FlitColors.success,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  IconData _iconForCategory(QuizCategory cat) {
+    switch (cat) {
+      case QuizCategory.stateName:
+        return Icons.map;
+      case QuizCategory.capital:
+        return Icons.location_city;
+      case QuizCategory.nickname:
+        return Icons.label;
+      case QuizCategory.sportsTeam:
+        return Icons.sports_football;
+      case QuizCategory.landmark:
+        return Icons.landscape;
+      case QuizCategory.flagDescription:
+        return Icons.flag;
+      case QuizCategory.stateBird:
+        return Icons.flutter_dash;
+      case QuizCategory.stateFlower:
+        return Icons.local_florist;
+      case QuizCategory.motto:
+        return Icons.format_quote;
+      case QuizCategory.celebrity:
+        return Icons.star;
+      case QuizCategory.filmSetting:
+        return Icons.movie;
+      case QuizCategory.mixed:
+        return Icons.shuffle;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      appBar: AppBar(
+        backgroundColor: FlitColors.backgroundMid,
+        title: const Text('Flight School Config'),
+        centerTitle: true,
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.error_outline,
+                      color: FlitColors.error,
+                      size: 48,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      _error!,
+                      style: const TextStyle(
+                        color: FlitColors.textSecondary,
+                        fontSize: 14,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: _loadConfig,
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                // Level selector dropdown
+                _buildLevelSelector(),
+                const SizedBox(height: 20),
+
+                // Level settings card
+                _buildLevelSettingsCard(),
+                const SizedBox(height: 20),
+
+                // Category multipliers header
+                const Padding(
+                  padding: EdgeInsets.only(bottom: 8),
+                  child: Text(
+                    'CATEGORY DIFFICULTY MULTIPLIERS',
+                    style: TextStyle(
+                      color: FlitColors.textMuted,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      letterSpacing: 1,
+                    ),
+                  ),
+                ),
+
+                // Category rows
+                ...QuizCategory.values.map(_buildCategoryRow),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildLevelSelector() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FlitColors.cardBorder),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<int>(
+          value: _selectedLevelIndex,
+          isExpanded: true,
+          dropdownColor: FlitColors.cardBackground,
+          style: const TextStyle(color: FlitColors.textPrimary, fontSize: 15),
+          items: List.generate(flightSchoolLevels.length, (i) {
+            final level = flightSchoolLevels[i];
+            return DropdownMenuItem(
+              value: i,
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.school,
+                    color: FlitColors.oceanHighlight,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 10),
+                  Text('${level.name} - ${level.subtitle}'),
+                ],
+              ),
+            );
+          }),
+          onChanged: (idx) {
+            if (idx == null) return;
+            setState(() {
+              _selectedLevelIndex = idx;
+            });
+            _syncControllersForLevel();
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLevelSettingsCard() {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FlitColors.cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.settings, color: FlitColors.gold, size: 20),
+              const SizedBox(width: 8),
+              Text(
+                '${_selectedLevel.name} Settings',
+                style: const TextStyle(
+                  color: FlitColors.textPrimary,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          _buildSettingRow(
+            label: 'Coin Reward (base)',
+            controller: _coinRewardController,
+            hint: '50',
+          ),
+          const SizedBox(height: 10),
+          _buildSettingRow(
+            label: 'Unlock Cost Override',
+            controller: _unlockCostController,
+            hint: _selectedLevel.unlockCost.toString(),
+          ),
+          const SizedBox(height: 10),
+          _buildSettingRow(
+            label: 'Required Level Override',
+            controller: _requiredLevelController,
+            hint: _selectedLevel.requiredLevel.toString(),
+          ),
+          const SizedBox(height: 16),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton.icon(
+              onPressed: _saveLevelSettings,
+              icon: const Icon(Icons.save, size: 18),
+              label: const Text('Save Level Settings'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: FlitColors.success,
+                foregroundColor: FlitColors.textPrimary,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSettingRow({
+    required String label,
+    required TextEditingController controller,
+    required String hint,
+  }) {
+    return Row(
+      children: [
+        Expanded(
+          flex: 3,
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: FlitColors.textSecondary,
+              fontSize: 13,
+            ),
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: TextField(
+            controller: controller,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            style: const TextStyle(color: FlitColors.textPrimary, fontSize: 14),
+            decoration: InputDecoration(
+              hintText: hint,
+              hintStyle: const TextStyle(
+                color: FlitColors.textMuted,
+                fontSize: 13,
+              ),
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 10,
+                vertical: 8,
+              ),
+              filled: true,
+              fillColor: FlitColors.backgroundMid,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+                borderSide: const BorderSide(color: FlitColors.cardBorder),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+                borderSide: const BorderSide(color: FlitColors.cardBorder),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+                borderSide: const BorderSide(color: FlitColors.oceanHighlight),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCategoryRow(QuizCategory category) {
+    final controller = _multiplierControllers[category.name];
+    final defaultMultiplier = clueDifficultyMultiplier(category);
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: FlitColors.cardBorder),
+      ),
+      child: Row(
+        children: [
+          // Category icon
+          Icon(
+            _iconForCategory(category),
+            color: FlitColors.oceanHighlight,
+            size: 20,
+          ),
+          const SizedBox(width: 10),
+
+          // Category name
+          Expanded(
+            flex: 3,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  category.displayName,
+                  style: const TextStyle(
+                    color: FlitColors.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                Text(
+                  'Default: ${defaultMultiplier.toStringAsFixed(1)}x',
+                  style: const TextStyle(
+                    color: FlitColors.textMuted,
+                    fontSize: 10,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Editable multiplier field
+          SizedBox(
+            width: 70,
+            child: TextField(
+              controller: controller,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[\d.]')),
+              ],
+              style: const TextStyle(
+                color: FlitColors.textPrimary,
+                fontSize: 13,
+              ),
+              textAlign: TextAlign.center,
+              decoration: InputDecoration(
+                isDense: true,
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 6,
+                  vertical: 6,
+                ),
+                filled: true,
+                fillColor: FlitColors.backgroundMid,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: const BorderSide(color: FlitColors.cardBorder),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: const BorderSide(color: FlitColors.cardBorder),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: const BorderSide(
+                    color: FlitColors.oceanHighlight,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+
+          // Save button
+          SizedBox(
+            width: 36,
+            height: 36,
+            child: IconButton(
+              onPressed: () => _saveCategoryMultiplier(category),
+              icon: const Icon(Icons.save, size: 18),
+              color: FlitColors.success,
+              padding: EdgeInsets.zero,
+              tooltip: 'Save ${category.displayName}',
+              style: IconButton.styleFrom(
+                backgroundColor: FlitColors.success.withOpacity(0.15),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(6),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/admin/gold_management_screen.dart
+++ b/lib/features/admin/gold_management_screen.dart
@@ -1,0 +1,1110 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../../data/models/economy_config.dart';
+import '../../data/services/economy_config_service.dart';
+import '../../game/quiz/flight_school_level.dart';
+
+/// Dedicated admin screen for gold and economy management.
+///
+/// Sections:
+/// 1. Player Gold Operations - gift, remove, set gold by username
+/// 2. Flight School Economy - coin rewards and unlock costs
+/// 3. Economy Config - edit global economy settings
+/// 4. Gold Audit Log - view recent gold transactions
+class GoldManagementScreen extends StatefulWidget {
+  const GoldManagementScreen({super.key});
+
+  @override
+  State<GoldManagementScreen> createState() => _GoldManagementScreenState();
+}
+
+class _GoldManagementScreenState extends State<GoldManagementScreen> {
+  SupabaseClient get _client => Supabase.instance.client;
+
+  // ── Player Gold Operations ──
+  final TextEditingController _playerUsernameController =
+      TextEditingController();
+  final TextEditingController _goldAmountController = TextEditingController();
+  bool _playerOpLoading = false;
+  String? _playerOpResult;
+  bool _playerOpIsError = false;
+
+  // ── Flight School Economy ──
+  Map<String, dynamic> _flightSchoolConfig = {};
+  bool _flightSchoolLoading = true;
+
+  // ── Economy Config ──
+  EconomyConfig? _economyConfig;
+  bool _economyLoading = true;
+  final TextEditingController _dailyScrambleController =
+      TextEditingController();
+  final TextEditingController _freeFlightPerClueController =
+      TextEditingController();
+  final TextEditingController _freeFlightCapController =
+      TextEditingController();
+
+  // ── Gold Audit Log ──
+  List<Map<String, dynamic>> _auditLog = [];
+  bool _auditLoading = false;
+  bool _auditLoaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadFlightSchoolConfig();
+    _loadEconomyConfig();
+  }
+
+  @override
+  void dispose() {
+    _playerUsernameController.dispose();
+    _goldAmountController.dispose();
+    _dailyScrambleController.dispose();
+    _freeFlightPerClueController.dispose();
+    _freeFlightCapController.dispose();
+    super.dispose();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Data loading
+  // ---------------------------------------------------------------------------
+
+  Future<void> _loadFlightSchoolConfig() async {
+    try {
+      final row = await _client
+          .from('remote_config')
+          .select('value')
+          .eq('key', 'flight_school_config')
+          .maybeSingle();
+
+      if (row != null && row['value'] != null) {
+        final raw = row['value'];
+        if (raw is Map<String, dynamic>) {
+          _flightSchoolConfig = Map<String, dynamic>.from(raw);
+        } else if (raw is String) {
+          _flightSchoolConfig = jsonDecode(raw) as Map<String, dynamic>;
+        }
+      }
+    } catch (_) {
+      // Non-fatal: we just show defaults
+    }
+    if (!mounted) return;
+    setState(() => _flightSchoolLoading = false);
+  }
+
+  Future<void> _loadEconomyConfig() async {
+    try {
+      final config = await EconomyConfigService.instance.getConfig();
+      if (!mounted) return;
+      _economyConfig = config;
+      _dailyScrambleController.text = config.earnings.dailyScrambleBaseReward
+          .toString();
+      _freeFlightPerClueController.text = config
+          .earnings
+          .freeFlightPerClueReward
+          .toString();
+      _freeFlightCapController.text = config.earnings.freeFlightDailyCap
+          .toString();
+    } catch (_) {
+      if (!mounted) return;
+      _economyConfig = EconomyConfig.defaults();
+      _dailyScrambleController.text = '150';
+      _freeFlightPerClueController.text = '15';
+      _freeFlightCapController.text = '150';
+    }
+    setState(() => _economyLoading = false);
+  }
+
+  Future<void> _loadAuditLog() async {
+    setState(() {
+      _auditLoading = true;
+    });
+    try {
+      final rows = await _client
+          .from('coin_ledger')
+          .select(
+            'id, user_id, amount, source, created_at, profiles!inner(username)',
+          )
+          .order('created_at', ascending: false)
+          .limit(50);
+
+      if (!mounted) return;
+      setState(() {
+        _auditLog = List<Map<String, dynamic>>.from(rows as List);
+        _auditLoading = false;
+        _auditLoaded = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _auditLoading = false;
+        _auditLoaded = true;
+      });
+      _showSnackBar('Failed to load audit log: $e', isError: true);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Player Gold Operations
+  // ---------------------------------------------------------------------------
+
+  Future<void> _giftGold() async {
+    await _executePlayerGoldOp('gift');
+  }
+
+  Future<void> _removeGold() async {
+    await _executePlayerGoldOp('remove');
+  }
+
+  Future<void> _setGold() async {
+    await _executePlayerGoldOp('set');
+  }
+
+  Future<void> _executePlayerGoldOp(String operation) async {
+    final username = _playerUsernameController.text.trim();
+    final amount = int.tryParse(_goldAmountController.text.trim());
+
+    if (username.isEmpty) {
+      _setOpResult('Please enter a username', isError: true);
+      return;
+    }
+    if (amount == null || amount < 0) {
+      _setOpResult('Please enter a valid amount', isError: true);
+      return;
+    }
+
+    setState(() {
+      _playerOpLoading = true;
+      _playerOpResult = null;
+    });
+
+    try {
+      // Look up user by username
+      final userRow = await _client
+          .from('profiles')
+          .select('id, coins')
+          .eq('username', username)
+          .maybeSingle();
+
+      if (userRow == null) {
+        _setOpResult('User "$username" not found', isError: true);
+        return;
+      }
+
+      final userId = userRow['id'] as String;
+      final currentCoins = userRow['coins'] as int? ?? 0;
+
+      int newCoins;
+      int ledgerAmount;
+      String source;
+
+      switch (operation) {
+        case 'gift':
+          newCoins = currentCoins + amount;
+          ledgerAmount = amount;
+          source = 'admin_gift';
+          break;
+        case 'remove':
+          newCoins = (currentCoins - amount).clamp(0, currentCoins);
+          ledgerAmount = -(currentCoins - newCoins);
+          source = 'admin_remove';
+          break;
+        case 'set':
+          newCoins = amount;
+          ledgerAmount = amount - currentCoins;
+          source = 'admin_set';
+          break;
+        default:
+          return;
+      }
+
+      // Update coins
+      await _client
+          .from('profiles')
+          .update({'coins': newCoins})
+          .eq('id', userId);
+
+      // Record in coin ledger
+      await _client.from('coin_ledger').insert({
+        'user_id': userId,
+        'amount': ledgerAmount,
+        'source': source,
+      });
+
+      final opLabel = operation == 'gift'
+          ? 'Gifted'
+          : operation == 'remove'
+          ? 'Removed'
+          : 'Set to';
+      _setOpResult(
+        '$opLabel ${operation == "set" ? newCoins : amount} coins '
+        'for @$username (was $currentCoins, now $newCoins)',
+      );
+    } catch (e) {
+      _setOpResult('Operation failed: $e', isError: true);
+    }
+  }
+
+  void _setOpResult(String message, {bool isError = false}) {
+    if (!mounted) return;
+    setState(() {
+      _playerOpLoading = false;
+      _playerOpResult = message;
+      _playerOpIsError = isError;
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Flight School Economy
+  // ---------------------------------------------------------------------------
+
+  Future<void> _saveFlightSchoolReward(String levelId, int reward) async {
+    _flightSchoolConfig[levelId] ??= <String, dynamic>{};
+    (_flightSchoolConfig[levelId] as Map<String, dynamic>)['coinReward'] =
+        reward;
+
+    try {
+      await _client.from('remote_config').upsert({
+        'key': 'flight_school_config',
+        'value': _flightSchoolConfig,
+      }, onConflict: 'key');
+      _showSnackBar('Saved reward for $levelId');
+    } catch (e) {
+      _showSnackBar('Save failed: $e', isError: true);
+    }
+  }
+
+  Future<void> _saveFlightSchoolUnlockCost(String levelId, int cost) async {
+    _flightSchoolConfig[levelId] ??= <String, dynamic>{};
+    (_flightSchoolConfig[levelId]
+            as Map<String, dynamic>)['unlockCostOverride'] =
+        cost;
+
+    try {
+      await _client.from('remote_config').upsert({
+        'key': 'flight_school_config',
+        'value': _flightSchoolConfig,
+      }, onConflict: 'key');
+      _showSnackBar('Saved unlock cost for $levelId');
+    } catch (e) {
+      _showSnackBar('Save failed: $e', isError: true);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Economy Config
+  // ---------------------------------------------------------------------------
+
+  Future<void> _saveEconomyConfig() async {
+    final daily = int.tryParse(_dailyScrambleController.text);
+    final perClue = int.tryParse(_freeFlightPerClueController.text);
+    final cap = int.tryParse(_freeFlightCapController.text);
+
+    if (daily == null || perClue == null || cap == null) {
+      _showSnackBar('Invalid values', isError: true);
+      return;
+    }
+
+    if (_economyConfig == null) return;
+
+    final updated = EconomyConfig(
+      earnings: EarningsConfig(
+        dailyScrambleBaseReward: daily,
+        freeFlightPerClueReward: perClue,
+        freeFlightDailyCap: cap,
+      ),
+      shopPriceOverrides: _economyConfig!.shopPriceOverrides,
+      promotions: _economyConfig!.promotions,
+      goldPackages: _economyConfig!.goldPackages,
+    );
+
+    try {
+      await _client.from('economy_config').upsert({
+        'id': 1,
+        'config': updated.toJson(),
+      });
+      EconomyConfigService.instance.invalidateCache();
+      _economyConfig = updated;
+      _showSnackBar('Economy config saved');
+    } catch (e) {
+      _showSnackBar('Save failed: $e', isError: true);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  void _showSnackBar(String message, {bool isError = false}) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError ? FlitColors.error : FlitColors.success,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build
+  // ---------------------------------------------------------------------------
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      appBar: AppBar(
+        backgroundColor: FlitColors.backgroundMid,
+        title: const Text('Gold Management'),
+        centerTitle: true,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _buildPlayerGoldSection(),
+          const SizedBox(height: 16),
+          _buildFlightSchoolEconomySection(),
+          const SizedBox(height: 16),
+          _buildEconomyConfigSection(),
+          const SizedBox(height: 16),
+          _buildAuditLogSection(),
+        ],
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Section 1: Player Gold Operations
+  // ---------------------------------------------------------------------------
+
+  Widget _buildPlayerGoldSection() {
+    return _CollapsibleSection(
+      title: 'Player Gold Operations',
+      icon: Icons.monetization_on,
+      iconColor: FlitColors.gold,
+      initiallyExpanded: true,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Username field
+          TextField(
+            controller: _playerUsernameController,
+            style: const TextStyle(color: FlitColors.textPrimary, fontSize: 14),
+            decoration: _inputDecoration('Username (without @)'),
+          ),
+          const SizedBox(height: 10),
+
+          // Amount field
+          TextField(
+            controller: _goldAmountController,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            style: const TextStyle(color: FlitColors.textPrimary, fontSize: 14),
+            decoration: _inputDecoration('Gold Amount'),
+          ),
+          const SizedBox(height: 14),
+
+          // Action buttons
+          if (_playerOpLoading)
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: CircularProgressIndicator(),
+              ),
+            )
+          else
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _actionButton(
+                  label: 'Gift Gold',
+                  icon: Icons.card_giftcard,
+                  color: FlitColors.success,
+                  onTap: _giftGold,
+                ),
+                _actionButton(
+                  label: 'Remove Gold',
+                  icon: Icons.remove_circle_outline,
+                  color: FlitColors.error,
+                  onTap: _removeGold,
+                ),
+                _actionButton(
+                  label: 'Set Exact',
+                  icon: Icons.edit,
+                  color: FlitColors.oceanHighlight,
+                  onTap: _setGold,
+                ),
+              ],
+            ),
+
+          // Result message
+          if (_playerOpResult != null) ...[
+            const SizedBox(height: 12),
+            Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color:
+                    (_playerOpIsError ? FlitColors.error : FlitColors.success)
+                        .withOpacity(0.15),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: _playerOpIsError
+                      ? FlitColors.error
+                      : FlitColors.success,
+                  width: 0.5,
+                ),
+              ),
+              child: Text(
+                _playerOpResult!,
+                style: TextStyle(
+                  color: _playerOpIsError
+                      ? FlitColors.error
+                      : FlitColors.success,
+                  fontSize: 12,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Section 2: Flight School Economy
+  // ---------------------------------------------------------------------------
+
+  Widget _buildFlightSchoolEconomySection() {
+    return _CollapsibleSection(
+      title: 'Flight School Economy',
+      icon: Icons.school,
+      iconColor: FlitColors.oceanHighlight,
+      child: _flightSchoolLoading
+          ? const Center(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: CircularProgressIndicator(),
+              ),
+            )
+          : Column(
+              children: flightSchoolLevels.map((level) {
+                final levelConfig =
+                    (_flightSchoolConfig[level.id] as Map<String, dynamic>?) ??
+                    <String, dynamic>{};
+                final coinReward = levelConfig['coinReward'] as int? ?? 50;
+                final unlockCost =
+                    levelConfig['unlockCostOverride'] as int? ??
+                    level.unlockCost;
+
+                return _FlightSchoolLevelRow(
+                  level: level,
+                  coinReward: coinReward,
+                  unlockCost: unlockCost,
+                  onSaveReward: (reward) =>
+                      _saveFlightSchoolReward(level.id, reward),
+                  onSaveUnlockCost: (cost) =>
+                      _saveFlightSchoolUnlockCost(level.id, cost),
+                );
+              }).toList(),
+            ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Section 3: Economy Config
+  // ---------------------------------------------------------------------------
+
+  Widget _buildEconomyConfigSection() {
+    return _CollapsibleSection(
+      title: 'Economy Config',
+      icon: Icons.tune,
+      iconColor: FlitColors.accent,
+      child: _economyLoading
+          ? const Center(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: CircularProgressIndicator(),
+              ),
+            )
+          : Column(
+              children: [
+                _configRow(
+                  label: 'Daily Scramble Base Reward',
+                  controller: _dailyScrambleController,
+                ),
+                const SizedBox(height: 10),
+                _configRow(
+                  label: 'Free Flight Per-Clue Reward',
+                  controller: _freeFlightPerClueController,
+                ),
+                const SizedBox(height: 10),
+                _configRow(
+                  label: 'Free Flight Daily Cap',
+                  controller: _freeFlightCapController,
+                ),
+                const SizedBox(height: 14),
+                if (_economyConfig != null) ...[
+                  // Promotions summary
+                  Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: FlitColors.backgroundMid,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.local_offer,
+                          color: FlitColors.textMuted,
+                          size: 16,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          '${_economyConfig!.promotions.length} promotions '
+                          '(${_economyConfig!.activePromotions.length} active)',
+                          style: const TextStyle(
+                            color: FlitColors.textSecondary,
+                            fontSize: 12,
+                          ),
+                        ),
+                        const Spacer(),
+                        Text(
+                          '${_economyConfig!.goldPackages.length} gold packages',
+                          style: const TextStyle(
+                            color: FlitColors.textSecondary,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 14),
+                ],
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: ElevatedButton.icon(
+                    onPressed: _saveEconomyConfig,
+                    icon: const Icon(Icons.save, size: 18),
+                    label: const Text('Save Economy Config'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: FlitColors.success,
+                      foregroundColor: FlitColors.textPrimary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Section 4: Gold Audit Log
+  // ---------------------------------------------------------------------------
+
+  Widget _buildAuditLogSection() {
+    return _CollapsibleSection(
+      title: 'Gold Audit Log',
+      icon: Icons.receipt_long,
+      iconColor: FlitColors.gold,
+      onExpansionChanged: (expanded) {
+        if (expanded && !_auditLoaded) {
+          _loadAuditLog();
+        }
+      },
+      child: _auditLoading
+          ? const Center(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: CircularProgressIndicator(),
+              ),
+            )
+          : !_auditLoaded
+          ? const Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'Expand to load audit log',
+                style: TextStyle(color: FlitColors.textMuted, fontSize: 13),
+              ),
+            )
+          : _auditLog.isEmpty
+          ? const Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'No audit log entries found',
+                style: TextStyle(color: FlitColors.textMuted, fontSize: 13),
+              ),
+            )
+          : Column(
+              children: [
+                // Refresh button
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    onPressed: _loadAuditLog,
+                    icon: const Icon(Icons.refresh, size: 16),
+                    label: const Text('Refresh'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: FlitColors.textSecondary,
+                    ),
+                  ),
+                ),
+                ...List.generate(
+                  _auditLog.length,
+                  (i) => _buildAuditRow(_auditLog[i]),
+                ),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildAuditRow(Map<String, dynamic> entry) {
+    final amount = entry['amount'] as int? ?? 0;
+    final source = entry['source'] as String? ?? 'unknown';
+    final createdAt = entry['created_at'] as String? ?? '';
+    final profiles = entry['profiles'] as Map<String, dynamic>?;
+    final username = profiles?['username'] as String? ?? '???';
+
+    final isPositive = amount >= 0;
+    final color = isPositive ? FlitColors.success : FlitColors.error;
+    final sign = isPositive ? '+' : '';
+
+    // Parse date for display
+    String dateStr = '';
+    final dt = DateTime.tryParse(createdAt);
+    if (dt != null) {
+      final local = dt.toLocal();
+      dateStr =
+          '${local.month}/${local.day} ${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: FlitColors.backgroundMid,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        children: [
+          // Amount
+          SizedBox(
+            width: 70,
+            child: Text(
+              '$sign$amount',
+              style: TextStyle(
+                color: color,
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          // Username
+          Expanded(
+            child: Text(
+              '@$username',
+              style: const TextStyle(
+                color: FlitColors.textPrimary,
+                fontSize: 12,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          // Source
+          SizedBox(
+            width: 80,
+            child: Text(
+              source,
+              style: const TextStyle(color: FlitColors.textMuted, fontSize: 10),
+              textAlign: TextAlign.right,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          // Date
+          SizedBox(
+            width: 70,
+            child: Text(
+              dateStr,
+              style: const TextStyle(color: FlitColors.textMuted, fontSize: 10),
+              textAlign: TextAlign.right,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared helpers
+  // ---------------------------------------------------------------------------
+
+  InputDecoration _inputDecoration(String hint) {
+    return InputDecoration(
+      hintText: hint,
+      hintStyle: const TextStyle(color: FlitColors.textMuted, fontSize: 13),
+      isDense: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      filled: true,
+      fillColor: FlitColors.backgroundMid,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: FlitColors.cardBorder),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: FlitColors.cardBorder),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: FlitColors.oceanHighlight),
+      ),
+    );
+  }
+
+  Widget _actionButton({
+    required String label,
+    required IconData icon,
+    required Color color,
+    required VoidCallback onTap,
+  }) {
+    return ElevatedButton.icon(
+      onPressed: onTap,
+      icon: Icon(icon, size: 16),
+      label: Text(label, style: const TextStyle(fontSize: 12)),
+      style: ElevatedButton.styleFrom(
+        backgroundColor: color.withOpacity(0.2),
+        foregroundColor: color,
+        side: BorderSide(color: color.withOpacity(0.5)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      ),
+    );
+  }
+
+  Widget _configRow({
+    required String label,
+    required TextEditingController controller,
+  }) {
+    return Row(
+      children: [
+        Expanded(
+          flex: 3,
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: FlitColors.textSecondary,
+              fontSize: 13,
+            ),
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: TextField(
+            controller: controller,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            style: const TextStyle(color: FlitColors.textPrimary, fontSize: 14),
+            decoration: InputDecoration(
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 10,
+                vertical: 8,
+              ),
+              filled: true,
+              fillColor: FlitColors.backgroundMid,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+                borderSide: const BorderSide(color: FlitColors.cardBorder),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+                borderSide: const BorderSide(color: FlitColors.cardBorder),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+                borderSide: const BorderSide(color: FlitColors.oceanHighlight),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// =============================================================================
+// Collapsible Section
+// =============================================================================
+
+class _CollapsibleSection extends StatelessWidget {
+  const _CollapsibleSection({
+    required this.title,
+    required this.icon,
+    required this.iconColor,
+    required this.child,
+    this.initiallyExpanded = false,
+    this.onExpansionChanged,
+  });
+
+  final String title;
+  final IconData icon;
+  final Color iconColor;
+  final Widget child;
+  final bool initiallyExpanded;
+  final ValueChanged<bool>? onExpansionChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FlitColors.cardBorder),
+      ),
+      child: Theme(
+        data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+        child: ExpansionTile(
+          initiallyExpanded: initiallyExpanded,
+          onExpansionChanged: onExpansionChanged,
+          tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+          childrenPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 8,
+          ),
+          leading: Icon(icon, color: iconColor, size: 22),
+          title: Text(
+            title,
+            style: const TextStyle(
+              color: FlitColors.textPrimary,
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          iconColor: FlitColors.textMuted,
+          collapsedIconColor: FlitColors.textMuted,
+          children: [child],
+        ),
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// Flight School Level Row
+// =============================================================================
+
+class _FlightSchoolLevelRow extends StatefulWidget {
+  const _FlightSchoolLevelRow({
+    required this.level,
+    required this.coinReward,
+    required this.unlockCost,
+    required this.onSaveReward,
+    required this.onSaveUnlockCost,
+  });
+
+  final FlightSchoolLevel level;
+  final int coinReward;
+  final int unlockCost;
+  final ValueChanged<int> onSaveReward;
+  final ValueChanged<int> onSaveUnlockCost;
+
+  @override
+  State<_FlightSchoolLevelRow> createState() => _FlightSchoolLevelRowState();
+}
+
+class _FlightSchoolLevelRowState extends State<_FlightSchoolLevelRow> {
+  late TextEditingController _rewardController;
+  late TextEditingController _costController;
+
+  @override
+  void initState() {
+    super.initState();
+    _rewardController = TextEditingController(
+      text: widget.coinReward.toString(),
+    );
+    _costController = TextEditingController(text: widget.unlockCost.toString());
+  }
+
+  @override
+  void didUpdateWidget(_FlightSchoolLevelRow old) {
+    super.didUpdateWidget(old);
+    if (old.coinReward != widget.coinReward) {
+      _rewardController.text = widget.coinReward.toString();
+    }
+    if (old.unlockCost != widget.unlockCost) {
+      _costController.text = widget.unlockCost.toString();
+    }
+  }
+
+  @override
+  void dispose() {
+    _rewardController.dispose();
+    _costController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: FlitColors.backgroundMid,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Level name
+          Row(
+            children: [
+              Icon(Icons.school, color: FlitColors.oceanHighlight, size: 16),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  '${widget.level.name} (Lv.${widget.level.requiredLevel})',
+                  style: const TextStyle(
+                    color: FlitColors.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+
+          // Reward and cost row
+          Row(
+            children: [
+              // Coin reward
+              const Text(
+                'Reward:',
+                style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
+              ),
+              const SizedBox(width: 4),
+              SizedBox(
+                width: 55,
+                child: TextField(
+                  controller: _rewardController,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  style: const TextStyle(
+                    color: FlitColors.textPrimary,
+                    fontSize: 12,
+                  ),
+                  textAlign: TextAlign.center,
+                  decoration: InputDecoration(
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 4,
+                      vertical: 4,
+                    ),
+                    filled: true,
+                    fillColor: FlitColors.cardBackground,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(
+                        color: FlitColors.cardBorder,
+                      ),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(
+                        color: FlitColors.cardBorder,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 4),
+              SizedBox(
+                width: 28,
+                height: 28,
+                child: IconButton(
+                  onPressed: () {
+                    final val = int.tryParse(_rewardController.text);
+                    if (val != null && val >= 0) {
+                      widget.onSaveReward(val);
+                    }
+                  },
+                  icon: const Icon(Icons.save, size: 14),
+                  color: FlitColors.success,
+                  padding: EdgeInsets.zero,
+                ),
+              ),
+              const Spacer(),
+
+              // Unlock cost
+              const Text(
+                'Unlock:',
+                style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
+              ),
+              const SizedBox(width: 4),
+              SizedBox(
+                width: 60,
+                child: TextField(
+                  controller: _costController,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  style: const TextStyle(
+                    color: FlitColors.textPrimary,
+                    fontSize: 12,
+                  ),
+                  textAlign: TextAlign.center,
+                  decoration: InputDecoration(
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 4,
+                      vertical: 4,
+                    ),
+                    filled: true,
+                    fillColor: FlitColors.cardBackground,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(
+                        color: FlitColors.cardBorder,
+                      ),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(
+                        color: FlitColors.cardBorder,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 4),
+              SizedBox(
+                width: 28,
+                height: 28,
+                child: IconButton(
+                  onPressed: () {
+                    final val = int.tryParse(_costController.text);
+                    if (val != null && val >= 0) {
+                      widget.onSaveUnlockCost(val);
+                    }
+                  },
+                  icon: const Icon(Icons.save, size: 14),
+                  color: FlitColors.success,
+                  padding: EdgeInsets.zero,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -21,7 +21,8 @@ import '../matchmaking/find_challenger_screen.dart';
 import '../play/practice_screen.dart';
 import '../play/region_select_screen.dart';
 import '../profile/profile_screen.dart';
-import '../quiz/quiz_setup_screen.dart';
+import '../quiz/daily_briefing_screen.dart';
+import '../quiz/flight_school_screen.dart';
 import '../shop/shop_screen.dart';
 import 'announcement_banner.dart';
 
@@ -411,7 +412,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
               title: 'Flight School',
               subtitle: 'Quiz yourself on states, capitals & more',
               icon: Icons.quiz_rounded,
-              onTap: () => _closeSheetAndNavigate(ctx, const QuizSetupScreen()),
+              onTap: () =>
+                  _closeSheetAndNavigate(ctx, const FlightSchoolScreen()),
+            ),
+            const SizedBox(height: 10),
+            _GameModeCard(
+              title: 'Daily Briefing',
+              subtitle: 'Daily quiz challenge — same for all pilots',
+              icon: Icons.today_rounded,
+              onTap: () =>
+                  _closeSheetAndNavigate(ctx, const DailyBriefingScreen()),
             ),
             const SizedBox(height: 10),
             _GameModeCard(

--- a/lib/features/leaderboard/leaderboard_screen.dart
+++ b/lib/features/leaderboard/leaderboard_screen.dart
@@ -76,6 +76,7 @@ class LeaderboardScreen extends StatefulWidget {
 class _LeaderboardScreenState extends State<LeaderboardScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _modeTabController;
+  LeaderboardMode _currentMode = LeaderboardMode.dailyScramble;
   TimeframeTab _timeframe = TimeframeTab.today;
   bool _loading = true;
   String? _errorMessage;
@@ -84,12 +85,10 @@ class _LeaderboardScreenState extends State<LeaderboardScreen>
 
   String? get _userId => Supabase.instance.client.auth.currentUser?.id;
 
-  bool get _isDailyScramble => _modeTabController.index == 0;
-
   @override
   void initState() {
     super.initState();
-    _modeTabController = TabController(length: 2, vsync: this);
+    _modeTabController = TabController(length: 3, vsync: this);
     _modeTabController.addListener(_onModeChanged);
     _loadData();
   }
@@ -103,6 +102,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen>
 
   void _onModeChanged() {
     if (!_modeTabController.indexIsChanging) return;
+    _currentMode = LeaderboardMode.values[_modeTabController.index];
     _loadData();
   }
 
@@ -119,7 +119,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen>
 
     try {
       final entries = await LeaderboardService.instance.fetchModeLeaderboard(
-        isDailyScramble: _isDailyScramble,
+        mode: _currentMode,
         timeframe: _timeframe,
       );
 
@@ -148,7 +148,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen>
 
     final rank = await LeaderboardService.instance.fetchPlayerRank(
       userId,
-      isDailyScramble: _isDailyScramble,
+      mode: _currentMode,
     );
     if (mounted) {
       setState(() => _playerRank = rank);
@@ -177,8 +177,9 @@ class _LeaderboardScreenState extends State<LeaderboardScreen>
           fontWeight: FontWeight.w500,
         ),
         tabs: const [
-          Tab(text: 'DAILY SCRAMBLE'),
-          Tab(text: 'TRAINING FLIGHT'),
+          Tab(text: 'SCRAMBLE'),
+          Tab(text: 'TRAINING'),
+          Tab(text: 'BRIEFING'),
         ],
       ),
     ),

--- a/lib/features/play/region_select_screen.dart
+++ b/lib/features/play/region_select_screen.dart
@@ -20,17 +20,27 @@ class RegionSelectScreen extends ConsumerWidget {
   static int unlockCost(GameRegion region) {
     switch (region) {
       case GameRegion.world:
-        return 0; // Always unlocked
+        return 0;
       case GameRegion.usStates:
-        return 500; // Level 3
+        return 500;
       case GameRegion.canadianProvinces:
-        return 750; // Level 4
+        return 750;
       case GameRegion.ukCounties:
-        return 1000; // Level 5
+        return 1000;
       case GameRegion.caribbean:
-        return 2000; // Level 7
+        return 2000;
       case GameRegion.ireland:
-        return 5000; // Level 10
+        return 5000;
+      case GameRegion.europe:
+        return 500;
+      case GameRegion.africa:
+        return 1000;
+      case GameRegion.asia:
+        return 1500;
+      case GameRegion.latinAmerica:
+        return 2000;
+      case GameRegion.oceania:
+        return 2500;
     }
   }
 
@@ -499,6 +509,16 @@ class _RegionCard extends StatelessWidget {
         return Icons.grass;
       case GameRegion.canadianProvinces:
         return Icons.landscape;
+      case GameRegion.europe:
+        return Icons.castle;
+      case GameRegion.africa:
+        return Icons.terrain;
+      case GameRegion.asia:
+        return Icons.temple_buddhist;
+      case GameRegion.latinAmerica:
+        return Icons.festival;
+      case GameRegion.oceania:
+        return Icons.beach_access;
     }
   }
 }

--- a/lib/features/quiz/daily_briefing_screen.dart
+++ b/lib/features/quiz/daily_briefing_screen.dart
@@ -1,0 +1,580 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../../game/quiz/daily_briefing.dart';
+import '../../game/quiz/quiz_category.dart';
+import '../../game/quiz/quiz_difficulty.dart';
+import '../../game/quiz/quiz_session.dart';
+import 'quiz_game_screen.dart';
+
+/// Daily Flight Briefing screen.
+///
+/// Shows today's deterministically generated quiz settings (level, category,
+/// difficulty, mode) and lets the player start the briefing. Players who have
+/// already completed today's briefing see a "CLEARED" badge and their score.
+///
+/// After completing the quiz, the score is submitted to the
+/// `daily_briefing_scores` table.
+class DailyBriefingScreen extends StatefulWidget {
+  const DailyBriefingScreen({super.key});
+
+  @override
+  State<DailyBriefingScreen> createState() => _DailyBriefingScreenState();
+}
+
+class _DailyBriefingScreenState extends State<DailyBriefingScreen>
+    with SingleTickerProviderStateMixin {
+  late final DailyBriefing _briefing;
+  late final AnimationController _pulseController;
+
+  bool _loading = true;
+  bool _completedToday = false;
+  int? _previousScore;
+  int? _previousTimeMs;
+
+  @override
+  void initState() {
+    super.initState();
+    _briefing = DailyBriefing.today();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    )..repeat(reverse: true);
+    _checkCompletion();
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _checkCompletion() async {
+    final userId = Supabase.instance.client.auth.currentUser?.id;
+    if (userId == null) {
+      if (mounted) setState(() => _loading = false);
+      return;
+    }
+
+    try {
+      final row = await Supabase.instance.client
+          .from('daily_briefing_scores')
+          .select('score, time_ms')
+          .eq('user_id', userId)
+          .eq('date_key', _briefing.dateKey)
+          .maybeSingle();
+
+      if (mounted) {
+        setState(() {
+          _completedToday = row != null;
+          _previousScore = row?['score'] as int?;
+          _previousTimeMs = row?['time_ms'] as int?;
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  void _startBriefing() {
+    if (_completedToday) return;
+
+    Navigator.of(context)
+        .push(
+          MaterialPageRoute<QuizSummary>(
+            builder: (_) => QuizGameScreen(
+              mode: _briefing.mode,
+              category: _briefing.category,
+              region: _briefing.level.region,
+              difficulty: _briefing.difficulty,
+              seed: _briefing.seed,
+              flightSchoolLevelId: _briefing.level.id,
+              dailyBriefingDateKey: _briefing.dateKey,
+            ),
+          ),
+        )
+        .then((summary) {
+          // The QuizGameScreen pushes QuizResultsScreen, but for the daily
+          // briefing we intercept the pop result to submit the score.
+          // QuizGameScreen pops without a result (navigates to results itself),
+          // so we check completion when returning.
+          _checkCompletion();
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build
+  // ---------------------------------------------------------------------------
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      appBar: AppBar(
+        backgroundColor: FlitColors.backgroundMid,
+        title: const Text('Daily Flight Briefing'),
+        centerTitle: true,
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : SingleChildScrollView(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                children: [
+                  _buildMissionHeader(),
+                  const SizedBox(height: 24),
+                  _buildBriefingCard(),
+                  const SizedBox(height: 24),
+                  _buildActionArea(),
+                  const SizedBox(height: 32),
+                  _buildInfoFooter(),
+                ],
+              ),
+            ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mission header
+  // ---------------------------------------------------------------------------
+
+  Widget _buildMissionHeader() {
+    return Column(
+      children: [
+        // Date badge
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          decoration: BoxDecoration(
+            color: FlitColors.accent.withValues(alpha: 0.15),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: FlitColors.accent.withValues(alpha: 0.4)),
+          ),
+          child: Text(
+            _briefing.dateKey,
+            style: const TextStyle(
+              color: FlitColors.accent,
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 1.5,
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        // Title
+        const Text(
+          'DAILY FLIGHT BRIEFING',
+          style: TextStyle(
+            color: FlitColors.textPrimary,
+            fontSize: 22,
+            fontWeight: FontWeight.w900,
+            letterSpacing: 2.0,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          _briefing.missionSubtitle,
+          style: const TextStyle(
+            color: FlitColors.textSecondary,
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 1.0,
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Briefing card (shows today's parameters)
+  // ---------------------------------------------------------------------------
+
+  Widget _buildBriefingCard() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: FlitColors.cardBorder),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.3),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Section title
+          Row(
+            children: [
+              Container(
+                width: 4,
+                height: 18,
+                decoration: BoxDecoration(
+                  color: FlitColors.accent,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(width: 10),
+              const Text(
+                'MISSION PARAMETERS',
+                style: TextStyle(
+                  color: FlitColors.accent,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 1.5,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+
+          // Parameters grid
+          _buildParameter(
+            'SORTIE',
+            _briefing.level.name,
+            _briefing.level.subtitle,
+            Icons.public,
+          ),
+          const SizedBox(height: 14),
+          _buildParameter(
+            'INTEL TYPE',
+            _briefing.category.displayName,
+            _briefing.category.description,
+            _categoryIcon(_briefing.category),
+          ),
+          const SizedBox(height: 14),
+          _buildParameter(
+            'ALTITUDE',
+            _briefing.difficulty.displayName,
+            _briefing.difficulty.description,
+            _difficultyIcon(_briefing.difficulty),
+          ),
+          const SizedBox(height: 14),
+          _buildParameter(
+            'MISSION TYPE',
+            _briefing.mode.displayName,
+            _briefing.estimatedDuration,
+            _modeIcon(_briefing.mode),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildParameter(
+    String label,
+    String value,
+    String subtitle,
+    IconData icon,
+  ) {
+    return Row(
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: FlitColors.backgroundDark,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Icon(icon, color: FlitColors.gold, size: 20),
+        ),
+        const SizedBox(width: 14),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: TextStyle(
+                  color: FlitColors.textMuted.withValues(alpha: 0.8),
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 1.2,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                value,
+                style: const TextStyle(
+                  color: FlitColors.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Text(
+                subtitle,
+                style: const TextStyle(
+                  color: FlitColors.textSecondary,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Action area (button or completed badge)
+  // ---------------------------------------------------------------------------
+
+  Widget _buildActionArea() {
+    if (_completedToday) {
+      return _buildCompletedBadge();
+    }
+    return _buildStartButton();
+  }
+
+  Widget _buildCompletedBadge() {
+    final timeStr = _formatTime(_previousTimeMs ?? 0);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: FlitColors.success.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: FlitColors.success.withValues(alpha: 0.4)),
+      ),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.check_circle, color: FlitColors.success, size: 28),
+              const SizedBox(width: 10),
+              const Text(
+                'CLEARED',
+                style: TextStyle(
+                  color: FlitColors.success,
+                  fontSize: 20,
+                  fontWeight: FontWeight.w900,
+                  letterSpacing: 2.0,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _buildStatChip('SCORE', '${_previousScore ?? 0}'),
+              const SizedBox(width: 20),
+              _buildStatChip('TIME', timeStr),
+            ],
+          ),
+          const SizedBox(height: 10),
+          const Text(
+            'Return tomorrow for a new briefing',
+            style: TextStyle(color: FlitColors.textSecondary, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatChip(String label, String value) {
+    return Column(
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            color: FlitColors.textMuted.withValues(alpha: 0.8),
+            fontSize: 10,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 1.0,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          value,
+          style: const TextStyle(
+            color: FlitColors.textPrimary,
+            fontSize: 22,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStartButton() {
+    return AnimatedBuilder(
+      animation: _pulseController,
+      builder: (context, child) {
+        final scale = 1.0 + _pulseController.value * 0.02;
+        return Transform.scale(scale: scale, child: child);
+      },
+      child: SizedBox(
+        width: double.infinity,
+        height: 56,
+        child: ElevatedButton(
+          onPressed: _startBriefing,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: FlitColors.accent,
+            foregroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+            ),
+            elevation: 6,
+            shadowColor: FlitColors.accent.withValues(alpha: 0.5),
+          ),
+          child: const Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.flight_takeoff, size: 22),
+              SizedBox(width: 10),
+              Text(
+                'BEGIN BRIEFING',
+                style: TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.w900,
+                  letterSpacing: 2.0,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Info footer
+  // ---------------------------------------------------------------------------
+
+  Widget _buildInfoFooter() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: FlitColors.backgroundMid,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FlitColors.cardBorder.withValues(alpha: 0.5)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.info_outline, color: FlitColors.textMuted, size: 16),
+              const SizedBox(width: 8),
+              const Text(
+                'OPERATIONAL BRIEF',
+                style: TextStyle(
+                  color: FlitColors.textMuted,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 1.0,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          _buildInfoLine('Every pilot receives the same mission parameters.'),
+          _buildInfoLine('One sortie per day. Make it count.'),
+          _buildInfoLine('No level unlock required for daily briefings.'),
+          _buildInfoLine(
+            'Scores are posted to the Flight Briefing leaderboard.',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoLine(String text) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '  -  ',
+            style: TextStyle(color: FlitColors.textMuted, fontSize: 12),
+          ),
+          Expanded(
+            child: Text(
+              text,
+              style: const TextStyle(
+                color: FlitColors.textSecondary,
+                fontSize: 12,
+                height: 1.4,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  String _formatTime(int ms) {
+    if (ms <= 0) return '--';
+    final seconds = (ms / 1000).floor();
+    final minutes = seconds ~/ 60;
+    final secs = seconds % 60;
+    return '$minutes:${secs.toString().padLeft(2, '0')}';
+  }
+
+  IconData _categoryIcon(QuizCategory category) {
+    switch (category) {
+      case QuizCategory.stateName:
+        return Icons.map;
+      case QuizCategory.capital:
+        return Icons.location_city;
+      case QuizCategory.nickname:
+        return Icons.label;
+      case QuizCategory.sportsTeam:
+        return Icons.sports_football;
+      case QuizCategory.landmark:
+        return Icons.landscape;
+      case QuizCategory.flagDescription:
+        return Icons.flag;
+      case QuizCategory.stateBird:
+        return Icons.flutter_dash;
+      case QuizCategory.stateFlower:
+        return Icons.local_florist;
+      case QuizCategory.motto:
+        return Icons.format_quote;
+      case QuizCategory.celebrity:
+        return Icons.star;
+      case QuizCategory.filmSetting:
+        return Icons.movie;
+      case QuizCategory.mixed:
+        return Icons.shuffle;
+    }
+  }
+
+  IconData _difficultyIcon(QuizDifficulty difficulty) {
+    switch (difficulty) {
+      case QuizDifficulty.easy:
+        return Icons.cloud;
+      case QuizDifficulty.medium:
+        return Icons.cloud_queue;
+      case QuizDifficulty.hard:
+        return Icons.thunderstorm;
+    }
+  }
+
+  IconData _modeIcon(QuizMode mode) {
+    switch (mode) {
+      case QuizMode.allStates:
+        return Icons.checklist;
+      case QuizMode.timeTrial:
+        return Icons.timer;
+      case QuizMode.rapidFire:
+        return Icons.bolt;
+      case QuizMode.typeIn:
+        return Icons.keyboard;
+    }
+  }
+}

--- a/lib/features/quiz/flight_school_screen.dart
+++ b/lib/features/quiz/flight_school_screen.dart
@@ -1,0 +1,590 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../../data/providers/account_provider.dart';
+import '../../game/quiz/flight_school_level.dart';
+import 'h2h_challenge_screen.dart';
+import 'quiz_setup_screen.dart';
+
+/// Flight School level selection screen.
+///
+/// Shows all available flight school levels (geographic regions) as cards
+/// with progress tracking, grades, and unlock requirements.
+/// Levels can be unlocked by reaching the required player level OR
+/// by spending coins for early access.
+class FlightSchoolScreen extends ConsumerStatefulWidget {
+  const FlightSchoolScreen({super.key});
+
+  @override
+  ConsumerState<FlightSchoolScreen> createState() => _FlightSchoolScreenState();
+}
+
+class _FlightSchoolScreenState extends ConsumerState<FlightSchoolScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final accountState = ref.watch(accountProvider);
+    final notifier = ref.read(accountProvider.notifier);
+    final playerLevel = accountState.currentPlayer.level;
+    final playerCoins = accountState.currentPlayer.coins;
+    final progressMap = accountState.flightSchoolProgress;
+
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      appBar: AppBar(
+        backgroundColor: FlitColors.backgroundMid,
+        title: const Text(
+          'Flight School',
+          style: TextStyle(color: FlitColors.textPrimary),
+        ),
+        centerTitle: true,
+        iconTheme: const IconThemeData(color: FlitColors.textPrimary),
+        actions: [
+          // Coin balance
+          Container(
+            margin: const EdgeInsets.only(right: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: FlitColors.gold.withOpacity(0.15),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.monetization_on,
+                  color: FlitColors.gold,
+                  size: 18,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  '$playerCoins',
+                  style: const TextStyle(
+                    color: FlitColors.gold,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => Navigator.of(context).push(
+          MaterialPageRoute<void>(builder: (_) => const H2HChallengeScreen()),
+        ),
+        backgroundColor: FlitColors.accent,
+        foregroundColor: FlitColors.textPrimary,
+        icon: const Icon(Icons.sports_mma, size: 20),
+        label: const Text(
+          'H2H',
+          style: TextStyle(fontWeight: FontWeight.w900, letterSpacing: 1),
+        ),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            _buildHeader(),
+            Expanded(
+              child: ListView.builder(
+                padding: const EdgeInsets.all(16),
+                itemCount: flightSchoolLevels.length,
+                itemBuilder: (context, index) {
+                  final level = flightSchoolLevels[index];
+                  final isUnlocked = notifier.isFlightSchoolLevelUnlocked(
+                    level,
+                  );
+                  final progress =
+                      progressMap[level.id] ?? const FlightSchoolProgress();
+                  final canBuyEarly =
+                      !isUnlocked &&
+                      level.unlockCost > 0 &&
+                      playerCoins >= level.unlockCost;
+
+                  return _LevelCard(
+                    level: level,
+                    progress: progress,
+                    isUnlocked: isUnlocked,
+                    canBuyEarly: canBuyEarly,
+                    playerLevel: playerLevel,
+                    playerCoins: playerCoins,
+                    onTap: isUnlocked ? () => _navigateToSetup(level) : null,
+                    onBuy: canBuyEarly
+                        ? () => _buyLevel(level, notifier)
+                        : null,
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() => Container(
+    width: double.infinity,
+    padding: const EdgeInsets.all(16),
+    decoration: const BoxDecoration(
+      color: FlitColors.backgroundMid,
+      border: Border(bottom: BorderSide(color: FlitColors.cardBorder)),
+    ),
+    child: Column(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: FlitColors.gold.withOpacity(0.15),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: const Icon(Icons.school, color: FlitColors.gold, size: 32),
+        ),
+        const SizedBox(height: 10),
+        const Text(
+          'Choose your training region',
+          style: TextStyle(color: FlitColors.textSecondary, fontSize: 14),
+        ),
+        const SizedBox(height: 6),
+        _buildOverallProgress(),
+      ],
+    ),
+  );
+
+  Widget _buildOverallProgress() {
+    final progressMap = ref.watch(accountProvider).flightSchoolProgress;
+    final completed = flightSchoolLevels.where((l) {
+      final p = progressMap[l.id];
+      return p != null && p.completions > 0;
+    }).length;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: FlitColors.accent.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: FlitColors.accent.withOpacity(0.25)),
+      ),
+      child: Text(
+        '$completed / ${flightSchoolLevels.length} regions completed',
+        style: const TextStyle(
+          color: FlitColors.accent,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  void _navigateToSetup(FlightSchoolLevel level) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (_) => QuizSetupScreen(level: level)),
+    );
+  }
+
+  void _buyLevel(FlightSchoolLevel level, AccountNotifier notifier) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: FlitColors.cardBackground,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: const BorderSide(color: FlitColors.cardBorder),
+        ),
+        title: Row(
+          children: [
+            const Icon(Icons.lock_open, color: FlitColors.gold, size: 24),
+            const SizedBox(width: 8),
+            Text(
+              'Unlock ${level.name}?',
+              style: const TextStyle(
+                color: FlitColors.textPrimary,
+                fontSize: 18,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ],
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Unlock ${level.name} early for ${level.unlockCost} coins.',
+              style: const TextStyle(
+                color: FlitColors.textSecondary,
+                fontSize: 14,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Or reach level ${level.requiredLevel} to unlock free.',
+              style: const TextStyle(color: FlitColors.textMuted, fontSize: 12),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text(
+              'Cancel',
+              style: TextStyle(color: FlitColors.textMuted),
+            ),
+          ),
+          ElevatedButton.icon(
+            onPressed: () {
+              final success = notifier.unlockFlightSchoolLevel(
+                level.id,
+                level.unlockCost,
+              );
+              Navigator.of(ctx).pop();
+              if (success) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text('${level.name} unlocked!'),
+                    backgroundColor: FlitColors.success,
+                  ),
+                );
+              } else {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Not enough coins'),
+                    backgroundColor: FlitColors.error,
+                  ),
+                );
+              }
+            },
+            icon: const Icon(Icons.monetization_on, size: 18),
+            label: Text('${level.unlockCost} coins'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: FlitColors.gold,
+              foregroundColor: FlitColors.backgroundDark,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LevelCard extends StatelessWidget {
+  const _LevelCard({
+    required this.level,
+    required this.progress,
+    required this.isUnlocked,
+    required this.canBuyEarly,
+    required this.playerLevel,
+    required this.playerCoins,
+    this.onTap,
+    this.onBuy,
+  });
+
+  final FlightSchoolLevel level;
+  final FlightSchoolProgress progress;
+  final bool isUnlocked;
+  final bool canBuyEarly;
+  final int playerLevel;
+  final int playerCoins;
+  final VoidCallback? onTap;
+  final VoidCallback? onBuy;
+
+  static const _iconMap = <String, IconData>{
+    'flag': Icons.flag,
+    'castle': Icons.castle,
+    'terrain': Icons.terrain,
+    'temple_buddhist': Icons.temple_buddhist,
+    'festival': Icons.festival,
+    'grass': Icons.grass,
+    'landscape': Icons.landscape,
+    'beach_access': Icons.beach_access,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = _iconMap[level.icon] ?? Icons.public;
+    final grade = progress.grade;
+    final gradeColor = _gradeColor(grade);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Material(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(14),
+        child: InkWell(
+          onTap: isUnlocked ? onTap : (canBuyEarly ? onBuy : null),
+          borderRadius: BorderRadius.circular(14),
+          child: Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(
+                color: isUnlocked
+                    ? FlitColors.cardBorder
+                    : canBuyEarly
+                    ? FlitColors.gold.withOpacity(0.4)
+                    : FlitColors.textMuted.withOpacity(0.3),
+              ),
+            ),
+            child: Row(
+              children: [
+                // Region icon
+                Container(
+                  width: 52,
+                  height: 52,
+                  decoration: BoxDecoration(
+                    color: isUnlocked
+                        ? FlitColors.accent.withOpacity(0.15)
+                        : canBuyEarly
+                        ? FlitColors.gold.withOpacity(0.1)
+                        : FlitColors.backgroundMid,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Center(
+                    child: Icon(
+                      icon,
+                      size: 26,
+                      color: isUnlocked
+                          ? FlitColors.accent
+                          : canBuyEarly
+                          ? FlitColors.gold
+                          : FlitColors.textMuted,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 14),
+
+                // Level info
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              level.name,
+                              style: TextStyle(
+                                color: isUnlocked
+                                    ? FlitColors.textPrimary
+                                    : canBuyEarly
+                                    ? FlitColors.textSecondary
+                                    : FlitColors.textMuted,
+                                fontSize: 16,
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ),
+                          if (progress.hasPlayed)
+                            _GradeBadge(grade: grade, color: gradeColor),
+                        ],
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        level.subtitle,
+                        style: TextStyle(
+                          color: isUnlocked
+                              ? FlitColors.textSecondary
+                              : FlitColors.textMuted,
+                          fontSize: 12,
+                        ),
+                      ),
+                      if (isUnlocked && progress.hasPlayed) ...[
+                        const SizedBox(height: 8),
+                        _buildProgressRow(),
+                      ],
+                      if (!isUnlocked) ...[
+                        const SizedBox(height: 6),
+                        _buildLockInfo(),
+                      ],
+                    ],
+                  ),
+                ),
+
+                // Chevron, buy button, or lock
+                const SizedBox(width: 8),
+                if (isUnlocked)
+                  const Icon(
+                    Icons.chevron_right,
+                    color: FlitColors.textSecondary,
+                    size: 22,
+                  )
+                else if (canBuyEarly)
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 6,
+                    ),
+                    decoration: BoxDecoration(
+                      color: FlitColors.gold.withOpacity(0.15),
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: FlitColors.gold.withOpacity(0.4),
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(
+                          Icons.monetization_on,
+                          color: FlitColors.gold,
+                          size: 14,
+                        ),
+                        const SizedBox(width: 3),
+                        Text(
+                          '${level.unlockCost}',
+                          style: const TextStyle(
+                            color: FlitColors.gold,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                else
+                  const Icon(Icons.lock, color: FlitColors.textMuted, size: 22),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLockInfo() {
+    final hasUnlockCost = level.unlockCost > 0;
+    final canAfford = playerCoins >= level.unlockCost;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Icon(Icons.lock, size: 13, color: FlitColors.warning),
+            const SizedBox(width: 4),
+            Text(
+              'Level ${level.requiredLevel} required',
+              style: const TextStyle(
+                color: FlitColors.warning,
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        if (hasUnlockCost) ...[
+          const SizedBox(height: 3),
+          Row(
+            children: [
+              Icon(
+                Icons.monetization_on,
+                size: 13,
+                color: canAfford ? FlitColors.gold : FlitColors.textMuted,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                canAfford
+                    ? 'Tap to unlock for ${level.unlockCost} coins'
+                    : '${level.unlockCost} coins to unlock early',
+                style: TextStyle(
+                  color: canAfford ? FlitColors.gold : FlitColors.textMuted,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildProgressRow() {
+    return Row(
+      children: [
+        _buildMiniStat(Icons.star, FlitColors.gold, '${progress.bestScore}'),
+        const SizedBox(width: 12),
+        _buildMiniStat(
+          Icons.timer,
+          FlitColors.accent,
+          progress.bestTimeFormatted,
+        ),
+        const SizedBox(width: 12),
+        _buildMiniStat(
+          Icons.check_circle,
+          FlitColors.success,
+          '${progress.completions}/${progress.attempts}',
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMiniStat(IconData icon, Color color, String value) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 12, color: color.withOpacity(0.7)),
+        const SizedBox(width: 3),
+        Text(
+          value,
+          style: TextStyle(
+            color: color,
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Color _gradeColor(String grade) {
+    switch (grade) {
+      case 'S':
+        return FlitColors.gold;
+      case 'A':
+        return FlitColors.success;
+      case 'B':
+        return const Color(0xFF6AB4E8);
+      case 'C':
+        return FlitColors.textSecondary;
+      case 'D':
+        return FlitColors.warning;
+      case 'F':
+        return FlitColors.error;
+      default:
+        return FlitColors.textMuted;
+    }
+  }
+}
+
+class _GradeBadge extends StatelessWidget {
+  const _GradeBadge({required this.grade, required this.color});
+
+  final String grade;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 30,
+      height: 30,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: color.withOpacity(0.15),
+        border: Border.all(color: color, width: 1.5),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        grade,
+        style: TextStyle(
+          color: color,
+          fontSize: 14,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/quiz/h2h_challenge_screen.dart
+++ b/lib/features/quiz/h2h_challenge_screen.dart
@@ -1,0 +1,986 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../../data/models/h2h_challenge.dart';
+import '../../data/providers/account_provider.dart';
+import '../../data/services/challenge_service.dart';
+import '../../game/quiz/flight_school_level.dart';
+import '../../game/quiz/quiz_category.dart';
+import '../../game/quiz/quiz_difficulty.dart';
+import '../../game/quiz/quiz_session.dart';
+import 'h2h_results_screen.dart';
+import 'quiz_game_screen.dart';
+
+/// Screen for creating and viewing H2H Flight School challenges.
+///
+/// Tab 1: Create Challenge - pick 3 rounds, enter opponent username, send.
+/// Tab 2: My Challenges - list of sent/received challenges with status.
+class H2HChallengeScreen extends ConsumerStatefulWidget {
+  const H2HChallengeScreen({super.key});
+
+  @override
+  ConsumerState<H2HChallengeScreen> createState() => _H2HChallengeScreenState();
+}
+
+class _H2HChallengeScreenState extends ConsumerState<H2HChallengeScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      appBar: AppBar(
+        backgroundColor: FlitColors.backgroundMid,
+        title: const Text(
+          'Head-to-Head',
+          style: TextStyle(color: FlitColors.textPrimary),
+        ),
+        centerTitle: true,
+        iconTheme: const IconThemeData(color: FlitColors.textPrimary),
+        bottom: TabBar(
+          controller: _tabController,
+          indicatorColor: FlitColors.accent,
+          labelColor: FlitColors.accent,
+          unselectedLabelColor: FlitColors.textSecondary,
+          tabs: const [
+            Tab(text: 'CREATE', icon: Icon(Icons.add_circle_outline, size: 20)),
+            Tab(text: 'MY CHALLENGES', icon: Icon(Icons.list_alt, size: 20)),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: const [_CreateChallengeTab(), _MyChallengesTab()],
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// Tab 1: Create Challenge
+// =============================================================================
+
+class _CreateChallengeTab extends ConsumerStatefulWidget {
+  const _CreateChallengeTab();
+
+  @override
+  ConsumerState<_CreateChallengeTab> createState() =>
+      _CreateChallengeTabState();
+}
+
+class _CreateChallengeTabState extends ConsumerState<_CreateChallengeTab> {
+  final _usernameController = TextEditingController();
+  bool _isSending = false;
+  String? _error;
+
+  // 3 round configs
+  final List<_RoundConfig> _rounds = List.generate(3, (_) => _RoundConfig());
+
+  /// Unlocked levels for the current player.
+  List<FlightSchoolLevel> get _unlockedLevels {
+    final playerLevel = ref.read(accountProvider).currentPlayer.level;
+    return flightSchoolLevels
+        .where((l) => playerLevel >= l.requiredLevel)
+        .toList();
+  }
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final unlockedLevels = _unlockedLevels;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: FlitColors.cardBackground,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: FlitColors.cardBorder),
+            ),
+            child: Column(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: FlitColors.accent.withOpacity(0.15),
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: const Icon(
+                    Icons.sports_mma,
+                    color: FlitColors.accent,
+                    size: 32,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                const Text(
+                  'Best of 3',
+                  style: TextStyle(
+                    color: FlitColors.textPrimary,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  'Pick 3 rounds and challenge a friend',
+                  style: TextStyle(
+                    color: FlitColors.textSecondary,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20),
+
+          // Round configs
+          for (var i = 0; i < 3; i++) ...[
+            _RoundConfigCard(
+              roundNumber: i + 1,
+              config: _rounds[i],
+              unlockedLevels: unlockedLevels,
+              onChanged: (config) => setState(() => _rounds[i] = config),
+            ),
+            if (i < 2) const SizedBox(height: 12),
+          ],
+
+          const SizedBox(height: 20),
+
+          // Opponent username
+          const Text(
+            'OPPONENT',
+            style: TextStyle(
+              color: FlitColors.textMuted,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 1.5,
+            ),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _usernameController,
+            style: const TextStyle(color: FlitColors.textPrimary),
+            decoration: InputDecoration(
+              hintText: 'Enter username...',
+              hintStyle: const TextStyle(color: FlitColors.textMuted),
+              prefixIcon: const Icon(
+                Icons.person_search,
+                color: FlitColors.textSecondary,
+              ),
+              filled: true,
+              fillColor: FlitColors.cardBackground,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(color: FlitColors.cardBorder),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(color: FlitColors.cardBorder),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(color: FlitColors.accent),
+              ),
+            ),
+          ),
+
+          if (_error != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _error!,
+              style: const TextStyle(color: FlitColors.error, fontSize: 13),
+            ),
+          ],
+
+          const SizedBox(height: 20),
+
+          // Send button
+          SizedBox(
+            width: double.infinity,
+            height: 52,
+            child: ElevatedButton(
+              onPressed: _isSending ? null : _sendChallenge,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: FlitColors.accent,
+                foregroundColor: FlitColors.textPrimary,
+                disabledBackgroundColor: FlitColors.accent.withOpacity(0.4),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                elevation: 4,
+              ),
+              child: _isSending
+                  ? const SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2.5,
+                        color: FlitColors.textPrimary,
+                      ),
+                    )
+                  : Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: const [
+                        Icon(Icons.send, size: 20),
+                        SizedBox(width: 8),
+                        Text(
+                          'SEND CHALLENGE',
+                          style: TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.w900,
+                            letterSpacing: 1,
+                          ),
+                        ),
+                      ],
+                    ),
+            ),
+          ),
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _sendChallenge() async {
+    final username = _usernameController.text.trim();
+    if (username.isEmpty) {
+      setState(() => _error = 'Please enter a username');
+      return;
+    }
+
+    setState(() {
+      _isSending = true;
+      _error = null;
+    });
+
+    final rng = Random();
+    final challengerName =
+        ref.read(accountProvider).currentPlayer.displayName ??
+        ref.read(accountProvider).currentPlayer.username;
+
+    final h2hRounds = _rounds.map((config) {
+      return H2HRound(
+        levelId: config.level.id,
+        levelName: config.level.name,
+        category: config.category,
+        difficulty: config.difficulty,
+        seed: rng.nextInt(1 << 31),
+      );
+    }).toList();
+
+    final challengeId = await ChallengeService.instance.createH2HChallenge(
+      challengedUsername: username,
+      challengerName: challengerName,
+      rounds: h2hRounds,
+    );
+
+    if (!mounted) return;
+
+    if (challengeId != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          backgroundColor: FlitColors.success,
+          content: Text('Challenge sent to $username!'),
+        ),
+      );
+      _usernameController.clear();
+      setState(() => _isSending = false);
+    } else {
+      setState(() {
+        _isSending = false;
+        _error = 'User not found or challenge failed. Check the username.';
+      });
+    }
+  }
+}
+
+/// Mutable round configuration used during challenge creation.
+class _RoundConfig {
+  FlightSchoolLevel level = flightSchoolLevels.first;
+  QuizCategory category = QuizCategory.mixed;
+  QuizDifficulty difficulty = QuizDifficulty.medium;
+}
+
+/// Card widget for configuring a single H2H round.
+class _RoundConfigCard extends StatelessWidget {
+  const _RoundConfigCard({
+    required this.roundNumber,
+    required this.config,
+    required this.unlockedLevels,
+    required this.onChanged,
+  });
+
+  final int roundNumber;
+  final _RoundConfig config;
+  final List<FlightSchoolLevel> unlockedLevels;
+  final ValueChanged<_RoundConfig> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: FlitColors.cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 30,
+                height: 30,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: FlitColors.accent.withOpacity(0.15),
+                  border: Border.all(color: FlitColors.accent, width: 1.5),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  '$roundNumber',
+                  style: const TextStyle(
+                    color: FlitColors.accent,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Text(
+                'Round $roundNumber',
+                style: const TextStyle(
+                  color: FlitColors.textPrimary,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+
+          // Level selector
+          _buildDropdown<FlightSchoolLevel>(
+            context: context,
+            label: 'Region',
+            value: config.level,
+            items: unlockedLevels,
+            itemLabel: (l) => l.name,
+            onChanged: (level) {
+              if (level == null) return;
+              final newConfig = _RoundConfig()
+                ..level = level
+                ..category = level.availableCategories.contains(config.category)
+                    ? config.category
+                    : QuizCategory.mixed
+                ..difficulty = config.difficulty;
+              onChanged(newConfig);
+            },
+          ),
+          const SizedBox(height: 8),
+
+          // Category selector
+          _buildDropdown<QuizCategory>(
+            context: context,
+            label: 'Category',
+            value: config.category,
+            items: config.level.availableCategories,
+            itemLabel: (c) => c.displayName,
+            onChanged: (cat) {
+              if (cat == null) return;
+              final newConfig = _RoundConfig()
+                ..level = config.level
+                ..category = cat
+                ..difficulty = config.difficulty;
+              onChanged(newConfig);
+            },
+          ),
+          const SizedBox(height: 8),
+
+          // Difficulty selector
+          _buildDropdown<QuizDifficulty>(
+            context: context,
+            label: 'Difficulty',
+            value: config.difficulty,
+            items: QuizDifficulty.values,
+            itemLabel: (d) => d.displayName,
+            onChanged: (diff) {
+              if (diff == null) return;
+              final newConfig = _RoundConfig()
+                ..level = config.level
+                ..category = config.category
+                ..difficulty = diff;
+              onChanged(newConfig);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDropdown<T>({
+    required BuildContext context,
+    required String label,
+    required T value,
+    required List<T> items,
+    required String Function(T) itemLabel,
+    required ValueChanged<T?> onChanged,
+  }) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 72,
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: FlitColors.textSecondary,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            decoration: BoxDecoration(
+              color: FlitColors.backgroundMid,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: FlitColors.cardBorder.withOpacity(0.6)),
+            ),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<T>(
+                value: items.contains(value) ? value : items.first,
+                isExpanded: true,
+                dropdownColor: FlitColors.backgroundMid,
+                style: const TextStyle(
+                  color: FlitColors.textPrimary,
+                  fontSize: 13,
+                ),
+                items: items.map((item) {
+                  return DropdownMenuItem<T>(
+                    value: item,
+                    child: Text(itemLabel(item)),
+                  );
+                }).toList(),
+                onChanged: onChanged,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// =============================================================================
+// Tab 2: My Challenges
+// =============================================================================
+
+class _MyChallengesTab extends ConsumerStatefulWidget {
+  const _MyChallengesTab();
+
+  @override
+  ConsumerState<_MyChallengesTab> createState() => _MyChallengesTabState();
+}
+
+class _MyChallengesTabState extends ConsumerState<_MyChallengesTab> {
+  List<H2HChallenge>? _challenges;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadChallenges();
+  }
+
+  Future<void> _loadChallenges() async {
+    setState(() => _isLoading = true);
+    final challenges = await ChallengeService.instance.fetchMyH2HChallenges();
+    if (mounted) {
+      setState(() {
+        _challenges = challenges;
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Center(
+        child: CircularProgressIndicator(color: FlitColors.accent),
+      );
+    }
+
+    final challenges = _challenges ?? [];
+    if (challenges.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sports_mma,
+              size: 56,
+              color: FlitColors.textMuted.withOpacity(0.4),
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              'No challenges yet',
+              style: TextStyle(
+                color: FlitColors.textMuted,
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              'Create one to get started!',
+              style: TextStyle(color: FlitColors.textMuted, fontSize: 13),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final userId = ref.read(accountProvider).currentPlayer.id;
+
+    return RefreshIndicator(
+      onRefresh: _loadChallenges,
+      color: FlitColors.accent,
+      child: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: challenges.length,
+        itemBuilder: (context, index) {
+          final challenge = challenges[index];
+          return _ChallengeListItem(
+            challenge: challenge,
+            currentUserId: userId,
+            onTap: () => _onChallengeTap(challenge),
+          );
+        },
+      ),
+    );
+  }
+
+  void _onChallengeTap(H2HChallenge challenge) {
+    final userId = ref.read(accountProvider).currentPlayer.id;
+    final isChallenger = challenge.challengerId == userId;
+    final isChallenged = challenge.challengedId == userId;
+
+    switch (challenge.status) {
+      case H2HStatus.pending:
+        if (isChallenged) {
+          _showAcceptDeclineDialog(challenge);
+        }
+        break;
+      case H2HStatus.inProgress:
+        _navigateToNextRound(challenge, isChallenger);
+        break;
+      case H2HStatus.completed:
+        _navigateToResults(challenge);
+        break;
+      case H2HStatus.declined:
+      case H2HStatus.expired:
+        break;
+    }
+  }
+
+  void _showAcceptDeclineDialog(H2HChallenge challenge) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: FlitColors.cardBackground,
+        title: const Text(
+          'Challenge Received',
+          style: TextStyle(color: FlitColors.textPrimary),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${challenge.challengerName} challenges you!',
+              style: const TextStyle(
+                color: FlitColors.textSecondary,
+                fontSize: 14,
+              ),
+            ),
+            const SizedBox(height: 12),
+            for (var i = 0; i < challenge.rounds.length; i++) ...[
+              Text(
+                'Round ${i + 1}: ${challenge.rounds[i].levelName} '
+                '(${challenge.rounds[i].category.displayName}, '
+                '${challenge.rounds[i].difficulty.displayName})',
+                style: const TextStyle(
+                  color: FlitColors.textPrimary,
+                  fontSize: 13,
+                ),
+              ),
+              if (i < challenge.rounds.length - 1) const SizedBox(height: 4),
+            ],
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () async {
+              Navigator.of(ctx).pop();
+              await ChallengeService.instance.declineH2HChallenge(challenge.id);
+              _loadChallenges();
+            },
+            child: const Text(
+              'DECLINE',
+              style: TextStyle(color: FlitColors.error),
+            ),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              Navigator.of(ctx).pop();
+              await ChallengeService.instance.acceptH2HChallenge(challenge.id);
+              await _loadChallenges();
+              // Navigate to the first round
+              final updated = await ChallengeService.instance.fetchH2HChallenge(
+                challenge.id,
+              );
+              if (updated != null && mounted) {
+                final isChallenger =
+                    updated.challengerId ==
+                    ref.read(accountProvider).currentPlayer.id;
+                _navigateToNextRound(updated, isChallenger);
+              }
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: FlitColors.accent,
+              foregroundColor: FlitColors.textPrimary,
+            ),
+            child: const Text(
+              'ACCEPT',
+              style: TextStyle(fontWeight: FontWeight.w700),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _navigateToNextRound(H2HChallenge challenge, bool isChallenger) {
+    // Find the next round that this player hasn't completed.
+    int? nextIndex;
+    for (var i = 0; i < challenge.rounds.length; i++) {
+      final round = challenge.rounds[i];
+      final hasPlayed = isChallenger
+          ? round.challengerPlayed
+          : round.challengedPlayed;
+      if (!hasPlayed) {
+        nextIndex = i;
+        break;
+      }
+    }
+
+    if (nextIndex == null) {
+      // All rounds played by this player — show results or wait.
+      if (challenge.isComplete) {
+        _navigateToResults(challenge);
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            backgroundColor: FlitColors.backgroundMid,
+            content: Text(
+              'Waiting for opponent to play their rounds...',
+              style: TextStyle(color: FlitColors.textPrimary),
+            ),
+          ),
+        );
+      }
+      return;
+    }
+
+    final round = challenge.rounds[nextIndex];
+    final opponentName = isChallenger
+        ? challenge.challengedName
+        : challenge.challengerName;
+
+    // Find the FlightSchoolLevel for this round.
+    final level = flightSchoolLevels.firstWhere(
+      (l) => l.id == round.levelId,
+      orElse: () => flightSchoolLevels.first,
+    );
+
+    Navigator.of(context)
+        .push(
+          MaterialPageRoute<void>(
+            builder: (_) => QuizGameScreen(
+              mode: QuizMode.allStates,
+              category: round.category,
+              region: level.region,
+              difficulty: round.difficulty,
+              challengeId: challenge.id,
+              challengeOpponentName: opponentName,
+              seed: round.seed,
+              flightSchoolLevelId: round.levelId,
+              h2hRoundIndex: nextIndex,
+            ),
+          ),
+        )
+        .then((_) => _loadChallenges());
+  }
+
+  void _navigateToResults(H2HChallenge challenge) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => H2HResultsScreen(challenge: challenge),
+      ),
+    );
+  }
+}
+
+/// List item widget for a single H2H challenge.
+class _ChallengeListItem extends StatelessWidget {
+  const _ChallengeListItem({
+    required this.challenge,
+    required this.currentUserId,
+    required this.onTap,
+  });
+
+  final H2HChallenge challenge;
+  final String currentUserId;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final isChallenger = challenge.challengerId == currentUserId;
+    final opponentName = isChallenger
+        ? challenge.challengedName
+        : challenge.challengerName;
+    final statusInfo = _statusInfo(isChallenger);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Material(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(14),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(14),
+          child: Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: FlitColors.cardBorder),
+            ),
+            child: Row(
+              children: [
+                // Status icon
+                Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    color: statusInfo.color.withOpacity(0.15),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Center(
+                    child: Icon(
+                      statusInfo.icon,
+                      color: statusInfo.color,
+                      size: 22,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+
+                // Info
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text(
+                            'vs $opponentName',
+                            style: const TextStyle(
+                              color: FlitColors.textPrimary,
+                              fontSize: 15,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                          const Spacer(),
+                          if (challenge.status == H2HStatus.completed ||
+                              challenge.status == H2HStatus.inProgress)
+                            Text(
+                              challenge.scoreText,
+                              style: TextStyle(
+                                color: statusInfo.color,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w900,
+                              ),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        statusInfo.label,
+                        style: TextStyle(
+                          color: statusInfo.color,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      // Round summaries
+                      Row(
+                        children: [
+                          for (var i = 0; i < challenge.rounds.length; i++) ...[
+                            _RoundChip(round: challenge.rounds[i], index: i),
+                            if (i < challenge.rounds.length - 1)
+                              const SizedBox(width: 4),
+                          ],
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+
+                const SizedBox(width: 8),
+                Icon(
+                  Icons.chevron_right,
+                  color: FlitColors.textSecondary,
+                  size: 22,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  ({String label, Color color, IconData icon}) _statusInfo(bool isChallenger) {
+    switch (challenge.status) {
+      case H2HStatus.pending:
+        if (isChallenger) {
+          return (
+            label: 'Waiting for response...',
+            color: FlitColors.warning,
+            icon: Icons.hourglass_top,
+          );
+        }
+        return (
+          label: 'Tap to accept or decline',
+          color: FlitColors.accent,
+          icon: Icons.notification_important,
+        );
+      case H2HStatus.inProgress:
+        return (
+          label: 'In progress - tap to play',
+          color: FlitColors.oceanHighlight,
+          icon: Icons.play_circle_outline,
+        );
+      case H2HStatus.completed:
+        final won = challenge.winnerId == currentUserId;
+        final draw = challenge.winnerId == null;
+        if (draw) {
+          return (
+            label: 'Draw',
+            color: FlitColors.textSecondary,
+            icon: Icons.handshake,
+          );
+        }
+        return won
+            ? (
+                label: 'Victory!',
+                color: FlitColors.gold,
+                icon: Icons.emoji_events,
+              )
+            : (
+                label: 'Defeated',
+                color: FlitColors.error,
+                icon: Icons.sentiment_dissatisfied,
+              );
+      case H2HStatus.declined:
+        return (
+          label: 'Declined',
+          color: FlitColors.textMuted,
+          icon: Icons.block,
+        );
+      case H2HStatus.expired:
+        return (
+          label: 'Expired',
+          color: FlitColors.textMuted,
+          icon: Icons.timer_off,
+        );
+    }
+  }
+}
+
+/// Small chip showing a round's level abbreviation.
+class _RoundChip extends StatelessWidget {
+  const _RoundChip({required this.round, required this.index});
+
+  final H2HRound round;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    Color bgColor;
+    Color textColor;
+
+    if (round.isComplete) {
+      final winner = round.winner;
+      if (winner == 'draw') {
+        bgColor = FlitColors.textSecondary.withOpacity(0.15);
+        textColor = FlitColors.textSecondary;
+      } else {
+        bgColor = FlitColors.success.withOpacity(0.15);
+        textColor = FlitColors.success;
+      }
+    } else {
+      bgColor = FlitColors.backgroundMid;
+      textColor = FlitColors.textMuted;
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        round.levelName.length > 6
+            ? round.levelName.substring(0, 6)
+            : round.levelName,
+        style: TextStyle(
+          color: textColor,
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/quiz/h2h_results_screen.dart
+++ b/lib/features/quiz/h2h_results_screen.dart
@@ -1,0 +1,489 @@
+import 'package:flutter/material.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../../data/models/h2h_challenge.dart';
+import 'flight_school_screen.dart';
+import 'h2h_challenge_screen.dart';
+
+/// Results screen for a completed H2H Flight School challenge.
+///
+/// Shows all 3 rounds side-by-side with scores, highlights round winners,
+/// and displays the overall winner with a celebration effect.
+class H2HResultsScreen extends StatefulWidget {
+  const H2HResultsScreen({super.key, required this.challenge});
+
+  final H2HChallenge challenge;
+
+  @override
+  State<H2HResultsScreen> createState() => _H2HResultsScreenState();
+}
+
+class _H2HResultsScreenState extends State<H2HResultsScreen>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _animController;
+  late Animation<double> _fadeIn;
+  late Animation<double> _slideUp;
+  late Animation<double> _scaleIn;
+
+  @override
+  void initState() {
+    super.initState();
+    _animController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    );
+    _fadeIn = CurvedAnimation(parent: _animController, curve: Curves.easeIn);
+    _slideUp = Tween<double>(begin: 40, end: 0).animate(
+      CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
+    );
+    _scaleIn = Tween<double>(begin: 0.5, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _animController,
+        curve: const Interval(0.2, 0.8, curve: Curves.elasticOut),
+      ),
+    );
+    _animController.forward();
+  }
+
+  @override
+  void dispose() {
+    _animController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final challenge = widget.challenge;
+    final isDraw = challenge.winnerId == null && challenge.isComplete;
+    final winnerName = challenge.winnerName;
+
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      body: SafeArea(
+        child: AnimatedBuilder(
+          animation: _animController,
+          builder: (context, child) {
+            return Opacity(
+              opacity: _fadeIn.value,
+              child: Transform.translate(
+                offset: Offset(0, _slideUp.value),
+                child: child,
+              ),
+            );
+          },
+          child: Column(
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 24,
+                  ),
+                  child: Column(
+                    children: [
+                      // Trophy / result badge
+                      _buildResultBadge(isDraw, winnerName),
+                      const SizedBox(height: 16),
+
+                      // Title
+                      Text(
+                        isDraw
+                            ? 'DRAW'
+                            : winnerName != null
+                            ? '$winnerName WINS!'
+                            : 'MATCH COMPLETE',
+                        style: TextStyle(
+                          color: isDraw
+                              ? FlitColors.textSecondary
+                              : FlitColors.gold,
+                          fontSize: 22,
+                          fontWeight: FontWeight.w900,
+                          letterSpacing: 2,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+
+                      // Matchup subtitle
+                      Text(
+                        '${challenge.challengerName} vs ${challenge.challengedName}',
+                        style: const TextStyle(
+                          color: FlitColors.textSecondary,
+                          fontSize: 14,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+
+                      // Overall score
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
+                        decoration: BoxDecoration(
+                          color: FlitColors.accent.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(
+                            color: FlitColors.accent.withOpacity(0.25),
+                          ),
+                        ),
+                        child: Text(
+                          challenge.scoreText,
+                          style: const TextStyle(
+                            color: FlitColors.accent,
+                            fontSize: 24,
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 28),
+
+                      // Round details
+                      const Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'ROUNDS',
+                          style: TextStyle(
+                            color: FlitColors.textMuted,
+                            fontSize: 11,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 1.5,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+
+                      for (var i = 0; i < challenge.rounds.length; i++) ...[
+                        _RoundResultCard(
+                          round: challenge.rounds[i],
+                          roundNumber: i + 1,
+                          challengerName: challenge.challengerName,
+                          challengedName: challenge.challengedName,
+                        ),
+                        if (i < challenge.rounds.length - 1)
+                          const SizedBox(height: 10),
+                      ],
+
+                      const SizedBox(height: 24),
+                    ],
+                  ),
+                ),
+              ),
+
+              // Bottom actions
+              _buildBottomBar(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildResultBadge(bool isDraw, String? winnerName) {
+    return AnimatedBuilder(
+      animation: _scaleIn,
+      builder: (context, child) {
+        return Transform.scale(scale: _scaleIn.value, child: child);
+      },
+      child: Container(
+        width: 100,
+        height: 100,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: isDraw
+              ? FlitColors.textSecondary.withOpacity(0.15)
+              : FlitColors.gold.withOpacity(0.15),
+          border: Border.all(
+            color: isDraw ? FlitColors.textSecondary : FlitColors.gold,
+            width: 3,
+          ),
+          boxShadow: isDraw
+              ? null
+              : [
+                  BoxShadow(
+                    color: FlitColors.gold.withOpacity(0.3),
+                    blurRadius: 24,
+                    spreadRadius: 4,
+                  ),
+                ],
+        ),
+        alignment: Alignment.center,
+        child: Icon(
+          isDraw ? Icons.handshake : Icons.emoji_events,
+          color: isDraw ? FlitColors.textSecondary : FlitColors.gold,
+          size: 48,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBottomBar() => Container(
+    padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+    decoration: const BoxDecoration(
+      color: FlitColors.backgroundMid,
+      border: Border(top: BorderSide(color: FlitColors.cardBorder)),
+    ),
+    child: Row(
+      children: [
+        Expanded(
+          child: SizedBox(
+            height: 50,
+            child: OutlinedButton(
+              onPressed: () => Navigator.of(context).pushReplacement(
+                MaterialPageRoute<void>(
+                  builder: (_) => const FlightSchoolScreen(),
+                ),
+              ),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: FlitColors.textSecondary,
+                side: const BorderSide(color: FlitColors.cardBorder),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: const Text(
+                'FLIGHT SCHOOL',
+                style: TextStyle(fontWeight: FontWeight.w700, letterSpacing: 1),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          flex: 2,
+          child: SizedBox(
+            height: 50,
+            child: ElevatedButton(
+              onPressed: () => Navigator.of(context).pushReplacement(
+                MaterialPageRoute<void>(
+                  builder: (_) => const H2HChallengeScreen(),
+                ),
+              ),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: FlitColors.accent,
+                foregroundColor: FlitColors.textPrimary,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                elevation: 4,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: const [
+                  Icon(Icons.replay, size: 20),
+                  SizedBox(width: 8),
+                  Text(
+                    'PLAY AGAIN',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w900,
+                      letterSpacing: 1,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Card showing a single round's results with side-by-side scores.
+class _RoundResultCard extends StatelessWidget {
+  const _RoundResultCard({
+    required this.round,
+    required this.roundNumber,
+    required this.challengerName,
+    required this.challengedName,
+  });
+
+  final H2HRound round;
+  final int roundNumber;
+  final String challengerName;
+  final String challengedName;
+
+  @override
+  Widget build(BuildContext context) {
+    final winner = round.winner;
+    final challengerWon = winner == 'challenger';
+    final challengedWon = winner == 'challenged';
+    final isDraw = winner == 'draw';
+
+    Color borderColor;
+    if (!round.isComplete) {
+      borderColor = FlitColors.cardBorder;
+    } else if (isDraw) {
+      borderColor = FlitColors.textSecondary.withOpacity(0.5);
+    } else {
+      borderColor = FlitColors.gold.withOpacity(0.5);
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: borderColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Round header
+          Row(
+            children: [
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: FlitColors.accent.withOpacity(0.15),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  '$roundNumber',
+                  style: const TextStyle(
+                    color: FlitColors.accent,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      round.levelName,
+                      style: const TextStyle(
+                        color: FlitColors.textPrimary,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    Text(
+                      '${round.category.displayName} - ${round.difficulty.displayName}',
+                      style: const TextStyle(
+                        color: FlitColors.textSecondary,
+                        fontSize: 11,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (round.isComplete)
+                Icon(
+                  isDraw ? Icons.horizontal_rule : Icons.emoji_events,
+                  color: isDraw ? FlitColors.textSecondary : FlitColors.gold,
+                  size: 20,
+                ),
+            ],
+          ),
+          const SizedBox(height: 12),
+
+          // Score comparison
+          Row(
+            children: [
+              // Challenger score
+              Expanded(
+                child: _buildPlayerScore(
+                  name: challengerName,
+                  score: round.challengerScore,
+                  correct: round.challengerCorrect,
+                  wrong: round.challengerWrong,
+                  isWinner: challengerWon,
+                ),
+              ),
+              // VS divider
+              Container(
+                width: 32,
+                alignment: Alignment.center,
+                child: const Text(
+                  'VS',
+                  style: TextStyle(
+                    color: FlitColors.textMuted,
+                    fontSize: 10,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              // Challenged score
+              Expanded(
+                child: _buildPlayerScore(
+                  name: challengedName,
+                  score: round.challengedScore,
+                  correct: round.challengedCorrect,
+                  wrong: round.challengedWrong,
+                  isWinner: challengedWon,
+                  alignRight: true,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlayerScore({
+    required String name,
+    required int? score,
+    required int? correct,
+    required int? wrong,
+    required bool isWinner,
+    bool alignRight = false,
+  }) {
+    final align = alignRight
+        ? CrossAxisAlignment.end
+        : CrossAxisAlignment.start;
+    final textAlign = alignRight ? TextAlign.right : TextAlign.left;
+
+    return Column(
+      crossAxisAlignment: align,
+      children: [
+        Text(
+          name.length > 12 ? '${name.substring(0, 12)}...' : name,
+          textAlign: textAlign,
+          style: TextStyle(
+            color: isWinner ? FlitColors.gold : FlitColors.textSecondary,
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isWinner && !alignRight)
+              const Padding(
+                padding: EdgeInsets.only(right: 4),
+                child: Icon(Icons.star, color: FlitColors.gold, size: 14),
+              ),
+            Text(
+              score != null ? '$score' : '--',
+              style: TextStyle(
+                color: isWinner ? FlitColors.gold : FlitColors.textPrimary,
+                fontSize: 22,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+            if (isWinner && alignRight)
+              const Padding(
+                padding: EdgeInsets.only(left: 4),
+                child: Icon(Icons.star, color: FlitColors.gold, size: 14),
+              ),
+          ],
+        ),
+        if (correct != null && wrong != null) ...[
+          const SizedBox(height: 2),
+          Text(
+            '$correct correct, $wrong wrong',
+            textAlign: textAlign,
+            style: const TextStyle(color: FlitColors.textMuted, fontSize: 10),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/features/quiz/quiz_game_screen.dart
+++ b/lib/features/quiz/quiz_game_screen.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../data/services/challenge_service.dart';
 import '../../game/quiz/quiz_category.dart';
+import '../../game/quiz/quiz_difficulty.dart';
 import '../../game/quiz/quiz_map_widget.dart';
+import '../../game/quiz/quiz_region_map_widget.dart';
 import '../../game/quiz/quiz_session.dart';
 import '../../game/map/region.dart';
 import 'quiz_results_screen.dart';
@@ -26,11 +28,16 @@ class QuizGameScreen extends StatefulWidget {
     this.challengeId,
     this.challengeOpponentName,
     this.seed,
+    this.flightSchoolLevelId,
+    this.difficulty = QuizDifficulty.medium,
+    this.h2hRoundIndex,
+    this.dailyBriefingDateKey,
   });
 
   final QuizMode mode;
   final QuizCategory category;
   final GameRegion region;
+  final QuizDifficulty difficulty;
 
   /// When non-null, this quiz is part of an H2H challenge.
   final String? challengeId;
@@ -40,6 +47,17 @@ class QuizGameScreen extends StatefulWidget {
 
   /// Deterministic seed for challenge mode (both players get same questions).
   final int? seed;
+
+  /// Flight school level ID for progress tracking.
+  final String? flightSchoolLevelId;
+
+  /// When non-null, this quiz is a round of a best-of-3 H2H challenge.
+  /// The value is the 0-based round index.
+  final int? h2hRoundIndex;
+
+  /// When non-null, this quiz is a Daily Flight Briefing. The value is the
+  /// date key (YYYY-MM-DD) used for score submission.
+  final String? dailyBriefingDateKey;
 
   @override
   State<QuizGameScreen> createState() => _QuizGameScreenState();
@@ -81,6 +99,7 @@ class _QuizGameScreenState extends State<QuizGameScreen>
       mode: widget.mode,
       category: widget.category,
       region: widget.region,
+      difficulty: widget.difficulty,
       seed: widget.seed,
     );
 
@@ -175,20 +194,72 @@ class _QuizGameScreenState extends State<QuizGameScreen>
     }
   }
 
+  void _useHint() {
+    final level = _session.useHint();
+    if (level == null) return;
+
+    final question = _session.currentQuestion;
+    if (question == null) return;
+
+    setState(() {
+      if (level >= 3) {
+        // Level 3: Highlight the exact correct answer
+        _highlightCode = question.answerCode;
+      } else if (level >= 2) {
+        // Level 2: Dim 75% of wrong answers
+        final areas = _stateVisuals.keys.toList();
+        final wrongAreas = areas
+            .where(
+              (c) =>
+                  c != question.answerCode &&
+                  _stateVisuals[c]?.status == StateVisualStatus.idle,
+            )
+            .toList();
+        wrongAreas.shuffle();
+        final toDim = wrongAreas.take((wrongAreas.length * 0.75).round());
+        for (final code in toDim) {
+          _stateVisuals[code]?.status = StateVisualStatus.completed;
+        }
+      }
+      // Level 1: Just a visual indicator (could highlight quadrant, but
+      // for now we just show that a hint was used - the reduced score is
+      // the main feedback)
+    });
+  }
+
   Future<void> _navigateToResults() async {
     if (!mounted) return;
 
     // Submit results to challenge system if this is an H2H quiz.
     if (widget.challengeId != null) {
       final summary = _session.summary;
-      await ChallengeService.instance.submitQuizRoundResult(
-        challengeId: widget.challengeId!,
-        score: summary.totalScore,
-        timeMs: summary.elapsedMs,
-        correctCount: summary.correctCount,
-        wrongCount: summary.wrongCount,
-      );
-      await ChallengeService.instance.tryCompleteChallenge(widget.challengeId!);
+
+      if (widget.h2hRoundIndex != null) {
+        // Best-of-3 H2H challenge round.
+        await ChallengeService.instance.submitH2HRoundScore(
+          challengeId: widget.challengeId!,
+          roundIndex: widget.h2hRoundIndex!,
+          score: summary.totalScore,
+          timeMs: summary.elapsedMs,
+          correctCount: summary.correctCount,
+          wrongCount: summary.wrongCount,
+        );
+        await ChallengeService.instance.tryCompleteH2HChallenge(
+          widget.challengeId!,
+        );
+      } else {
+        // Legacy single-round quiz challenge.
+        await ChallengeService.instance.submitQuizRoundResult(
+          challengeId: widget.challengeId!,
+          score: summary.totalScore,
+          timeMs: summary.elapsedMs,
+          correctCount: summary.correctCount,
+          wrongCount: summary.wrongCount,
+        );
+        await ChallengeService.instance.tryCompleteChallenge(
+          widget.challengeId!,
+        );
+      }
     }
 
     if (!mounted) return;
@@ -198,6 +269,10 @@ class _QuizGameScreenState extends State<QuizGameScreen>
           summary: _session.summary,
           challengeId: widget.challengeId,
           opponentName: widget.challengeOpponentName,
+          flightSchoolLevelId: widget.flightSchoolLevelId,
+          region: widget.region,
+          h2hRoundIndex: widget.h2hRoundIndex,
+          dailyBriefingDateKey: widget.dailyBriefingDateKey,
         ),
       ),
     );
@@ -263,14 +338,23 @@ class _QuizGameScreenState extends State<QuizGameScreen>
             Expanded(
               child: Stack(
                 children: [
-                  // Interactive map
+                  // Interactive map (US-specific or generic region map)
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8),
-                    child: QuizMapWidget(
-                      stateVisuals: _stateVisuals,
-                      onStateTapped: _handleStateTapped,
-                      highlightCode: _highlightCode,
-                    ),
+                    child: widget.region == GameRegion.usStates
+                        ? QuizMapWidget(
+                            stateVisuals: _stateVisuals,
+                            onStateTapped: _handleStateTapped,
+                            highlightCode: _highlightCode,
+                            showLabels: _session.showLabels,
+                          )
+                        : QuizRegionMapWidget(
+                            region: widget.region,
+                            stateVisuals: _stateVisuals,
+                            onStateTapped: _handleStateTapped,
+                            highlightCode: _highlightCode,
+                            showLabels: _session.showLabels,
+                          ),
                   ),
 
                   // Points popup animation
@@ -529,6 +613,41 @@ class _QuizGameScreenState extends State<QuizGameScreen>
               ),
             ),
 
+          // Hint button
+          if (_session.canUseHint)
+            GestureDetector(
+              onTap: _useHint,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                decoration: BoxDecoration(
+                  color: FlitColors.warning.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(6),
+                  border: Border.all(
+                    color: FlitColors.warning.withOpacity(0.4),
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.lightbulb_outline,
+                      color: FlitColors.warning,
+                      size: 14,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      'Hint (${widget.difficulty.maxHints - _session.hintsUsed})',
+                      style: const TextStyle(
+                        color: FlitColors.warning,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
           // Correct / Wrong counts
           Row(
             mainAxisSize: MainAxisSize.min,
@@ -640,7 +759,7 @@ class _QuizGameScreenState extends State<QuizGameScreen>
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                '${_session.correctCount} of ${_session.totalQuestions} states found',
+                '${_session.correctCount} of ${_session.totalQuestions} found',
                 style: const TextStyle(
                   color: FlitColors.textSecondary,
                   fontSize: 12,

--- a/lib/features/quiz/quiz_results_screen.dart
+++ b/lib/features/quiz/quiz_results_screen.dart
@@ -1,9 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../data/providers/account_provider.dart';
+import '../../data/services/leaderboard_service.dart';
+import '../../game/map/region.dart';
+import '../../game/quiz/flight_school_level.dart';
 import '../../game/quiz/quiz_category.dart';
 import '../../game/quiz/quiz_session.dart';
-import 'quiz_setup_screen.dart';
+import 'flight_school_screen.dart';
 
 /// Results screen shown after completing a Flight School quiz.
 ///
@@ -14,12 +20,16 @@ import 'quiz_setup_screen.dart';
 /// - Time taken
 /// - Best streak
 /// - Correct/Wrong breakdown
-class QuizResultsScreen extends StatefulWidget {
+class QuizResultsScreen extends ConsumerStatefulWidget {
   const QuizResultsScreen({
     super.key,
     required this.summary,
     this.challengeId,
     this.opponentName,
+    this.flightSchoolLevelId,
+    this.region,
+    this.h2hRoundIndex,
+    this.dailyBriefingDateKey,
   });
 
   final QuizSummary summary;
@@ -30,12 +40,27 @@ class QuizResultsScreen extends StatefulWidget {
   /// Opponent name for challenge display.
   final String? opponentName;
 
+  /// Flight school level ID for progress tracking.
+  final String? flightSchoolLevelId;
+
+  /// Region played (for context).
+  final GameRegion? region;
+
+  /// When non-null, this was a round of a best-of-3 H2H challenge.
+  final int? h2hRoundIndex;
+
+  /// When non-null, this quiz was a Daily Flight Briefing. The value is the
+  /// date key (YYYY-MM-DD) for score submission.
+  final String? dailyBriefingDateKey;
+
   @override
-  State<QuizResultsScreen> createState() => _QuizResultsScreenState();
+  ConsumerState<QuizResultsScreen> createState() => _QuizResultsScreenState();
 }
 
-class _QuizResultsScreenState extends State<QuizResultsScreen>
+class _QuizResultsScreenState extends ConsumerState<QuizResultsScreen>
     with SingleTickerProviderStateMixin {
+  bool _progressSaved = false;
+  int _coinsEarned = 0;
   late AnimationController _animController;
   late Animation<double> _fadeIn;
   late Animation<double> _slideUp;
@@ -52,6 +77,80 @@ class _QuizResultsScreenState extends State<QuizResultsScreen>
       CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
     );
     _animController.forward();
+    _saveFlightSchoolProgress();
+    _saveDailyBriefingScore();
+  }
+
+  void _saveFlightSchoolProgress() {
+    final levelId = widget.flightSchoolLevelId;
+    if (levelId == null || _progressSaved) return;
+    _progressSaved = true;
+
+    final summary = widget.summary;
+    final isCompleted = summary.mode == QuizMode.allStates
+        ? summary.correctCount == summary.totalQuestions
+        : summary.correctCount > 0;
+
+    final notifier = ref.read(accountProvider.notifier);
+
+    notifier.updateFlightSchoolProgress(
+      levelId: levelId,
+      score: summary.totalScore,
+      timeMs: summary.elapsedMs,
+      completed: isCompleted,
+    );
+
+    // Award coins based on performance with diminishing returns
+    final progress =
+        ref.read(accountProvider).flightSchoolProgress[levelId] ??
+        const FlightSchoolProgress();
+    final baseCoinReward = summary.coinReward;
+    final adjustedReward = progress.coinRewardForCompletion(baseCoinReward);
+    if (adjustedReward > 0) {
+      notifier.addCoins(adjustedReward, source: 'flight_school');
+      _coinsEarned = adjustedReward;
+    }
+  }
+
+  /// Submit the score to the daily briefing tables when this quiz is a
+  /// Daily Flight Briefing.
+  Future<void> _saveDailyBriefingScore() async {
+    final dateKey = widget.dailyBriefingDateKey;
+    if (dateKey == null) return;
+
+    final userId = Supabase.instance.client.auth.currentUser?.id;
+    if (userId == null) return;
+
+    final summary = widget.summary;
+
+    try {
+      final client = Supabase.instance.client;
+
+      // 1. Dedicated daily_briefing_scores table (one per day, upsert).
+      await client.from('daily_briefing_scores').upsert({
+        'user_id': userId,
+        'date_key': dateKey,
+        'score': summary.totalScore,
+        'time_ms': summary.elapsedMs,
+        'level_id': widget.flightSchoolLevelId ?? '',
+        'category': summary.category.name,
+        'difficulty': summary.difficulty.name,
+        'mode': summary.mode.name,
+      }, onConflict: 'user_id,date_key');
+
+      // 2. Shared scores table with region = 'briefing' for the leaderboard.
+      await client.from('scores').insert({
+        'user_id': userId,
+        'score': summary.totalScore,
+        'time_ms': summary.elapsedMs,
+        'region': 'briefing',
+        'rounds_completed': summary.correctCount,
+      });
+
+      LeaderboardService.instance.invalidateCache();
+    } catch (e) {
+      debugPrint('[QuizResults] Failed to save daily briefing score: $e');
+    }
   }
 
   @override
@@ -138,7 +237,13 @@ class _QuizResultsScreenState extends State<QuizResultsScreen>
 
                       // Score card (big)
                       _buildScoreCard(summary),
-                      const SizedBox(height: 16),
+                      const SizedBox(height: 12),
+
+                      // Coin reward
+                      if (_coinsEarned > 0) ...[
+                        _buildCoinReward(),
+                        const SizedBox(height: 12),
+                      ],
 
                       // Stats grid
                       _buildStatsGrid(summary),
@@ -269,6 +374,33 @@ class _QuizResultsScreenState extends State<QuizResultsScreen>
               ),
             ),
           ],
+        ),
+      ],
+    ),
+  );
+
+  // ── Coin reward ────────────────────────────────────────────────────────
+
+  Widget _buildCoinReward() => Container(
+    width: double.infinity,
+    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+    decoration: BoxDecoration(
+      color: FlitColors.gold.withOpacity(0.1),
+      borderRadius: BorderRadius.circular(12),
+      border: Border.all(color: FlitColors.gold.withOpacity(0.3)),
+    ),
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Icon(Icons.monetization_on, color: FlitColors.gold, size: 24),
+        const SizedBox(width: 8),
+        Text(
+          '+$_coinsEarned coins earned',
+          style: const TextStyle(
+            color: FlitColors.gold,
+            fontSize: 16,
+            fontWeight: FontWeight.w800,
+          ),
         ),
       ],
     ),
@@ -432,7 +564,7 @@ class _QuizResultsScreenState extends State<QuizResultsScreen>
             child: OutlinedButton(
               onPressed: () => Navigator.of(context).pushReplacement(
                 MaterialPageRoute<void>(
-                  builder: (_) => const QuizSetupScreen(),
+                  builder: (_) => const FlightSchoolScreen(),
                 ),
               ),
               style: OutlinedButton.styleFrom(

--- a/lib/features/quiz/quiz_setup_screen.dart
+++ b/lib/features/quiz/quiz_setup_screen.dart
@@ -1,19 +1,25 @@
 import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../game/quiz/flight_school_level.dart';
 import '../../game/quiz/quiz_category.dart';
+import '../../game/quiz/quiz_difficulty.dart';
 import '../../game/quiz/quiz_session.dart';
 import '../../game/map/region.dart';
 import 'quiz_game_screen.dart';
+import 'type_in_game_screen.dart';
 
 /// Setup/lobby screen for Flight School quiz mode.
 ///
 /// Lets the player choose:
-/// 1. Quiz category (capitals, nicknames, sports teams, etc.)
-/// 2. Game mode (all states, time trial, rapid fire)
-/// 3. Region (USA first, extensible)
+/// 1. Quiz category (filtered by region)
+/// 2. Game mode (all areas, time trial, rapid fire)
+///
+/// The [level] parameter determines which region and categories are available.
 class QuizSetupScreen extends StatefulWidget {
-  const QuizSetupScreen({super.key});
+  const QuizSetupScreen({super.key, required this.level});
+
+  final FlightSchoolLevel level;
 
   @override
   State<QuizSetupScreen> createState() => _QuizSetupScreenState();
@@ -22,6 +28,7 @@ class QuizSetupScreen extends StatefulWidget {
 class _QuizSetupScreenState extends State<QuizSetupScreen> {
   QuizCategory _selectedCategory = QuizCategory.mixed;
   QuizMode _selectedMode = QuizMode.allStates;
+  QuizDifficulty _selectedDifficulty = QuizDifficulty.medium;
 
   static const _iconMap = <String, IconData>{
     'map': Icons.map,
@@ -38,16 +45,38 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
     'shuffle': Icons.shuffle,
   };
 
+  List<QuizCategory> get _availableCategories =>
+      _selectedDifficulty.filterCategories(widget.level.availableCategories);
+
+  @override
+  void initState() {
+    super.initState();
+    // Ensure default selection is valid for this level
+    if (!_availableCategories.contains(_selectedCategory)) {
+      _selectedCategory = _availableCategories.first;
+    }
+  }
+
   void _startQuiz() {
-    Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => QuizGameScreen(
-          mode: _selectedMode,
-          category: _selectedCategory,
-          region: GameRegion.usStates,
-        ),
-      ),
-    );
+    final Widget screen;
+    if (_selectedMode == QuizMode.typeIn) {
+      screen = TypeInGameScreen(
+        mode: _selectedMode,
+        category: _selectedCategory,
+        region: widget.level.region,
+        difficulty: _selectedDifficulty,
+        flightSchoolLevelId: widget.level.id,
+      );
+    } else {
+      screen = QuizGameScreen(
+        mode: _selectedMode,
+        category: _selectedCategory,
+        region: widget.level.region,
+        difficulty: _selectedDifficulty,
+        flightSchoolLevelId: widget.level.id,
+      );
+    }
+    Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => screen));
   }
 
   @override
@@ -56,9 +85,9 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
       backgroundColor: FlitColors.backgroundDark,
       appBar: AppBar(
         backgroundColor: FlitColors.backgroundMid,
-        title: const Text(
-          'Flight School',
-          style: TextStyle(color: FlitColors.textPrimary),
+        title: Text(
+          widget.level.name,
+          style: const TextStyle(color: FlitColors.textPrimary),
         ),
         centerTitle: true,
         iconTheme: const IconThemeData(color: FlitColors.textPrimary),
@@ -75,17 +104,20 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // Header
                     _buildHeader(),
                     const SizedBox(height: 24),
 
-                    // Game mode selection
+                    // Difficulty selector
+                    _buildSectionLabel('DIFFICULTY', Icons.tune),
+                    const SizedBox(height: 10),
+                    _buildDifficultySelector(),
+                    const SizedBox(height: 24),
+
                     _buildSectionLabel('GAME MODE', Icons.videogame_asset),
                     const SizedBox(height: 10),
                     ..._buildModeCards(),
                     const SizedBox(height: 24),
 
-                    // Category selection
                     _buildSectionLabel('CATEGORY', Icons.category),
                     const SizedBox(height: 10),
                     _buildCategoryGrid(),
@@ -95,15 +127,12 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
               ),
             ),
 
-            // Bottom start button
             _buildBottomBar(),
           ],
         ),
       ),
     );
   }
-
-  // ── Header ──────────────────────────────────────────────────────────────
 
   Widget _buildHeader() => Container(
     width: double.infinity,
@@ -124,9 +153,9 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
           child: const Icon(Icons.school, color: FlitColors.gold, size: 36),
         ),
         const SizedBox(height: 14),
-        const Text(
-          'FLIGHT SCHOOL',
-          style: TextStyle(
+        Text(
+          widget.level.name.toUpperCase(),
+          style: const TextStyle(
             color: FlitColors.textPrimary,
             fontSize: 24,
             fontWeight: FontWeight.w900,
@@ -134,10 +163,10 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
           ),
         ),
         const SizedBox(height: 8),
-        const Text(
-          'Test your knowledge of US states!\n'
-          'Tap the correct state on the map as fast as you can.',
-          style: TextStyle(
+        Text(
+          'Test your knowledge of ${widget.level.name}!\n'
+          'Tap the correct area on the map as fast as you can.',
+          style: const TextStyle(
             color: FlitColors.textSecondary,
             fontSize: 14,
             height: 1.4,
@@ -145,7 +174,6 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: 12),
-        // Region badge
         Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
           decoration: BoxDecoration(
@@ -155,12 +183,12 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
           ),
           child: Row(
             mainAxisSize: MainAxisSize.min,
-            children: const [
-              Icon(Icons.public, color: FlitColors.accent, size: 16),
-              SizedBox(width: 6),
+            children: [
+              const Icon(Icons.public, color: FlitColors.accent, size: 16),
+              const SizedBox(width: 6),
               Text(
-                'USA — 50 States',
-                style: TextStyle(
+                '${widget.level.name} \u2014 ${widget.level.subtitle}',
+                style: const TextStyle(
                   color: FlitColors.accent,
                   fontSize: 12,
                   fontWeight: FontWeight.w600,
@@ -172,8 +200,6 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
       ],
     ),
   );
-
-  // ── Section label ───────────────────────────────────────────────────────
 
   Widget _buildSectionLabel(String label, IconData icon) => Row(
     children: [
@@ -191,8 +217,6 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
     ],
   );
 
-  // ── Mode cards ──────────────────────────────────────────────────────────
-
   List<Widget> _buildModeCards() {
     return QuizMode.values.map((mode) {
       final isSelected = _selectedMode == mode;
@@ -204,6 +228,8 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
           icon = Icons.timer;
         case QuizMode.rapidFire:
           icon = Icons.bolt;
+        case QuizMode.typeIn:
+          icon = Icons.keyboard;
       }
 
       return Padding(
@@ -287,13 +313,11 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
     }).toList();
   }
 
-  // ── Category grid ──────────────────────────────────────────────────────
-
   Widget _buildCategoryGrid() {
     return Wrap(
       spacing: 8,
       runSpacing: 8,
-      children: QuizCategory.values.map((category) {
+      children: _availableCategories.map((category) {
         final isSelected = _selectedCategory == category;
         final iconData = _iconMap[category.icon] ?? Icons.help;
 
@@ -345,7 +369,103 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
     );
   }
 
-  // ── Bottom bar ──────────────────────────────────────────────────────────
+  Widget _buildDifficultySelector() {
+    return Row(
+      children: QuizDifficulty.values.map((diff) {
+        final isSelected = _selectedDifficulty == diff;
+        final color = _difficultyColor(diff);
+
+        return Expanded(
+          child: Padding(
+            padding: EdgeInsets.only(
+              right: diff != QuizDifficulty.hard ? 8 : 0,
+            ),
+            child: GestureDetector(
+              onTap: () {
+                setState(() {
+                  _selectedDifficulty = diff;
+                  // Re-validate category selection
+                  if (!_availableCategories.contains(_selectedCategory)) {
+                    _selectedCategory = _availableCategories.first;
+                  }
+                });
+              },
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? color.withOpacity(0.15)
+                      : FlitColors.cardBackground,
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                    color: isSelected
+                        ? color.withOpacity(0.7)
+                        : FlitColors.cardBorder,
+                    width: isSelected ? 1.5 : 1,
+                  ),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      diff.displayName.toUpperCase(),
+                      style: TextStyle(
+                        color: isSelected ? color : FlitColors.textSecondary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 1,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      diff.showLabels ? 'Labels on' : 'Labels off',
+                      style: TextStyle(
+                        color: isSelected
+                            ? FlitColors.textSecondary
+                            : FlitColors.textMuted,
+                        fontSize: 10,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '${diff.maxHints} hints',
+                      style: TextStyle(
+                        color: isSelected
+                            ? FlitColors.textSecondary
+                            : FlitColors.textMuted,
+                        fontSize: 10,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '${diff.scoreMultiplier}x pts',
+                      style: TextStyle(
+                        color: isSelected ? color : FlitColors.textMuted,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Color _difficultyColor(QuizDifficulty diff) {
+    switch (diff) {
+      case QuizDifficulty.easy:
+        return FlitColors.success;
+      case QuizDifficulty.medium:
+        return FlitColors.accent;
+      case QuizDifficulty.hard:
+        return FlitColors.gold;
+    }
+  }
 
   Widget _buildBottomBar() => Container(
     padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),

--- a/lib/features/quiz/type_in_game_screen.dart
+++ b/lib/features/quiz/type_in_game_screen.dart
@@ -1,0 +1,1119 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../../game/quiz/quiz_category.dart';
+import '../../game/quiz/quiz_difficulty.dart';
+import '../../game/quiz/quiz_session.dart';
+import '../../game/map/region.dart';
+import 'quiz_results_screen.dart';
+
+/// Type-In game screen for Flight School.
+///
+/// Shows a clue card and a text input field. The player types the answer
+/// (country/state name) instead of tapping a map. Autocomplete suggestions
+/// filter as the player types.
+class TypeInGameScreen extends StatefulWidget {
+  const TypeInGameScreen({
+    super.key,
+    required this.mode,
+    required this.category,
+    this.region = GameRegion.usStates,
+    this.difficulty = QuizDifficulty.medium,
+    this.flightSchoolLevelId,
+  });
+
+  final QuizMode mode;
+  final QuizCategory category;
+  final GameRegion region;
+  final QuizDifficulty difficulty;
+  final String? flightSchoolLevelId;
+
+  @override
+  State<TypeInGameScreen> createState() => _TypeInGameScreenState();
+}
+
+class _TypeInGameScreenState extends State<TypeInGameScreen>
+    with TickerProviderStateMixin {
+  late QuizSession _session;
+  late List<String> _allAreaNames;
+  late Map<String, String> _nameToCode;
+  Timer? _timer;
+
+  final TextEditingController _textController = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
+
+  List<String> _suggestions = [];
+  bool _showFeedback = false;
+  bool _lastAnswerCorrect = false;
+  String _feedbackText = '';
+  int? _lastPoints;
+
+  late AnimationController _feedbackAnimController;
+  late Animation<double> _feedbackOpacity;
+  late AnimationController _shakeController;
+  late Animation<double> _shakeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _feedbackAnimController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    );
+    _feedbackOpacity = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(
+        parent: _feedbackAnimController,
+        curve: const Interval(0.6, 1.0, curve: Curves.easeOut),
+      ),
+    );
+
+    _shakeController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 400),
+    );
+    _shakeAnimation = Tween<double>(begin: 0, end: 1).animate(
+      CurvedAnimation(parent: _shakeController, curve: Curves.elasticIn),
+    );
+
+    _initSession();
+  }
+
+  void _initSession() {
+    _session = QuizSession(
+      mode: widget.mode,
+      category: widget.category,
+      region: widget.region,
+      difficulty: widget.difficulty,
+    );
+
+    // Build area name lookup
+    final areas = RegionalData.getAreas(widget.region);
+    _nameToCode = {for (final area in areas) area.name: area.code};
+    _allAreaNames = areas.map((a) => a.name).toList()..sort();
+
+    _session.start();
+    _startTimer();
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(milliseconds: 100), (_) {
+      _session.tick();
+      if (_session.isFinished) {
+        _timer?.cancel();
+        _navigateToResults();
+      }
+      setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _textController.dispose();
+    _focusNode.dispose();
+    _feedbackAnimController.dispose();
+    _shakeController.dispose();
+    super.dispose();
+  }
+
+  // ── Answer matching ──────────────────────────────────────────────────────
+
+  /// Normalize a string for comparison: lowercase, trim, remove diacritics.
+  static String _normalize(String s) {
+    var result = s.toLowerCase().trim();
+    // Remove common diacritics by mapping to ASCII equivalents
+    const diacriticMap = {
+      '\u00e0': 'a', '\u00e1': 'a', '\u00e2': 'a', '\u00e3': 'a',
+      '\u00e4': 'a', '\u00e5': 'a',
+      '\u00e8': 'e', '\u00e9': 'e', '\u00ea': 'e', '\u00eb': 'e',
+      '\u00ec': 'i', '\u00ed': 'i', '\u00ee': 'i', '\u00ef': 'i',
+      '\u00f2': 'o', '\u00f3': 'o', '\u00f4': 'o', '\u00f5': 'o',
+      '\u00f6': 'o',
+      '\u00f9': 'u', '\u00fa': 'u', '\u00fb': 'u', '\u00fc': 'u',
+      '\u00f1': 'n',
+      '\u00e7': 'c',
+      '\u00ff': 'y', '\u00fd': 'y',
+      '\u00f0': 'd',
+      '\u00df': 'ss',
+      '\u00e6': 'ae',
+      '\u0153': 'oe',
+      '\u00f8': 'o',
+      // Uppercase variants (after lowercasing these shouldn't appear, but safe)
+    };
+    for (final entry in diacriticMap.entries) {
+      result = result.replaceAll(entry.key, entry.value);
+    }
+    // Also strip curly/smart quotes and normalize apostrophes
+    result = result
+        .replaceAll('\u2018', "'")
+        .replaceAll('\u2019', "'")
+        .replaceAll('\u201c', '"')
+        .replaceAll('\u201d', '"');
+    return result;
+  }
+
+  /// Check if the typed input matches the expected answer.
+  bool _isMatch(String input, String expected) {
+    final normInput = _normalize(input);
+    final normExpected = _normalize(expected);
+
+    if (normInput.isEmpty) return false;
+
+    // Exact normalized match
+    if (normInput == normExpected) return true;
+
+    // Easy difficulty: accept if input contains a significant keyword
+    // e.g. "congo" matches "Democratic Republic of the Congo"
+    if (widget.difficulty == QuizDifficulty.easy) {
+      // Split expected into words, check if any significant word (>3 chars)
+      // matches or is contained
+      final expectedWords = normExpected.split(RegExp(r'\s+'));
+      final significantWords = expectedWords
+          .where((w) => w.length > 3)
+          .toList();
+      // Accept if the input matches any significant word
+      for (final word in significantWords) {
+        if (normInput == word) return true;
+      }
+      // Accept if expected contains input and input is reasonably long
+      if (normInput.length >= 4 && normExpected.contains(normInput)) {
+        return true;
+      }
+    }
+
+    // Hard difficulty: only exact normalized match (already checked above)
+    if (widget.difficulty == QuizDifficulty.hard) return false;
+
+    // Medium: accept close matches — allow missing/extra "the", minor diffs
+    // Strip common articles
+    String stripArticles(String s) =>
+        s.replaceAll(RegExp(r'^(the|a|an|of)\s+'), '').trim();
+    final strippedInput = stripArticles(normInput);
+    final strippedExpected = stripArticles(normExpected);
+    if (strippedInput == strippedExpected) return true;
+
+    // Accept if expected contains input as a substantial substring
+    if (strippedInput.length >= 4 && strippedExpected.contains(strippedInput)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // ── Autocomplete ────────────────────────────────────────────────────────
+
+  void _onTextChanged(String value) {
+    setState(() {
+      if (value.trim().isEmpty) {
+        _suggestions = [];
+      } else {
+        final normInput = _normalize(value);
+        _suggestions = _allAreaNames.where((name) {
+          final normName = _normalize(name);
+          return normName.contains(normInput);
+        }).toList();
+        // Limit suggestions to 6
+        if (_suggestions.length > 6) {
+          _suggestions = _suggestions.sublist(0, 6);
+        }
+      }
+    });
+  }
+
+  void _selectSuggestion(String name) {
+    _textController.text = name;
+    _textController.selection = TextSelection.collapsed(offset: name.length);
+    setState(() {
+      _suggestions = [];
+    });
+    _submitAnswer();
+  }
+
+  // ── Submit ──────────────────────────────────────────────────────────────
+
+  void _submitAnswer() {
+    if (_session.isFinished || _session.currentQuestion == null) return;
+
+    final input = _textController.text.trim();
+    if (input.isEmpty) return;
+
+    final question = _session.currentQuestion!;
+    final correct = _isMatch(input, question.answerName);
+
+    if (correct) {
+      // Submit the correct answer code to record a correct result
+      final result = _session.submitAnswer(question.answerCode);
+      if (result == null) return;
+
+      setState(() {
+        _showFeedback = true;
+        _lastAnswerCorrect = true;
+        _lastPoints = result.points;
+        _feedbackText = 'Correct! ${question.answerName}';
+        _textController.clear();
+        _suggestions = [];
+      });
+    } else {
+      // Submit a synthetic wrong code, then advance past the question
+      final result = _session.submitAnswer('__wrong_typein__');
+      if (result == null) return;
+      // Advance to the next question since the player can't "retry" in type-in
+      _session.advanceQuestion();
+
+      setState(() {
+        _showFeedback = true;
+        _lastAnswerCorrect = false;
+        _lastPoints = result.points;
+        _feedbackText = 'Wrong! It was ${question.answerName}';
+        _textController.clear();
+        _suggestions = [];
+      });
+
+      _shakeController.forward(from: 0);
+    }
+
+    // Play feedback animation
+    _feedbackAnimController.forward(from: 0).then((_) {
+      if (mounted) {
+        setState(() => _showFeedback = false);
+      }
+    });
+
+    if (_session.isFinished) {
+      _timer?.cancel();
+      Future.delayed(const Duration(milliseconds: 800), _navigateToResults);
+    } else {
+      _focusNode.requestFocus();
+    }
+  }
+
+  void _skipQuestion() {
+    if (_session.isFinished || _session.currentQuestion == null) return;
+    final question = _session.currentQuestion!;
+
+    // Record as wrong, then advance past the question
+    _session.submitAnswer('__skip_typein__');
+    _session.advanceQuestion();
+
+    setState(() {
+      _showFeedback = true;
+      _lastAnswerCorrect = false;
+      _lastPoints = 0;
+      _feedbackText = 'Skipped! It was ${question.answerName}';
+      _textController.clear();
+      _suggestions = [];
+    });
+
+    _feedbackAnimController.forward(from: 0).then((_) {
+      if (mounted) {
+        setState(() => _showFeedback = false);
+      }
+    });
+
+    if (_session.isFinished) {
+      _timer?.cancel();
+      Future.delayed(const Duration(milliseconds: 800), _navigateToResults);
+    } else {
+      _focusNode.requestFocus();
+    }
+  }
+
+  // ── Navigation ──────────────────────────────────────────────────────────
+
+  Future<void> _navigateToResults() async {
+    if (!mounted) return;
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute<void>(
+        builder: (_) => QuizResultsScreen(
+          summary: _session.summary,
+          flightSchoolLevelId: widget.flightSchoolLevelId,
+          region: widget.region,
+        ),
+      ),
+    );
+  }
+
+  void _confirmQuit() {
+    showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: FlitColors.cardBackground,
+        title: const Text(
+          'Quit Quiz?',
+          style: TextStyle(color: FlitColors.textPrimary),
+        ),
+        content: const Text(
+          'Your progress will be lost.',
+          style: TextStyle(color: FlitColors.textSecondary),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text(
+              'CANCEL',
+              style: TextStyle(color: FlitColors.textSecondary),
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop(true);
+              _session.finish();
+              _navigateToResults();
+            },
+            child: const Text(
+              'QUIT',
+              style: TextStyle(color: FlitColors.error),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Build ───────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final question = _session.currentQuestion;
+    final remaining = _session.remainingMs;
+
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      resizeToAvoidBottomInset: true,
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Top bar
+            _buildTopBar(remaining),
+
+            // Scrollable content area
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Column(
+                  children: [
+                    const SizedBox(height: 8),
+
+                    // Score bar
+                    _buildScoreBar(),
+                    const SizedBox(height: 12),
+
+                    // Clue card
+                    _buildClueCard(question),
+                    const SizedBox(height: 8),
+
+                    // First letter hint (easy mode)
+                    if (widget.difficulty == QuizDifficulty.easy &&
+                        question != null)
+                      _buildFirstLetterHint(question.answerName),
+
+                    const SizedBox(height: 16),
+
+                    // Feedback animation
+                    if (_showFeedback) _buildFeedback(),
+
+                    // Text input
+                    _buildTextInput(),
+                    const SizedBox(height: 8),
+
+                    // Action buttons
+                    _buildActionButtons(),
+                    const SizedBox(height: 8),
+
+                    // Autocomplete suggestions
+                    if (_suggestions.isNotEmpty) _buildSuggestions(),
+
+                    const SizedBox(height: 16),
+                  ],
+                ),
+              ),
+            ),
+
+            // Progress bar
+            _buildProgressBar(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ── Top bar ─────────────────────────────────────────────────────────────
+
+  Widget _buildTopBar(int? remainingMs) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: const BoxDecoration(
+        color: FlitColors.backgroundMid,
+        border: Border(
+          bottom: BorderSide(color: FlitColors.cardBorder, width: 0.5),
+        ),
+      ),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: _confirmQuit,
+            child: const Icon(
+              Icons.arrow_back_ios_new,
+              color: FlitColors.textSecondary,
+              size: 20,
+            ),
+          ),
+          const SizedBox(width: 12),
+
+          // Mode label
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: FlitColors.accent.withOpacity(0.15),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.keyboard, color: FlitColors.accent, size: 14),
+                const SizedBox(width: 4),
+                Text(
+                  widget.mode.displayName.toUpperCase(),
+                  style: const TextStyle(
+                    color: FlitColors.accent,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 1,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+
+          // Category label
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: FlitColors.gold.withOpacity(0.15),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              widget.category.displayName.toUpperCase(),
+              style: const TextStyle(
+                color: FlitColors.gold,
+                fontSize: 11,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 1,
+              ),
+            ),
+          ),
+
+          const Spacer(),
+
+          // Timer
+          _buildTimer(remainingMs),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTimer(int? remainingMs) {
+    final isCountdown = remainingMs != null;
+    final displayTime = isCountdown
+        ? _formatMs(remainingMs)
+        : _session.elapsedFormatted;
+    final isUrgent = isCountdown && remainingMs < 10000;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: isUrgent
+            ? FlitColors.error.withOpacity(0.2)
+            : FlitColors.backgroundDark,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: isUrgent ? FlitColors.error : FlitColors.cardBorder,
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            isCountdown ? Icons.timer : Icons.access_time,
+            color: isUrgent ? FlitColors.error : FlitColors.textSecondary,
+            size: 16,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            displayTime,
+            style: TextStyle(
+              color: isUrgent ? FlitColors.error : FlitColors.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w900,
+              fontFamily: 'monospace',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatMs(int ms) {
+    final seconds = (ms / 1000).ceil();
+    final minutes = seconds ~/ 60;
+    final secs = seconds % 60;
+    return '$minutes:${secs.toString().padLeft(2, '0')}';
+  }
+
+  // ── Score bar ───────────────────────────────────────────────────────────
+
+  Widget _buildScoreBar() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        // Score
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.star, color: FlitColors.gold, size: 18),
+            const SizedBox(width: 4),
+            Text(
+              '${_session.totalScore}',
+              style: const TextStyle(
+                color: FlitColors.gold,
+                fontSize: 16,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ],
+        ),
+
+        // Streak
+        if (_session.streak > 1)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: FlitColors.accent.withOpacity(0.2),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.local_fire_department,
+                  color: FlitColors.accent,
+                  size: 16,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  '${_session.streak}x streak',
+                  style: const TextStyle(
+                    color: FlitColors.accent,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+        // Correct / Wrong counts
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '${_session.correctCount}',
+              style: const TextStyle(
+                color: FlitColors.success,
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const Text(
+              ' / ',
+              style: TextStyle(color: FlitColors.textMuted, fontSize: 14),
+            ),
+            Text(
+              '${_session.wrongCount}',
+              style: const TextStyle(
+                color: FlitColors.error,
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  // ── Clue card ───────────────────────────────────────────────────────────
+
+  Widget _buildClueCard(QuizQuestion? question) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      child: Container(
+        key: ValueKey(question?.clueText ?? 'empty'),
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: FlitColors.accent.withOpacity(0.4)),
+          boxShadow: [
+            BoxShadow(
+              color: FlitColors.accent.withOpacity(0.1),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: question != null
+            ? Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Question number
+                  Text(
+                    '${_session.currentIndex + 1} / ${_session.totalQuestions}',
+                    style: const TextStyle(
+                      color: FlitColors.textMuted,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  // Category icon
+                  Icon(
+                    Icons.keyboard,
+                    color: FlitColors.accent.withOpacity(0.5),
+                    size: 28,
+                  ),
+                  const SizedBox(height: 8),
+                  // Clue text
+                  Text(
+                    question.clueText,
+                    style: const TextStyle(
+                      color: FlitColors.textPrimary,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w800,
+                      height: 1.3,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              )
+            : const Text(
+                'Quiz Complete!',
+                style: TextStyle(
+                  color: FlitColors.gold,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+      ),
+    );
+  }
+
+  // ── First letter hint (easy mode) ───────────────────────────────────────
+
+  Widget _buildFirstLetterHint(String answerName) {
+    final firstLetter = answerName.isNotEmpty ? answerName[0] : '?';
+    return Container(
+      margin: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: FlitColors.success.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: FlitColors.success.withOpacity(0.3)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.lightbulb_outline,
+            color: FlitColors.success,
+            size: 16,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            'Starts with "$firstLetter"',
+            style: const TextStyle(
+              color: FlitColors.success,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Feedback ────────────────────────────────────────────────────────────
+
+  Widget _buildFeedback() {
+    final color = _lastAnswerCorrect ? FlitColors.success : FlitColors.error;
+    final icon = _lastAnswerCorrect ? Icons.check_circle : Icons.cancel;
+
+    return AnimatedBuilder(
+      animation: _feedbackAnimController,
+      builder: (context, child) {
+        return Opacity(
+          opacity: _feedbackOpacity.value.clamp(0.0, 1.0),
+          child: Container(
+            width: double.infinity,
+            margin: const EdgeInsets.only(bottom: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            decoration: BoxDecoration(
+              color: color.withOpacity(0.15),
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: color.withOpacity(0.4)),
+            ),
+            child: Row(
+              children: [
+                Icon(icon, color: color, size: 24),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    _feedbackText,
+                    style: TextStyle(
+                      color: color,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                if (_lastPoints != null && _lastPoints != 0)
+                  Text(
+                    _lastPoints! > 0 ? '+$_lastPoints' : '$_lastPoints',
+                    style: TextStyle(
+                      color: color,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  // ── Text input ──────────────────────────────────────────────────────────
+
+  Widget _buildTextInput() {
+    return AnimatedBuilder(
+      animation: _shakeController,
+      builder: (context, child) {
+        final shakeOffset =
+            _shakeAnimation.value * 8 * _shakeDirectionMultiplier();
+        return Transform.translate(
+          offset: Offset(shakeOffset, 0),
+          child: child,
+        );
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: _focusNode.hasFocus
+                ? FlitColors.accent.withOpacity(0.6)
+                : FlitColors.cardBorder,
+            width: _focusNode.hasFocus ? 1.5 : 1,
+          ),
+        ),
+        child: TextField(
+          controller: _textController,
+          focusNode: _focusNode,
+          autofocus: true,
+          textInputAction: TextInputAction.done,
+          style: const TextStyle(
+            color: FlitColors.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+          ),
+          decoration: InputDecoration(
+            hintText: 'Type the answer...',
+            hintStyle: TextStyle(
+              color: FlitColors.textMuted.withOpacity(0.6),
+              fontSize: 16,
+            ),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 14,
+            ),
+            border: InputBorder.none,
+            prefixIcon: const Icon(
+              Icons.edit,
+              color: FlitColors.textMuted,
+              size: 20,
+            ),
+            suffixIcon: _textController.text.isNotEmpty
+                ? GestureDetector(
+                    onTap: () {
+                      _textController.clear();
+                      setState(() => _suggestions = []);
+                    },
+                    child: const Icon(
+                      Icons.clear,
+                      color: FlitColors.textMuted,
+                      size: 20,
+                    ),
+                  )
+                : null,
+          ),
+          onChanged: _onTextChanged,
+          onSubmitted: (_) => _submitAnswer(),
+        ),
+      ),
+    );
+  }
+
+  /// Produces a sine-like shake pattern based on the animation value.
+  double _shakeDirectionMultiplier() {
+    final t = _shakeAnimation.value;
+    // Oscillate: right, left, right, center
+    if (t < 0.25) return 1;
+    if (t < 0.5) return -1;
+    if (t < 0.75) return 1;
+    return -1;
+  }
+
+  // ── Action buttons ─────────────────────────────────────────────────────
+
+  Widget _buildActionButtons() {
+    return Row(
+      children: [
+        // Skip button
+        Expanded(
+          child: GestureDetector(
+            onTap: _skipQuestion,
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              decoration: BoxDecoration(
+                color: FlitColors.backgroundMid,
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: FlitColors.cardBorder),
+              ),
+              child: const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.skip_next,
+                    color: FlitColors.textSecondary,
+                    size: 20,
+                  ),
+                  SizedBox(width: 6),
+                  Text(
+                    'SKIP',
+                    style: TextStyle(
+                      color: FlitColors.textSecondary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 1,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        // Submit button
+        Expanded(
+          flex: 2,
+          child: GestureDetector(
+            onTap: _submitAnswer,
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              decoration: BoxDecoration(
+                color: FlitColors.accent,
+                borderRadius: BorderRadius.circular(10),
+                boxShadow: [
+                  BoxShadow(
+                    color: FlitColors.accent.withOpacity(0.3),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.send, color: FlitColors.textPrimary, size: 20),
+                  SizedBox(width: 8),
+                  Text(
+                    'SUBMIT',
+                    style: TextStyle(
+                      color: FlitColors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 1.5,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ── Suggestions ─────────────────────────────────────────────────────────
+
+  Widget _buildSuggestions() {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(top: 4),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: FlitColors.cardBorder),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: _suggestions.asMap().entries.map((entry) {
+          final index = entry.key;
+          final name = entry.value;
+          final isLast = index == _suggestions.length - 1;
+
+          return GestureDetector(
+            onTap: () => _selectSuggestion(name),
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+              decoration: BoxDecoration(
+                border: isLast
+                    ? null
+                    : const Border(
+                        bottom: BorderSide(
+                          color: FlitColors.cardBorder,
+                          width: 0.5,
+                        ),
+                      ),
+              ),
+              child: Row(
+                children: [
+                  const Icon(
+                    Icons.place,
+                    color: FlitColors.textMuted,
+                    size: 16,
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(child: _buildHighlightedName(name)),
+                  const Icon(
+                    Icons.north_west,
+                    color: FlitColors.textMuted,
+                    size: 14,
+                  ),
+                ],
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  /// Highlight the matching portion of the suggestion.
+  Widget _buildHighlightedName(String name) {
+    final input = _textController.text.trim().toLowerCase();
+    final nameLower = name.toLowerCase();
+    final matchIndex = nameLower.indexOf(input);
+
+    if (input.isEmpty || matchIndex < 0) {
+      return Text(
+        name,
+        style: const TextStyle(color: FlitColors.textSecondary, fontSize: 15),
+      );
+    }
+
+    final before = name.substring(0, matchIndex);
+    final match = name.substring(matchIndex, matchIndex + input.length);
+    final after = name.substring(matchIndex + input.length);
+
+    return RichText(
+      text: TextSpan(
+        children: [
+          TextSpan(
+            text: before,
+            style: const TextStyle(
+              color: FlitColors.textSecondary,
+              fontSize: 15,
+            ),
+          ),
+          TextSpan(
+            text: match,
+            style: const TextStyle(
+              color: FlitColors.accent,
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          TextSpan(
+            text: after,
+            style: const TextStyle(
+              color: FlitColors.textSecondary,
+              fontSize: 15,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Progress bar ────────────────────────────────────────────────────────
+
+  Widget _buildProgressBar() {
+    final answered = _session.correctCount + _session.wrongCount;
+    final total = _session.totalQuestions;
+    final progress = total > 0 ? _session.correctCount / total : 0.0;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+      decoration: const BoxDecoration(
+        color: FlitColors.backgroundMid,
+        border: Border(
+          top: BorderSide(color: FlitColors.cardBorder, width: 0.5),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '$answered of $total answered',
+                style: const TextStyle(
+                  color: FlitColors.textSecondary,
+                  fontSize: 12,
+                ),
+              ),
+              Text(
+                '${(progress * 100).round()}% correct',
+                style: const TextStyle(
+                  color: FlitColors.gold,
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(3),
+            child: LinearProgressIndicator(
+              value: progress,
+              backgroundColor: FlitColors.backgroundDark,
+              valueColor: const AlwaysStoppedAnimation<Color>(FlitColors.gold),
+              minHeight: 5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/game/map/region.dart
+++ b/lib/game/map/region.dart
@@ -10,6 +10,11 @@ enum GameRegion {
   caribbean,
   ireland,
   canadianProvinces,
+  europe,
+  africa,
+  asia,
+  latinAmerica,
+  oceania,
 }
 
 /// Whether a region uses a flat map projection instead of the globe.
@@ -20,6 +25,11 @@ bool isRegionalFlatMap(GameRegion region) {
   switch (region) {
     case GameRegion.world:
     case GameRegion.caribbean:
+    case GameRegion.europe:
+    case GameRegion.africa:
+    case GameRegion.asia:
+    case GameRegion.latinAmerica:
+    case GameRegion.oceania:
       return false;
     case GameRegion.usStates:
     case GameRegion.ukCounties:
@@ -44,6 +54,16 @@ extension GameRegionExtension on GameRegion {
         return 'Ireland';
       case GameRegion.canadianProvinces:
         return 'Canada';
+      case GameRegion.europe:
+        return 'Europe';
+      case GameRegion.africa:
+        return 'Africa';
+      case GameRegion.asia:
+        return 'Asia';
+      case GameRegion.latinAmerica:
+        return 'Latin America';
+      case GameRegion.oceania:
+        return 'Oceania';
     }
   }
 
@@ -61,6 +81,16 @@ extension GameRegionExtension on GameRegion {
         return 'Tour all 32 counties of Ireland';
       case GameRegion.canadianProvinces:
         return 'Fly across Canada\'s provinces';
+      case GameRegion.europe:
+        return 'Test your knowledge of European countries';
+      case GameRegion.africa:
+        return 'Navigate the African continent';
+      case GameRegion.asia:
+        return 'Explore the diverse nations of Asia';
+      case GameRegion.latinAmerica:
+        return 'Fly through Central & South America';
+      case GameRegion.oceania:
+        return 'Discover the Pacific island nations';
     }
   }
 
@@ -79,6 +109,16 @@ extension GameRegionExtension on GameRegion {
         return [-11, 51, -5, 56];
       case GameRegion.canadianProvinces:
         return [-141, 42, -52, 72];
+      case GameRegion.europe:
+        return [-25, 34, 45, 72];
+      case GameRegion.africa:
+        return [-18, -35, 52, 38];
+      case GameRegion.asia:
+        return [25, -12, 150, 55];
+      case GameRegion.latinAmerica:
+        return [-118, -56, -34, 33];
+      case GameRegion.oceania:
+        return [110, -50, 180, 0];
     }
   }
 
@@ -95,14 +135,24 @@ extension GameRegionExtension on GameRegion {
         return 1;
       case GameRegion.usStates:
         return 3;
+      case GameRegion.canadianProvinces:
+        return 4;
       case GameRegion.ukCounties:
         return 5;
+      case GameRegion.europe:
+        return 3;
+      case GameRegion.africa:
+        return 5;
+      case GameRegion.asia:
+        return 7;
+      case GameRegion.latinAmerica:
+        return 9;
+      case GameRegion.oceania:
+        return 11;
       case GameRegion.caribbean:
         return 7;
       case GameRegion.ireland:
         return 10;
-      case GameRegion.canadianProvinces:
-        return 4;
     }
   }
 
@@ -155,8 +205,238 @@ abstract class RegionalData {
         return _irelandCounties;
       case GameRegion.canadianProvinces:
         return _canadianProvinces;
+      case GameRegion.europe:
+        return _countriesForCodes(_europeCodes);
+      case GameRegion.africa:
+        return _countriesForCodes(_africaCodes);
+      case GameRegion.asia:
+        return _countriesForCodes(_asiaCodes);
+      case GameRegion.latinAmerica:
+        return _countriesForCodes(_latinAmericaCodes);
+      case GameRegion.oceania:
+        return _countriesForCodes(_oceaniaCodes);
     }
   }
+
+  static List<RegionalArea> _countriesForCodes(Set<String> codes) {
+    return CountryData.countries
+        .where((c) => codes.contains(c.code))
+        .map(
+          (c) => RegionalArea(
+            code: c.code,
+            name: c.name,
+            points: c.allPoints,
+            capital: c.capital,
+          ),
+        )
+        .toList();
+  }
+
+  // ── Continent country code sets ────────────────────────────────────────
+
+  static const _europeCodes = <String>{
+    'AD',
+    'AL',
+    'AT',
+    'BA',
+    'BE',
+    'BG',
+    'BY',
+    'CH',
+    'CY',
+    'CZ',
+    'DE',
+    'DK',
+    'EE',
+    'ES',
+    'FI',
+    'FR',
+    'GB',
+    'GR',
+    'HR',
+    'HU',
+    'IE',
+    'IS',
+    'IT',
+    'LI',
+    'LT',
+    'LU',
+    'LV',
+    'MC',
+    'MD',
+    'ME',
+    'MK',
+    'MT',
+    'NL',
+    'NO',
+    'PL',
+    'PT',
+    'RO',
+    'RS',
+    'RU',
+    'SE',
+    'SI',
+    'SK',
+    'SM',
+    'TR',
+    'UA',
+    'VA',
+    'XK',
+  };
+
+  static const _africaCodes = <String>{
+    'AO',
+    'BF',
+    'BI',
+    'BJ',
+    'BW',
+    'CD',
+    'CF',
+    'CG',
+    'CI',
+    'CM',
+    'CV',
+    'DJ',
+    'DZ',
+    'EG',
+    'EH',
+    'ER',
+    'ET',
+    'GA',
+    'GH',
+    'GM',
+    'GN',
+    'GQ',
+    'GW',
+    'KE',
+    'KM',
+    'LR',
+    'LS',
+    'LY',
+    'MA',
+    'MG',
+    'ML',
+    'MR',
+    'MU',
+    'MW',
+    'MZ',
+    'NA',
+    'NE',
+    'NG',
+    'RW',
+    'SC',
+    'SD',
+    'SL',
+    'SN',
+    'SO',
+    'SS',
+    'ST',
+    'SZ',
+    'TD',
+    'TG',
+    'TN',
+    'TZ',
+    'UG',
+    'ZA',
+    'ZM',
+    'ZW',
+  };
+
+  static const _asiaCodes = <String>{
+    'AE',
+    'AF',
+    'AM',
+    'AZ',
+    'BD',
+    'BH',
+    'BN',
+    'BT',
+    'CN',
+    'GE',
+    'ID',
+    'IL',
+    'IN',
+    'IQ',
+    'IR',
+    'JO',
+    'JP',
+    'KG',
+    'KH',
+    'KP',
+    'KR',
+    'KW',
+    'KZ',
+    'LA',
+    'LB',
+    'LK',
+    'MM',
+    'MN',
+    'MV',
+    'MY',
+    'NP',
+    'OM',
+    'PH',
+    'PK',
+    'PS',
+    'QA',
+    'SA',
+    'SG',
+    'SY',
+    'TH',
+    'TJ',
+    'TL',
+    'TM',
+    'TW',
+    'UZ',
+    'VN',
+    'YE',
+  };
+
+  static const _latinAmericaCodes = <String>{
+    'AR',
+    'BO',
+    'BR',
+    'BZ',
+    'CL',
+    'CO',
+    'CR',
+    'CU',
+    'DO',
+    'EC',
+    'GT',
+    'GY',
+    'HN',
+    'HT',
+    'JM',
+    'MX',
+    'NI',
+    'PA',
+    'PE',
+    'PR',
+    'PY',
+    'SR',
+    'SV',
+    'TT',
+    'UY',
+    'VE',
+  };
+
+  static const _oceaniaCodes = <String>{
+    'AU',
+    'FJ',
+    'FM',
+    'KI',
+    'MH',
+    'NR',
+    'NZ',
+    'PG',
+    'PW',
+    'SB',
+    'TO',
+    'TV',
+    'VU',
+    'WS',
+  };
 
   /// Get random area from a region
   static RegionalArea getRandomArea(GameRegion region) {

--- a/lib/game/quiz/daily_briefing.dart
+++ b/lib/game/quiz/daily_briefing.dart
@@ -1,0 +1,140 @@
+import 'dart:math';
+
+import 'flight_school_level.dart';
+import 'quiz_category.dart';
+import 'quiz_difficulty.dart';
+import 'quiz_session.dart';
+
+/// Daily Flight Briefing configuration — a deterministic quiz challenge
+/// generated from the current date.
+///
+/// Every player who opens the briefing on the same calendar day (UTC) receives
+/// the same level, category, difficulty, mode, and question seed. This allows
+/// fair leaderboard competition: one attempt per day, same conditions for all.
+class DailyBriefing {
+  const DailyBriefing({
+    required this.dateKey,
+    required this.seed,
+    required this.level,
+    required this.category,
+    required this.difficulty,
+    required this.mode,
+  });
+
+  /// Date string in YYYY-MM-DD format.
+  final String dateKey;
+
+  /// Deterministic seed derived from the date (used for question order).
+  final int seed;
+
+  /// The Flight School level selected for today's briefing.
+  final FlightSchoolLevel level;
+
+  /// The quiz category for today's briefing.
+  final QuizCategory category;
+
+  /// The difficulty setting for today's briefing.
+  final QuizDifficulty difficulty;
+
+  /// The quiz mode for today's briefing.
+  final QuizMode mode;
+
+  /// Modes eligible for the daily briefing rotation.
+  ///
+  /// [QuizMode.typeIn] is excluded because it requires a text input UX that
+  /// doesn't pair well with the "same conditions for everyone" philosophy
+  /// (autocomplete/keyboard differences across devices).
+  static const List<QuizMode> _eligibleModes = [
+    QuizMode.allStates,
+    QuizMode.timeTrial,
+    QuizMode.rapidFire,
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Factories
+  // ---------------------------------------------------------------------------
+
+  /// Generate today's briefing (UTC).
+  factory DailyBriefing.today() {
+    final now = DateTime.now().toUtc();
+    return DailyBriefing.forDate(DateTime.utc(now.year, now.month, now.day));
+  }
+
+  /// Generate a briefing for a specific [date].
+  ///
+  /// Only the year/month/day components matter; the time portion is ignored.
+  factory DailyBriefing.forDate(DateTime date) {
+    final normalised = DateTime.utc(date.year, date.month, date.day);
+    final dateKey =
+        '${normalised.year}-'
+        '${normalised.month.toString().padLeft(2, '0')}-'
+        '${normalised.day.toString().padLeft(2, '0')}';
+
+    // Build a seed from the date string hash so it's stable across platforms.
+    final seed = _hashDateKey(dateKey);
+    final rng = Random(seed);
+
+    // 1. Pick a level from all available flight school levels.
+    final level = flightSchoolLevels[rng.nextInt(flightSchoolLevels.length)];
+
+    // 2. Pick a difficulty.
+    final difficulty =
+        QuizDifficulty.values[rng.nextInt(QuizDifficulty.values.length)];
+
+    // 3. Pick a category valid for this level (respecting difficulty filter).
+    final filteredCategories = difficulty.filterCategories(
+      level.availableCategories,
+    );
+    final categoryPool = filteredCategories.isNotEmpty
+        ? filteredCategories
+        : level.availableCategories;
+    final category = categoryPool[rng.nextInt(categoryPool.length)];
+
+    // 4. Pick a mode from the eligible set.
+    final mode = _eligibleModes[rng.nextInt(_eligibleModes.length)];
+
+    return DailyBriefing(
+      dateKey: dateKey,
+      seed: seed,
+      level: level,
+      category: category,
+      difficulty: difficulty,
+      mode: mode,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /// Simple djb2-style hash of the date key string to produce a stable int
+  /// seed across all Dart platforms.
+  static int _hashDateKey(String key) {
+    int hash = 5381;
+    for (int i = 0; i < key.length; i++) {
+      hash = ((hash << 5) + hash) + key.codeUnitAt(i); // hash * 33 + c
+    }
+    return hash.abs();
+  }
+
+  /// Aviation-themed subtitle describing the mission parameters.
+  String get missionSubtitle {
+    final modeLabel = mode.displayName.toUpperCase();
+    final diffLabel = difficulty.displayName.toUpperCase();
+    return '$modeLabel / $diffLabel';
+  }
+
+  /// Estimated duration label for the briefing card.
+  String get estimatedDuration {
+    switch (mode) {
+      case QuizMode.allStates:
+        return '~${level.areaCount} questions';
+      case QuizMode.timeTrial:
+        return '60 seconds';
+      case QuizMode.rapidFire:
+        return '3 strikes';
+      case QuizMode.typeIn:
+        return '90 seconds';
+    }
+  }
+}

--- a/lib/game/quiz/flight_school_level.dart
+++ b/lib/game/quiz/flight_school_level.dart
@@ -1,0 +1,297 @@
+import '../map/region.dart';
+import 'quiz_category.dart';
+
+/// A single Flight School level representing a geographic region to quiz on.
+class FlightSchoolLevel {
+  const FlightSchoolLevel({
+    required this.id,
+    required this.name,
+    required this.subtitle,
+    required this.region,
+    required this.requiredLevel,
+    required this.areaCount,
+    required this.icon,
+    required this.availableCategories,
+    this.unlockCost = 0,
+  });
+
+  final String id;
+  final String name;
+  final String subtitle;
+  final GameRegion region;
+
+  /// Minimum player level required. 0 = no level requirement (pay-only).
+  final int requiredLevel;
+  final int areaCount;
+  final String icon;
+  final List<QuizCategory> availableCategories;
+
+  /// Coin cost to unlock early (before reaching requiredLevel).
+  /// 0 means no early unlock available (level-gated only).
+  final int unlockCost;
+
+  /// Whether this level supports rich US-specific categories.
+  bool get hasRichClues => region == GameRegion.usStates;
+}
+
+/// Progress data for a single flight school level.
+class FlightSchoolProgress {
+  const FlightSchoolProgress({
+    this.bestScore = 0,
+    this.bestTimeMs = 0,
+    this.completions = 0,
+    this.attempts = 0,
+  });
+
+  final int bestScore;
+  final int bestTimeMs;
+  final int completions;
+  final int attempts;
+
+  String get grade => computeGrade(bestScore, completions, attempts);
+
+  bool get hasPlayed => attempts > 0;
+
+  String get bestTimeFormatted {
+    if (bestTimeMs <= 0) return '--';
+    final seconds = (bestTimeMs / 1000).floor();
+    final minutes = seconds ~/ 60;
+    final secs = seconds % 60;
+    return '$minutes:${secs.toString().padLeft(2, '0')}';
+  }
+
+  double get completionRate => attempts > 0 ? completions / attempts : 0;
+
+  /// Coin reward for the next completion.
+  ///
+  /// First completion: full reward (50 coins).
+  /// Subsequent completions: diminishing returns.
+  int coinRewardForCompletion(int baseCoinReward) {
+    if (completions == 0) return baseCoinReward;
+    if (completions < 3) return (baseCoinReward * 0.5).round();
+    if (completions < 10) return (baseCoinReward * 0.25).round();
+    return (baseCoinReward * 0.1).round(); // Minimal reward after 10+
+  }
+
+  FlightSchoolProgress copyWith({
+    int? bestScore,
+    int? bestTimeMs,
+    int? completions,
+    int? attempts,
+  }) => FlightSchoolProgress(
+    bestScore: bestScore ?? this.bestScore,
+    bestTimeMs: bestTimeMs ?? this.bestTimeMs,
+    completions: completions ?? this.completions,
+    attempts: attempts ?? this.attempts,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'best_score': bestScore,
+    'best_time_ms': bestTimeMs,
+    'completions': completions,
+    'attempts': attempts,
+  };
+
+  factory FlightSchoolProgress.fromJson(Map<String, dynamic> json) =>
+      FlightSchoolProgress(
+        bestScore: json['best_score'] as int? ?? 0,
+        bestTimeMs: json['best_time_ms'] as int? ?? 0,
+        completions: json['completions'] as int? ?? 0,
+        attempts: json['attempts'] as int? ?? 0,
+      );
+
+  /// Compute an aviation grade based on score, completions, and attempts.
+  static String computeGrade(int bestScore, int completions, int attempts) {
+    if (attempts == 0) return '-';
+    if (completions == 0) return 'F';
+
+    final rate = completions / attempts;
+
+    if (rate >= 0.95 && bestScore >= 50000) return 'S';
+    if (rate >= 0.90 || bestScore >= 40000) return 'A';
+    if (rate >= 0.75 || bestScore >= 30000) return 'B';
+    if (rate >= 0.50 || bestScore >= 20000) return 'C';
+    return 'D';
+  }
+
+  static String gradeTitle(String grade) {
+    switch (grade) {
+      case 'S':
+        return 'Captain';
+      case 'A':
+        return 'First Officer';
+      case 'B':
+        return 'Flight Engineer';
+      case 'C':
+        return 'Navigator';
+      case 'D':
+        return 'Cadet';
+      case 'F':
+        return 'Grounded';
+      default:
+        return 'Unranked';
+    }
+  }
+}
+
+/// All available flight school levels in unlock order.
+///
+/// Levels with unlockCost > 0 can be purchased early with coins.
+/// Levels with requiredLevel > 0 unlock automatically at that level.
+/// Some levels are both level-gated AND purchasable early.
+const List<FlightSchoolLevel> flightSchoolLevels = [
+  // ── Tier 1: Starter (free / low level) ──
+  FlightSchoolLevel(
+    id: 'europe',
+    name: 'Europe',
+    subtitle: '47 Countries',
+    region: GameRegion.europe,
+    requiredLevel: 1,
+    areaCount: 47,
+    icon: 'castle',
+    availableCategories: [
+      QuizCategory.stateName,
+      QuizCategory.capital,
+      QuizCategory.mixed,
+    ],
+  ),
+
+  // ── Tier 2: Purchasable early ──
+  FlightSchoolLevel(
+    id: 'us_states',
+    name: 'United States',
+    subtitle: '50 States',
+    region: GameRegion.usStates,
+    requiredLevel: 5,
+    unlockCost: 500,
+    areaCount: 50,
+    icon: 'flag',
+    availableCategories: QuizCategory.values,
+  ),
+  FlightSchoolLevel(
+    id: 'africa',
+    name: 'Africa',
+    subtitle: '55 Countries',
+    region: GameRegion.africa,
+    requiredLevel: 7,
+    unlockCost: 500,
+    areaCount: 55,
+    icon: 'terrain',
+    availableCategories: [
+      QuizCategory.stateName,
+      QuizCategory.capital,
+      QuizCategory.mixed,
+    ],
+  ),
+
+  // ── Tier 3: Mid-level ──
+  FlightSchoolLevel(
+    id: 'asia',
+    name: 'Asia',
+    subtitle: '47 Countries',
+    region: GameRegion.asia,
+    requiredLevel: 9,
+    unlockCost: 750,
+    areaCount: 47,
+    icon: 'temple_buddhist',
+    availableCategories: [
+      QuizCategory.stateName,
+      QuizCategory.capital,
+      QuizCategory.mixed,
+    ],
+  ),
+  FlightSchoolLevel(
+    id: 'latin_america',
+    name: 'Latin America',
+    subtitle: '26 Countries',
+    region: GameRegion.latinAmerica,
+    requiredLevel: 11,
+    unlockCost: 750,
+    areaCount: 26,
+    icon: 'festival',
+    availableCategories: [
+      QuizCategory.stateName,
+      QuizCategory.capital,
+      QuizCategory.mixed,
+    ],
+  ),
+
+  // ── Tier 4: Advanced (higher level or purchase) ──
+  FlightSchoolLevel(
+    id: 'uk_counties',
+    name: 'United Kingdom',
+    subtitle: 'Counties',
+    region: GameRegion.ukCounties,
+    requiredLevel: 13,
+    unlockCost: 1000,
+    areaCount: 100,
+    icon: 'castle',
+    availableCategories: [
+      QuizCategory.stateName,
+      QuizCategory.capital,
+      QuizCategory.mixed,
+    ],
+  ),
+  FlightSchoolLevel(
+    id: 'ireland',
+    name: 'Ireland',
+    subtitle: '32 Counties',
+    region: GameRegion.ireland,
+    requiredLevel: 15,
+    unlockCost: 1000,
+    areaCount: 32,
+    icon: 'grass',
+    availableCategories: [
+      QuizCategory.stateName,
+      QuizCategory.capital,
+      QuizCategory.mixed,
+    ],
+  ),
+  FlightSchoolLevel(
+    id: 'canada',
+    name: 'Canada',
+    subtitle: 'Provinces & Territories',
+    region: GameRegion.canadianProvinces,
+    requiredLevel: 17,
+    unlockCost: 1500,
+    areaCount: 13,
+    icon: 'landscape',
+    availableCategories: [
+      QuizCategory.stateName,
+      QuizCategory.capital,
+      QuizCategory.mixed,
+    ],
+  ),
+
+  // ── Tier 5: Expert ──
+  FlightSchoolLevel(
+    id: 'oceania',
+    name: 'Oceania',
+    subtitle: '14 Countries',
+    region: GameRegion.oceania,
+    requiredLevel: 19,
+    unlockCost: 2000,
+    areaCount: 14,
+    icon: 'beach_access',
+    availableCategories: [
+      QuizCategory.stateName,
+      QuizCategory.capital,
+      QuizCategory.mixed,
+    ],
+  ),
+  FlightSchoolLevel(
+    id: 'caribbean',
+    name: 'Caribbean',
+    subtitle: 'Island Nations',
+    region: GameRegion.caribbean,
+    requiredLevel: 20,
+    unlockCost: 2000,
+    areaCount: 28,
+    icon: 'beach_access',
+    availableCategories: [
+      QuizCategory.stateName,
+      QuizCategory.capital,
+      QuizCategory.mixed,
+    ],
+  ),
+];

--- a/lib/game/quiz/quiz_category.dart
+++ b/lib/game/quiz/quiz_category.dart
@@ -153,13 +153,19 @@ class QuizQuestionGenerator {
     QuizCategory.filmSetting,
   ];
 
-  /// Generate a list of questions for the given category, covering all states.
+  /// Categories available for any region (name + capital).
+  static const List<QuizCategory> _universalCategories = [
+    QuizCategory.stateName,
+    QuizCategory.capital,
+  ];
+
+  /// Generate a list of questions for the given category, covering all areas.
   List<QuizQuestion> generateQuestions(QuizCategory category) {
     final areas = RegionalData.getAreas(region);
     final questions = <QuizQuestion>[];
 
     for (final area in areas) {
-      final question = _generateForState(area, category);
+      final question = _generateForArea(area, category);
       if (question != null) {
         questions.add(question);
       }
@@ -169,11 +175,19 @@ class QuizQuestionGenerator {
     return questions;
   }
 
-  /// Generate a single question for a state in the given category.
-  QuizQuestion? _generateForState(RegionalArea area, QuizCategory category) {
-    final effectiveCategory = category == QuizCategory.mixed
-        ? _singleCategories[_random.nextInt(_singleCategories.length)]
-        : category;
+  /// Whether this generator's region has rich US-specific clue data.
+  bool get _hasRichClues => region == GameRegion.usStates;
+
+  /// Generate a single question for an area in the given category.
+  QuizQuestion? _generateForArea(RegionalArea area, QuizCategory category) {
+    QuizCategory effectiveCategory;
+    if (category == QuizCategory.mixed) {
+      // For non-US regions, mixed only uses universal categories.
+      final pool = _hasRichClues ? _singleCategories : _universalCategories;
+      effectiveCategory = pool[_random.nextInt(pool.length)];
+    } else {
+      effectiveCategory = category;
+    }
 
     switch (effectiveCategory) {
       case QuizCategory.stateName:

--- a/lib/game/quiz/quiz_difficulty.dart
+++ b/lib/game/quiz/quiz_difficulty.dart
@@ -1,0 +1,137 @@
+import 'quiz_category.dart';
+
+/// Difficulty level for Flight School quizzes.
+///
+/// Controls label visibility, available clue categories, hint availability,
+/// and scoring multipliers.
+enum QuizDifficulty { easy, medium, hard }
+
+extension QuizDifficultyExtension on QuizDifficulty {
+  String get displayName {
+    switch (this) {
+      case QuizDifficulty.easy:
+        return 'Easy';
+      case QuizDifficulty.medium:
+        return 'Medium';
+      case QuizDifficulty.hard:
+        return 'Hard';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case QuizDifficulty.easy:
+        return 'Labels shown, easier clues, hints available';
+      case QuizDifficulty.medium:
+        return 'No labels, all clue types, fewer hints';
+      case QuizDifficulty.hard:
+        return 'No labels, hardest clues only, no hints';
+    }
+  }
+
+  /// Whether area code labels are shown on the map.
+  bool get showLabels {
+    switch (this) {
+      case QuizDifficulty.easy:
+        return true;
+      case QuizDifficulty.medium:
+      case QuizDifficulty.hard:
+        return false;
+    }
+  }
+
+  /// Maximum hints allowed per quiz session.
+  int get maxHints {
+    switch (this) {
+      case QuizDifficulty.easy:
+        return 5;
+      case QuizDifficulty.medium:
+        return 2;
+      case QuizDifficulty.hard:
+        return 0;
+    }
+  }
+
+  /// Scoring multiplier for this difficulty.
+  /// Higher difficulty = more points.
+  double get scoreMultiplier {
+    switch (this) {
+      case QuizDifficulty.easy:
+        return 0.7;
+      case QuizDifficulty.medium:
+        return 1.0;
+      case QuizDifficulty.hard:
+        return 1.5;
+    }
+  }
+
+  /// Filter categories for US-specific regions by difficulty.
+  /// Easy: only the easiest categories.
+  /// Medium: all categories.
+  /// Hard: only the hardest categories.
+  List<QuizCategory> filterCategories(List<QuizCategory> available) {
+    // For non-US regions with only name/capital/mixed, return as-is
+    if (available.length <= 3) return available;
+
+    switch (this) {
+      case QuizDifficulty.easy:
+        return available
+            .where(
+              (c) =>
+                  c == QuizCategory.stateName ||
+                  c == QuizCategory.capital ||
+                  c == QuizCategory.nickname ||
+                  c == QuizCategory.landmark ||
+                  c == QuizCategory.mixed,
+            )
+            .toList();
+      case QuizDifficulty.medium:
+        return available;
+      case QuizDifficulty.hard:
+        return available
+            .where(
+              (c) =>
+                  c == QuizCategory.flagDescription ||
+                  c == QuizCategory.motto ||
+                  c == QuizCategory.stateBird ||
+                  c == QuizCategory.stateFlower ||
+                  c == QuizCategory.filmSetting ||
+                  c == QuizCategory.mixed,
+            )
+            .toList();
+    }
+  }
+}
+
+/// Difficulty rating for each quiz category.
+///
+/// Used as a scoring multiplier — harder clue categories earn more points.
+/// Scale: 1.0 (easiest) to 2.0 (hardest).
+double clueDifficultyMultiplier(QuizCategory category) {
+  switch (category) {
+    case QuizCategory.stateName:
+      return 1.0;
+    case QuizCategory.capital:
+      return 1.2;
+    case QuizCategory.nickname:
+      return 1.3;
+    case QuizCategory.sportsTeam:
+      return 1.4;
+    case QuizCategory.landmark:
+      return 1.3;
+    case QuizCategory.flagDescription:
+      return 1.6;
+    case QuizCategory.stateBird:
+      return 1.7;
+    case QuizCategory.stateFlower:
+      return 1.8;
+    case QuizCategory.motto:
+      return 1.9;
+    case QuizCategory.celebrity:
+      return 1.5;
+    case QuizCategory.filmSetting:
+      return 1.5;
+    case QuizCategory.mixed:
+      return 1.3; // average of all
+  }
+}

--- a/lib/game/quiz/quiz_map_widget.dart
+++ b/lib/game/quiz/quiz_map_widget.dart
@@ -48,6 +48,7 @@ class QuizMapWidget extends StatefulWidget {
     required this.stateVisuals,
     required this.onStateTapped,
     this.highlightCode,
+    this.showLabels = true,
   });
 
   /// Visual state for each US state.
@@ -58,6 +59,9 @@ class QuizMapWidget extends StatefulWidget {
 
   /// Optional state to highlight (e.g., for showing the correct answer).
   final String? highlightCode;
+
+  /// Whether to show state code labels on the map.
+  final bool showLabels;
 
   @override
   State<QuizMapWidget> createState() => _QuizMapWidgetState();
@@ -98,6 +102,7 @@ class _QuizMapWidgetState extends State<QuizMapWidget>
                   stateVisuals: widget.stateVisuals,
                   highlightCode: widget.highlightCode,
                   pulseValue: _pulseController.value,
+                  showLabels: widget.showLabels,
                 ),
               ),
             );
@@ -112,6 +117,7 @@ class _QuizMapWidgetState extends State<QuizMapWidget>
       stateVisuals: widget.stateVisuals,
       highlightCode: widget.highlightCode,
       pulseValue: 0,
+      showLabels: widget.showLabels,
     );
 
     final code = painter.hitTestState(position, size);
@@ -127,11 +133,13 @@ class _UsaMapPainter extends CustomPainter {
     required this.stateVisuals,
     required this.highlightCode,
     required this.pulseValue,
+    this.showLabels = true,
   });
 
   final Map<String, StateVisual> stateVisuals;
   final String? highlightCode;
   final double pulseValue;
+  final bool showLabels;
 
   // CONUS bounds (continental US)
   static const double _conusMinLng = -125.0;
@@ -201,10 +209,12 @@ class _UsaMapPainter extends CustomPainter {
       _drawStateBorder(canvas, size, hiArea, _hiTransform(size));
     }
 
-    // Draw state labels for larger states
-    for (final area in areas) {
-      if (area.code == 'AK' || area.code == 'HI') continue;
-      _drawStateLabel(canvas, size, area, _conusTransform(size));
+    // Draw state labels for larger states (only when enabled)
+    if (showLabels) {
+      for (final area in areas) {
+        if (area.code == 'AK' || area.code == 'HI') continue;
+        _drawStateLabel(canvas, size, area, _conusTransform(size));
+      }
     }
   }
 
@@ -219,15 +229,37 @@ class _UsaMapPainter extends CustomPainter {
     // Reserve bottom space for insets
     final mainH = drawH * 0.78;
 
+    // Correct aspect ratio for latitude distortion.
+    // At ~37N (mid-CONUS), cos(37) ≈ 0.799
+    const lngSpan = _conusMaxLng - _conusMinLng; // 59 degrees
+    const latSpan = _conusMaxLat - _conusMinLat; // 26 degrees
+    const midLatRad = 37.0 * 3.14159265 / 180.0;
+    // cos(37°) ≈ 0.799
+    const cosLat = 0.799;
+    final geoAspect = (lngSpan * cosLat) / latSpan;
+    final canvasAspect = drawW / mainH;
+
+    double usedW, usedH;
+    if (geoAspect > canvasAspect) {
+      usedW = drawW;
+      usedH = drawW / geoAspect;
+    } else {
+      usedH = mainH;
+      usedW = mainH * geoAspect;
+    }
+
+    final offsetX = padX + (drawW - usedW) / 2;
+    final offsetY = padY + (mainH - usedH) / 2;
+
     return _GeoTransform(
       minLng: _conusMinLng,
       maxLng: _conusMaxLng,
       minLat: _conusMinLat,
       maxLat: _conusMaxLat,
-      offsetX: padX,
-      offsetY: padY,
-      width: drawW,
-      height: mainH,
+      offsetX: offsetX,
+      offsetY: offsetY,
+      width: usedW,
+      height: usedH,
     );
   }
 

--- a/lib/game/quiz/quiz_region_map_widget.dart
+++ b/lib/game/quiz/quiz_region_map_widget.dart
@@ -1,0 +1,378 @@
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart';
+
+import '../map/region.dart';
+import 'quiz_map_widget.dart';
+
+/// Generic region map widget for Flight School quiz mode on non-US regions.
+///
+/// Renders any set of [RegionalArea] polygons within the region's bounds.
+/// Supports tap detection, visual feedback, and labels.
+class QuizRegionMapWidget extends StatefulWidget {
+  const QuizRegionMapWidget({
+    super.key,
+    required this.region,
+    required this.stateVisuals,
+    required this.onStateTapped,
+    this.highlightCode,
+    this.showLabels = true,
+  });
+
+  final GameRegion region;
+  final Map<String, StateVisual> stateVisuals;
+  final OnStateTapped onStateTapped;
+  final String? highlightCode;
+  final bool showLabels;
+
+  @override
+  State<QuizRegionMapWidget> createState() => _QuizRegionMapWidgetState();
+}
+
+class _QuizRegionMapWidgetState extends State<QuizRegionMapWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulseController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return AnimatedBuilder(
+          animation: _pulseController,
+          builder: (context, child) {
+            return GestureDetector(
+              onTapDown: (details) =>
+                  _handleTap(details.localPosition, constraints.biggest),
+              child: CustomPaint(
+                size: constraints.biggest,
+                painter: _RegionMapPainter(
+                  region: widget.region,
+                  stateVisuals: widget.stateVisuals,
+                  highlightCode: widget.highlightCode,
+                  pulseValue: _pulseController.value,
+                  showLabels: widget.showLabels,
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  void _handleTap(Offset position, Size size) {
+    final painter = _RegionMapPainter(
+      region: widget.region,
+      stateVisuals: widget.stateVisuals,
+      highlightCode: widget.highlightCode,
+      pulseValue: 0,
+      showLabels: widget.showLabels,
+    );
+
+    final code = painter.hitTestArea(position, size);
+    if (code != null) {
+      widget.onStateTapped(code);
+    }
+  }
+}
+
+class _RegionMapPainter extends CustomPainter {
+  _RegionMapPainter({
+    required this.region,
+    required this.stateVisuals,
+    required this.highlightCode,
+    required this.pulseValue,
+    this.showLabels = true,
+  });
+
+  final GameRegion region;
+  final Map<String, StateVisual> stateVisuals;
+  final String? highlightCode;
+  final double pulseValue;
+  final bool showLabels;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.isEmpty) return;
+
+    canvas.drawRect(
+      Offset.zero & size,
+      Paint()..color = const Color(0xFF1A2A32),
+    );
+
+    final areas = RegionalData.getAreas(region);
+    final transform = _regionTransform(size);
+
+    // Draw fills
+    for (final area in areas) {
+      _drawArea(canvas, size, area, transform);
+    }
+
+    // Draw borders
+    for (final area in areas) {
+      _drawAreaBorder(canvas, area, transform);
+    }
+
+    // Draw labels for larger areas (only when enabled)
+    if (showLabels) {
+      for (final area in areas) {
+        _drawAreaLabel(canvas, size, area, transform);
+      }
+    }
+  }
+
+  _GeoTransform _regionTransform(Size size) {
+    final bounds = region.bounds;
+    final minLng = bounds[0];
+    final minLat = bounds[1];
+    final maxLng = bounds[2];
+    final maxLat = bounds[3];
+
+    final padX = size.width * 0.04;
+    final padY = size.height * 0.04;
+    final drawW = size.width - padX * 2;
+    final drawH = size.height - padY * 2;
+
+    // Preserve aspect ratio using a Mercator-like correction
+    final lngSpan = maxLng - minLng;
+    final latSpan = maxLat - minLat;
+    final midLat = (minLat + maxLat) / 2;
+    // Rough cos correction for latitude distortion
+    final cosLat = _cos(midLat * 3.14159265 / 180.0);
+    final geoAspect = (lngSpan * cosLat) / latSpan;
+    final canvasAspect = drawW / drawH;
+
+    double usedW, usedH;
+    if (geoAspect > canvasAspect) {
+      usedW = drawW;
+      usedH = drawW / geoAspect;
+    } else {
+      usedH = drawH;
+      usedW = drawH * geoAspect;
+    }
+
+    final offsetX = padX + (drawW - usedW) / 2;
+    final offsetY = padY + (drawH - usedH) / 2;
+
+    return _GeoTransform(
+      minLng: minLng,
+      maxLng: maxLng,
+      minLat: minLat,
+      maxLat: maxLat,
+      offsetX: offsetX,
+      offsetY: offsetY,
+      width: usedW,
+      height: usedH,
+    );
+  }
+
+  static double _cos(double radians) {
+    // Taylor approximation good enough for aspect ratio correction
+    final x2 = radians * radians;
+    return 1.0 - x2 / 2.0 + x2 * x2 / 24.0;
+  }
+
+  void _drawArea(
+    Canvas canvas,
+    Size size,
+    RegionalArea area,
+    _GeoTransform transform,
+  ) {
+    if (area.points.isEmpty) return;
+
+    final visual = stateVisuals[area.code];
+    final status = visual?.status ?? StateVisualStatus.idle;
+    final isHighlighted = highlightCode == area.code;
+
+    final path = _buildPath(area.points, transform);
+    final fillColor = _getFillColor(status, isHighlighted);
+    canvas.drawPath(path, Paint()..color = fillColor);
+  }
+
+  void _drawAreaBorder(
+    Canvas canvas,
+    RegionalArea area,
+    _GeoTransform transform,
+  ) {
+    if (area.points.isEmpty) return;
+    final path = _buildPath(area.points, transform);
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = const Color(0xFF3A5A6A)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 0.8,
+    );
+  }
+
+  void _drawAreaLabel(
+    Canvas canvas,
+    Size size,
+    RegionalArea area,
+    _GeoTransform transform,
+  ) {
+    final centroid = _centroid(area.points);
+    final pos = transform.toCanvas(centroid.x, centroid.y);
+
+    if (pos.dx < 0 ||
+        pos.dx > size.width ||
+        pos.dy < 0 ||
+        pos.dy > size.height) {
+      return;
+    }
+
+    final visual = stateVisuals[area.code];
+    final status = visual?.status ?? StateVisualStatus.idle;
+    final textColor = status == StateVisualStatus.completed
+        ? const Color(0xFF5A7A8A)
+        : const Color(0xFFB0C8D8);
+
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: area.code,
+        style: TextStyle(
+          color: textColor,
+          fontSize: 7,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.5,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    textPainter.paint(
+      canvas,
+      Offset(pos.dx - textPainter.width / 2, pos.dy - textPainter.height / 2),
+    );
+  }
+
+  Color _getFillColor(StateVisualStatus status, bool isHighlighted) {
+    if (isHighlighted) {
+      final opacity = 0.4 + 0.4 * pulseValue;
+      return Color.fromRGBO(232, 122, 90, opacity);
+    }
+    switch (status) {
+      case StateVisualStatus.idle:
+        return const Color(0xFF2A4A5A);
+      case StateVisualStatus.correct:
+        return const Color(0xFF2A8A4A);
+      case StateVisualStatus.wrong:
+        return const Color(0xFFAA3333);
+      case StateVisualStatus.completed:
+        return const Color(0xFF1E3340);
+    }
+  }
+
+  Path _buildPath(List<Vector2> points, _GeoTransform transform) {
+    final path = Path();
+    if (points.isEmpty) return path;
+
+    final first = transform.toCanvas(points.first.x, points.first.y);
+    path.moveTo(first.dx, first.dy);
+
+    for (var i = 1; i < points.length; i++) {
+      final p = transform.toCanvas(points[i].x, points[i].y);
+      path.lineTo(p.dx, p.dy);
+    }
+
+    path.close();
+    return path;
+  }
+
+  Vector2 _centroid(List<Vector2> points) {
+    if (points.isEmpty) return Vector2.zero();
+    var sumX = 0.0;
+    var sumY = 0.0;
+    for (final p in points) {
+      sumX += p.x;
+      sumY += p.y;
+    }
+    return Vector2(sumX / points.length, sumY / points.length);
+  }
+
+  String? hitTestArea(Offset position, Size size) {
+    final areas = RegionalData.getAreas(region);
+    final transform = _regionTransform(size);
+
+    for (final area in areas) {
+      if (_pointInPolygon(position, area.points, transform)) {
+        return area.code;
+      }
+    }
+    return null;
+  }
+
+  bool _pointInPolygon(
+    Offset point,
+    List<Vector2> polygon,
+    _GeoTransform transform,
+  ) {
+    if (polygon.length < 3) return false;
+
+    var inside = false;
+    var j = polygon.length - 1;
+
+    for (var i = 0; i < polygon.length; i++) {
+      final pi = transform.toCanvas(polygon[i].x, polygon[i].y);
+      final pj = transform.toCanvas(polygon[j].x, polygon[j].y);
+
+      if (((pi.dy > point.dy) != (pj.dy > point.dy)) &&
+          (point.dx <
+              (pj.dx - pi.dx) * (point.dy - pi.dy) / (pj.dy - pi.dy) + pi.dx)) {
+        inside = !inside;
+      }
+      j = i;
+    }
+
+    return inside;
+  }
+
+  @override
+  bool shouldRepaint(covariant _RegionMapPainter oldDelegate) {
+    return oldDelegate.highlightCode != highlightCode ||
+        oldDelegate.pulseValue != pulseValue ||
+        true;
+  }
+}
+
+class _GeoTransform {
+  const _GeoTransform({
+    required this.minLng,
+    required this.maxLng,
+    required this.minLat,
+    required this.maxLat,
+    required this.offsetX,
+    required this.offsetY,
+    required this.width,
+    required this.height,
+  });
+
+  final double minLng;
+  final double maxLng;
+  final double minLat;
+  final double maxLat;
+  final double offsetX;
+  final double offsetY;
+  final double width;
+  final double height;
+
+  Offset toCanvas(double lng, double lat) {
+    final x = offsetX + ((lng - minLng) / (maxLng - minLng)) * width;
+    final y = offsetY + ((maxLat - lat) / (maxLat - minLat)) * height;
+    return Offset(x, y);
+  }
+}

--- a/lib/game/quiz/quiz_session.dart
+++ b/lib/game/quiz/quiz_session.dart
@@ -1,11 +1,12 @@
 import 'dart:math';
 
 import 'quiz_category.dart';
+import 'quiz_difficulty.dart';
 import '../map/region.dart';
 
 /// Game modes for Flight School quizzes.
 enum QuizMode {
-  /// Answer all states as fast as possible.
+  /// Answer all areas as fast as possible.
   allStates,
 
   /// Time trial: answer as many as you can in a time limit.
@@ -13,28 +14,35 @@ enum QuizMode {
 
   /// Rapid fire: 3 strikes and you're out.
   rapidFire,
+
+  /// Type-in: type the name from the clue instead of tapping the map.
+  typeIn,
 }
 
 extension QuizModeExtension on QuizMode {
   String get displayName {
     switch (this) {
       case QuizMode.allStates:
-        return 'All States';
+        return 'Complete';
       case QuizMode.timeTrial:
         return 'Time Trial';
       case QuizMode.rapidFire:
         return 'Rapid Fire';
+      case QuizMode.typeIn:
+        return 'Type-In';
     }
   }
 
   String get description {
     switch (this) {
       case QuizMode.allStates:
-        return 'Find all 50 states — fastest time wins';
+        return 'Find every area — fastest time wins';
       case QuizMode.timeTrial:
         return '60 seconds — how many can you get?';
       case QuizMode.rapidFire:
         return '3 wrong answers and you\'re out';
+      case QuizMode.typeIn:
+        return 'Type the name from the clue';
     }
   }
 
@@ -47,6 +55,8 @@ extension QuizModeExtension on QuizMode {
         return 60;
       case QuizMode.rapidFire:
         return null;
+      case QuizMode.typeIn:
+        return 90;
     }
   }
 
@@ -59,6 +69,8 @@ extension QuizModeExtension on QuizMode {
         return null;
       case QuizMode.rapidFire:
         return 3;
+      case QuizMode.typeIn:
+        return null;
     }
   }
 }
@@ -73,6 +85,7 @@ class QuizAnswerResult {
     required this.answerCode,
     required this.correctCode,
     required this.elapsedMs,
+    this.hintUsed = false,
   });
 
   final bool correct;
@@ -82,6 +95,7 @@ class QuizAnswerResult {
   final String answerCode;
   final String correctCode;
   final int elapsedMs;
+  final bool hintUsed;
 }
 
 /// Manages the state of a single quiz round.
@@ -90,6 +104,7 @@ class QuizSession {
     required this.mode,
     required this.category,
     required this.region,
+    this.difficulty = QuizDifficulty.medium,
     int? seed,
   }) : _generator = QuizQuestionGenerator(region: region, seed: seed),
        _results = [],
@@ -99,11 +114,14 @@ class QuizSession {
        _streak = 0,
        _totalScore = 0,
        _wrongCount = 0,
+       _hintsUsed = 0,
+       _currentHintLevel = 0,
        _isFinished = false;
 
   final QuizMode mode;
   final QuizCategory category;
   final GameRegion region;
+  final QuizDifficulty difficulty;
   final QuizQuestionGenerator _generator;
 
   late final List<QuizQuestion> _questions;
@@ -115,6 +133,8 @@ class QuizSession {
   int _streak;
   int _totalScore;
   int _wrongCount;
+  int _hintsUsed;
+  int _currentHintLevel;
   bool _isFinished;
 
   // ── Public getters ────────────────────────────────────────────────────────
@@ -126,9 +146,18 @@ class QuizSession {
   int get streak => _streak;
   int get totalScore => _totalScore;
   int get wrongCount => _wrongCount;
+  int get hintsUsed => _hintsUsed;
   int get correctCount => _results.where((r) => r.correct).length;
   Set<String> get answeredCodes => Set.unmodifiable(_answeredCodes);
   List<QuizAnswerResult> get results => List.unmodifiable(_results);
+  bool get showLabels => difficulty.showLabels;
+
+  /// Current hint level for the current question (0 = no hint, 1-3 = progressive).
+  int get currentHintLevel => _currentHintLevel;
+
+  /// Whether a hint can be used on the current question.
+  bool get canUseHint =>
+      _hintsUsed < difficulty.maxHints && _currentHintLevel < 3;
 
   QuizQuestion? get currentQuestion {
     if (_isFinished || _currentIndex >= _questions.length) return null;
@@ -178,7 +207,22 @@ class QuizSession {
     _startTime = DateTime.now();
   }
 
-  /// Submit an answer by tapping a state code.
+  /// Use a hint on the current question. Returns the hint level (1-3).
+  ///
+  /// Hint levels:
+  /// 1. Highlight the correct region of the map (narrows to quadrant)
+  /// 2. Eliminate 75% of wrong answers (dim them out)
+  /// 3. Highlight the exact correct answer (pulsing)
+  ///
+  /// Each hint reduces the score multiplier for this question.
+  int? useHint() {
+    if (!canUseHint || currentQuestion == null) return null;
+    _hintsUsed++;
+    _currentHintLevel++;
+    return _currentHintLevel;
+  }
+
+  /// Submit an answer by tapping an area code.
   QuizAnswerResult? submitAnswer(String tappedCode) {
     if (_isFinished || currentQuestion == null) return null;
     if (_answeredCodes.contains(tappedCode)) return null;
@@ -186,11 +230,12 @@ class QuizSession {
     final question = currentQuestion!;
     final correct = tappedCode == question.answerCode;
     final elapsed = elapsedMs;
+    final hintUsed = _currentHintLevel > 0;
 
     if (correct) {
       _streak++;
       _answeredCodes.add(tappedCode);
-      final points = _calculatePoints(elapsed);
+      final points = _calculatePoints(elapsed, question.category);
       _totalScore += points;
 
       final result = QuizAnswerResult(
@@ -201,9 +246,11 @@ class QuizSession {
         answerCode: tappedCode,
         correctCode: question.answerCode,
         elapsedMs: elapsed,
+        hintUsed: hintUsed,
       );
       _results.add(result);
       _currentIndex++;
+      _currentHintLevel = 0; // Reset hints for next question
 
       if (_currentIndex >= _questions.length || isTimeUp) {
         _isFinished = true;
@@ -214,23 +261,38 @@ class QuizSession {
       _streak = 0;
       _wrongCount++;
 
+      final penalty = _calculatePenalty();
       final result = QuizAnswerResult(
         correct: false,
-        points: -200,
+        points: -penalty,
         streak: 0,
         questionIndex: _currentIndex,
         answerCode: tappedCode,
         correctCode: question.answerCode,
         elapsedMs: elapsed,
+        hintUsed: hintUsed,
       );
       _results.add(result);
-      _totalScore = max(0, _totalScore - 200);
+      _totalScore = max(0, _totalScore - penalty);
 
       if (isStrikedOut) {
         _isFinished = true;
       }
 
       return result;
+    }
+  }
+
+  /// Advance to the next question without scoring.
+  ///
+  /// Used by type-in mode to move past a question after a wrong answer
+  /// (since the player cannot "try again" by tapping differently).
+  void advanceQuestion() {
+    if (_isFinished || currentQuestion == null) return;
+    _currentIndex++;
+    _currentHintLevel = 0;
+    if (_currentIndex >= _questions.length || isTimeUp) {
+      _isFinished = true;
     }
   }
 
@@ -248,23 +310,47 @@ class QuizSession {
 
   // ── Scoring ───────────────────────────────────────────────────────────────
 
-  /// Calculate points for a correct answer based on speed and streak.
-  int _calculatePoints(int elapsedMs) {
-    // Base points
+  /// Calculate points for a correct answer.
+  ///
+  /// Formula: (base + speedBonus) * streakMultiplier * clueDifficulty
+  ///          * difficultyMultiplier * hintPenalty
+  int _calculatePoints(int elapsedMs, QuizCategory questionCategory) {
     const base = 1000;
 
     // Streak multiplier: 1.0, 1.2, 1.4, 1.6, 1.8, 2.0 (max)
-    final streakMultiplier = min(2.0, 1.0 + (_streak - 1) * 0.2);
+    final streakMult = min(2.0, 1.0 + (_streak - 1) * 0.2);
 
     // Speed bonus: decays over 10 seconds per question
-    // Full bonus (500) if answered in <1s, linearly to 0 at 10s
     final questionElapsed = _results.isEmpty
         ? elapsedMs
         : elapsedMs - (_results.last.elapsedMs);
     final speedFraction = (1.0 - (questionElapsed / 10000)).clamp(0.0, 1.0);
     final speedBonus = (500 * speedFraction).round();
 
-    return ((base + speedBonus) * streakMultiplier).round();
+    // Clue difficulty multiplier (harder clues = more points)
+    final clueMult = clueDifficultyMultiplier(questionCategory);
+
+    // Overall difficulty multiplier (easy=0.7, medium=1.0, hard=1.5)
+    final diffMult = difficulty.scoreMultiplier;
+
+    // Hint penalty: each hint level reduces score by 25%
+    final hintPenalty = 1.0 - (_currentHintLevel * 0.25);
+
+    final raw =
+        (base + speedBonus) * streakMult * clueMult * diffMult * hintPenalty;
+    return raw.round();
+  }
+
+  /// Calculate penalty for a wrong answer (scales with difficulty).
+  int _calculatePenalty() {
+    switch (difficulty) {
+      case QuizDifficulty.easy:
+        return 100;
+      case QuizDifficulty.medium:
+        return 200;
+      case QuizDifficulty.hard:
+        return 300;
+    }
   }
 
   // ── Summary ───────────────────────────────────────────────────────────────
@@ -273,6 +359,7 @@ class QuizSession {
   QuizSummary get summary => QuizSummary(
     mode: mode,
     category: category,
+    difficulty: difficulty,
     totalScore: _totalScore,
     correctCount: correctCount,
     wrongCount: _wrongCount,
@@ -282,6 +369,7 @@ class QuizSession {
       0,
       (best, r) => r.correct && r.streak > best ? r.streak : best,
     ),
+    hintsUsed: _hintsUsed,
     results: List.unmodifiable(_results),
   );
 }
@@ -291,23 +379,27 @@ class QuizSummary {
   const QuizSummary({
     required this.mode,
     required this.category,
+    required this.difficulty,
     required this.totalScore,
     required this.correctCount,
     required this.wrongCount,
     required this.totalQuestions,
     required this.elapsedMs,
     required this.bestStreak,
+    required this.hintsUsed,
     required this.results,
   });
 
   final QuizMode mode;
   final QuizCategory category;
+  final QuizDifficulty difficulty;
   final int totalScore;
   final int correctCount;
   final int wrongCount;
   final int totalQuestions;
   final int elapsedMs;
   final int bestStreak;
+  final int hintsUsed;
   final List<QuizAnswerResult> results;
 
   double get accuracy => (correctCount + wrongCount) > 0
@@ -319,6 +411,17 @@ class QuizSummary {
     final minutes = seconds ~/ 60;
     final secs = seconds % 60;
     return '$minutes:${secs.toString().padLeft(2, '0')}';
+  }
+
+  /// Coin reward for this quiz session.
+  ///
+  /// Base reward scales with correct answers and difficulty.
+  /// Diminishing returns for repeat completions should be applied externally.
+  int get coinReward {
+    final base = correctCount * 5;
+    final diffBonus = (base * difficulty.scoreMultiplier).round();
+    final accuracyBonus = (accuracy * 20).round();
+    return diffBonus + accuracyBonus;
   }
 
   /// Grade based on accuracy and speed.

--- a/lib/game/rendering/region_camera_presets.dart
+++ b/lib/game/rendering/region_camera_presets.dart
@@ -111,6 +111,56 @@ abstract class RegionCameraPresets {
     fovOverride: 50.0,
   );
 
+  /// Europe: centered roughly on the Alps.
+  static const CameraPreset _europePreset = CameraPreset(
+    centerLat: 50.0,
+    centerLng: 10.0,
+    altitudeDistance: 2.2,
+    maxBoundsLat: 25.0,
+    maxBoundsLng: 40.0,
+    fovOverride: 50.0,
+  );
+
+  /// Africa: centered on the equatorial belt.
+  static const CameraPreset _africaPreset = CameraPreset(
+    centerLat: 2.0,
+    centerLng: 20.0,
+    altitudeDistance: 2.8,
+    maxBoundsLat: 40.0,
+    maxBoundsLng: 40.0,
+    fovOverride: 50.0,
+  );
+
+  /// Asia: centered on the Indian subcontinent area.
+  static const CameraPreset _asiaPreset = CameraPreset(
+    centerLat: 30.0,
+    centerLng: 80.0,
+    altitudeDistance: 3.0,
+    maxBoundsLat: 40.0,
+    maxBoundsLng: 70.0,
+    fovOverride: 50.0,
+  );
+
+  /// Latin America: centered on the Amazon basin.
+  static const CameraPreset _latinAmericaPreset = CameraPreset(
+    centerLat: -5.0,
+    centerLng: -60.0,
+    altitudeDistance: 2.8,
+    maxBoundsLat: 45.0,
+    maxBoundsLng: 45.0,
+    fovOverride: 50.0,
+  );
+
+  /// Oceania: centered on Australia / Coral Sea.
+  static const CameraPreset _oceaniaPreset = CameraPreset(
+    centerLat: -22.0,
+    centerLng: 150.0,
+    altitudeDistance: 2.5,
+    maxBoundsLat: 30.0,
+    maxBoundsLng: 40.0,
+    fovOverride: 50.0,
+  );
+
   // ---------------------------------------------------------------------------
   // Public API
   // ---------------------------------------------------------------------------
@@ -130,6 +180,16 @@ abstract class RegionCameraPresets {
         return _irelandPreset;
       case GameRegion.canadianProvinces:
         return _canadianProvincesPreset;
+      case GameRegion.europe:
+        return _europePreset;
+      case GameRegion.africa:
+        return _africaPreset;
+      case GameRegion.asia:
+        return _asiaPreset;
+      case GameRegion.latinAmerica:
+        return _latinAmericaPreset;
+      case GameRegion.oceania:
+        return _oceaniaPreset;
     }
   }
 

--- a/supabase/migrations/20260305_daily_briefing.sql
+++ b/supabase/migrations/20260305_daily_briefing.sql
@@ -1,0 +1,55 @@
+-- Daily Flight Briefing scores table.
+--
+-- Stores one row per player per day. The unique constraint on
+-- (user_id, date_key) enforces the "one attempt per day" rule at the
+-- database level.
+
+create table if not exists public.daily_briefing_scores (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users (id) on delete cascade,
+  date_key   text not null,            -- 'YYYY-MM-DD'
+  score      int  not null default 0,
+  time_ms    int  not null default 0,
+  level_id   text not null,            -- flight school level id (e.g. 'europe')
+  category   text not null,            -- quiz category name
+  difficulty text not null,            -- easy / medium / hard
+  mode       text not null,            -- allStates / timeTrial / rapidFire
+  created_at timestamptz not null default now()
+);
+
+-- One attempt per player per day.
+alter table public.daily_briefing_scores
+  add constraint daily_briefing_scores_user_date_unique
+  unique (user_id, date_key);
+
+-- Fast leaderboard lookup: top scores for a given day.
+create index if not exists idx_daily_briefing_scores_date_score
+  on public.daily_briefing_scores (date_key, score desc);
+
+-- Player history lookup.
+create index if not exists idx_daily_briefing_scores_user
+  on public.daily_briefing_scores (user_id, created_at desc);
+
+-- ---------------------------------------------------------------------------
+-- Row-Level Security
+-- ---------------------------------------------------------------------------
+
+alter table public.daily_briefing_scores enable row level security;
+
+-- Anyone can read all scores (leaderboard is public).
+create policy "Anyone can read daily briefing scores"
+  on public.daily_briefing_scores
+  for select
+  using (true);
+
+-- Authenticated users can insert their own scores only.
+create policy "Users can insert own daily briefing scores"
+  on public.daily_briefing_scores
+  for insert
+  with check (auth.uid() = user_id);
+
+-- Users can update their own scores (not expected, but safe).
+create policy "Users can update own daily briefing scores"
+  on public.daily_briefing_scores
+  for update
+  using (auth.uid() = user_id);

--- a/supabase/migrations/20260305_flight_school_progress.sql
+++ b/supabase/migrations/20260305_flight_school_progress.sql
@@ -1,0 +1,10 @@
+-- Add flight_school_progress JSONB column to account_state.
+-- Stores per-level progress: best_score, best_time_ms, completions, attempts.
+-- Example: {"us_states": {"best_score": 45000, "best_time_ms": 120000, "completions": 5, "attempts": 8}}
+
+ALTER TABLE public.account_state
+  ADD COLUMN IF NOT EXISTS flight_school_progress JSONB NOT NULL DEFAULT '{}';
+
+-- Index for querying players with progress on specific levels
+CREATE INDEX IF NOT EXISTS idx_account_flight_school_progress
+  ON public.account_state USING gin (flight_school_progress);

--- a/supabase/migrations/20260305_h2h_challenges.sql
+++ b/supabase/migrations/20260305_h2h_challenges.sql
@@ -1,0 +1,58 @@
+-- H2H Flight School Challenges (best-of-3)
+-- Each challenge has 3 rounds with level, category, difficulty, and a
+-- deterministic seed so both players get the same questions.
+
+create table if not exists public.h2h_challenges (
+  id uuid primary key default gen_random_uuid(),
+  challenger_id uuid not null references auth.users(id) on delete cascade,
+  challenger_name text not null default '',
+  challenged_id uuid not null references auth.users(id) on delete cascade,
+  challenged_name text not null default '',
+  rounds jsonb not null default '[]'::jsonb,
+  status text not null default 'pending'
+    check (status in ('pending', 'in_progress', 'completed', 'declined', 'expired')),
+  winner_id uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  completed_at timestamptz
+);
+
+-- Indexes for common queries
+create index if not exists idx_h2h_challenges_challenger
+  on public.h2h_challenges (challenger_id);
+
+create index if not exists idx_h2h_challenges_challenged
+  on public.h2h_challenges (challenged_id);
+
+create index if not exists idx_h2h_challenges_status
+  on public.h2h_challenges (status);
+
+create index if not exists idx_h2h_challenges_created
+  on public.h2h_challenges (created_at desc);
+
+-- RLS: enable row-level security
+alter table public.h2h_challenges enable row level security;
+
+-- Policy: players can read challenges they are part of
+create policy "h2h_challenges_select_own"
+  on public.h2h_challenges
+  for select
+  using (
+    auth.uid() = challenger_id or auth.uid() = challenged_id
+  );
+
+-- Policy: authenticated users can create challenges where they are the challenger
+create policy "h2h_challenges_insert_own"
+  on public.h2h_challenges
+  for insert
+  with check (
+    auth.uid() = challenger_id
+  );
+
+-- Policy: participants can update challenges they are part of
+-- (for accepting, declining, submitting scores, completing)
+create policy "h2h_challenges_update_own"
+  on public.h2h_challenges
+  for update
+  using (
+    auth.uid() = challenger_id or auth.uid() = challenged_id
+  );

--- a/supabase/rebuild.sql
+++ b/supabase/rebuild.sql
@@ -1637,6 +1637,65 @@ ALTER TABLE public.account_state
 ALTER TABLE public.account_state
   ADD COLUMN IF NOT EXISTS free_flight_coin_date TEXT;
 
+ALTER TABLE public.account_state
+  ADD COLUMN IF NOT EXISTS flight_school_progress JSONB NOT NULL DEFAULT '{}';
+
+CREATE INDEX IF NOT EXISTS idx_account_flight_school_progress
+  ON public.account_state USING gin (flight_school_progress);
+
+-- H2H Flight School Challenges (best-of-3)
+CREATE TABLE IF NOT EXISTS public.h2h_challenges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  challenger_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  challenger_name text NOT NULL DEFAULT '',
+  challenged_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  challenged_name text NOT NULL DEFAULT '',
+  rounds jsonb NOT NULL DEFAULT '[]'::jsonb,
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'in_progress', 'completed', 'declined', 'expired')),
+  winner_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz
+);
+CREATE INDEX IF NOT EXISTS idx_h2h_challenges_challenger ON public.h2h_challenges (challenger_id);
+CREATE INDEX IF NOT EXISTS idx_h2h_challenges_challenged ON public.h2h_challenges (challenged_id);
+CREATE INDEX IF NOT EXISTS idx_h2h_challenges_status ON public.h2h_challenges (status);
+CREATE INDEX IF NOT EXISTS idx_h2h_challenges_created ON public.h2h_challenges (created_at DESC);
+ALTER TABLE public.h2h_challenges ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "h2h_challenges_select_own" ON public.h2h_challenges FOR SELECT
+  USING (auth.uid() = challenger_id OR auth.uid() = challenged_id);
+CREATE POLICY "h2h_challenges_insert_own" ON public.h2h_challenges FOR INSERT
+  WITH CHECK (auth.uid() = challenger_id);
+CREATE POLICY "h2h_challenges_update_own" ON public.h2h_challenges FOR UPDATE
+  USING (auth.uid() = challenger_id OR auth.uid() = challenged_id);
+
+-- Daily Flight Briefing scores
+CREATE TABLE IF NOT EXISTS public.daily_briefing_scores (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  date_key text NOT NULL,
+  score int NOT NULL DEFAULT 0,
+  time_ms int NOT NULL DEFAULT 0,
+  level_id text NOT NULL,
+  category text NOT NULL,
+  difficulty text NOT NULL,
+  mode text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.daily_briefing_scores
+  ADD CONSTRAINT daily_briefing_scores_user_date_unique UNIQUE (user_id, date_key);
+CREATE INDEX IF NOT EXISTS idx_daily_briefing_scores_date_score
+  ON public.daily_briefing_scores (date_key, score DESC);
+CREATE INDEX IF NOT EXISTS idx_daily_briefing_scores_user
+  ON public.daily_briefing_scores (user_id, created_at DESC);
+ALTER TABLE public.daily_briefing_scores ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read daily briefing scores" ON public.daily_briefing_scores
+  FOR SELECT USING (true);
+CREATE POLICY "Users can insert own daily briefing scores" ON public.daily_briefing_scores
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own daily briefing scores" ON public.daily_briefing_scores
+  FOR UPDATE USING (auth.uid() = user_id);
+
 
 -- ---------------------------------------------------------------------------
 -- 15. SEED ADMIN ROLES


### PR DESCRIPTION
…ode, and daily briefing

Major Flight School expansion:
- 10 geographic regions (Europe, USA, Africa, Asia, LATAM, UK, Ireland, Canada, Oceania, Caribbean)
- Per-level progress tracking (best score, best time, completions, attempts, aviation grade)
- Difficulty system (Easy/Medium/Hard) controlling labels, hints, scoring multipliers
- Progressive hint system reducing score proportionally
- Coin rewards with diminishing returns for repeat completions
- Pay-to-unlock for premium levels (USA at 500 coins, etc.)
- showLabels wired from difficulty to both QuizMapWidget and QuizRegionMapWidget

New game modes:
- Type-In mode: type country/state names from clues with autocomplete
- Head-to-Head (H2H): best-of-3 challenges with friends across any levels
- Daily Flight Briefing: same deterministic quiz for all players, daily leaderboard

Admin panels:
- Flight School Config: per-level clue difficulty multiplier overrides
- Gold Management: player gold ops, flight school economy, audit log

Leaderboard:
- 3 tabs: Daily Scramble, Training Flight, Flight Briefing
- LeaderboardMode enum replaces isDailyScramble boolean

Supabase migrations executed:
- h2h_challenges table with RLS
- daily_briefing_scores table with RLS and unique constraint

https://claude.ai/code/session_0175mV8UrGipubTpwnFGnrKa