### PR TITLE
fix: pole-safe camera, night clouds, darker night side, cloud defaults

### DIFF
--- a/lib/core/services/game_settings.dart
+++ b/lib/core/services/game_settings.dart
@@ -294,8 +294,8 @@ class GameSettings extends ChangeNotifier {
   }
 
   /// Cloud coverage threshold (0.0 = fully covered, 1.0 = clear sky).
-  /// Higher values mean fewer clouds. Default 0.42.
-  double _cloudCoverage = 0.42;
+  /// Higher values mean fewer clouds. Default 0.25.
+  double _cloudCoverage = 0.25;
 
   double get cloudCoverage => _cloudCoverage;
 
@@ -308,8 +308,8 @@ class GameSettings extends ChangeNotifier {
   String get cloudCoverageLabel => '${((_cloudCoverage) * 100).round()}%';
 
   /// Cloud blend opacity (0.0 = transparent, 1.0 = fully opaque).
-  /// Default 0.9 (90% opaque).
-  double _cloudOpacity = 0.9;
+  /// Default 0.5 (50% opaque).
+  double _cloudOpacity = 0.5;
 
   double get cloudOpacity => _cloudOpacity;
 

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -1195,56 +1195,63 @@ class FlitGame extends FlameGame
     final halfFovTan = tan(fov / 2);
     final offsetRad = desiredUvY * (d - CameraState.globeRadius) * halfFovTan;
 
-    // Convert camera heading to navigation bearing (0 = north).
+    // Use 3D cartesian great-circle math instead of Vincenty lat/lng formulas.
+    // Vincenty degenerates at the poles (cosPLat → 0 causes atan2(0, small)
+    // to flip longitude by 180°), while cartesian math handles poles smoothly.
     final camBearing = _cameraHeading + pi / 2;
 
-    // Great-circle destination: move offsetRad ahead of the plane (for Canvas).
     final planeLat = _worldPosition.y * deg2rad;
     final planeLng = _worldPosition.x * deg2rad;
+    final cosLat = cos(planeLat);
+    final sinLat = sin(planeLat);
+    final cosLng = cos(planeLng);
+    final sinLng = sin(planeLng);
 
-    final sinPLat = sin(planeLat);
-    final cosPLat = cos(planeLat);
-    final sinDist = sin(offsetRad);
-    final cosDist = cos(offsetRad);
+    // Position on unit sphere
+    final px = cosLat * cosLng;
+    final py = sinLat;
+    final pz = cosLat * sinLng;
 
-    final aheadLat = asin(
-      (sinPLat * cosDist + cosPLat * sinDist * cos(camBearing)).clamp(
-        -1.0,
-        1.0,
-      ),
-    );
-    final aheadLng =
-        planeLng +
-        atan2(
-          sin(camBearing) * sinDist * cosPLat,
-          cosDist - sinPLat * sin(aheadLat),
-        );
+    // Local tangent basis at plane position
+    final ex = -sinLng;
+    const ey = 0.0;
+    final ez = cosLng;
+    final nx = -sinLat * cosLng;
+    final ny = cosLat;
+    final nz = -sinLat * sinLng;
+
+    // Heading tangent in 3D (navigation bearing)
+    final cosB = cos(camBearing);
+    final sinB = sin(camBearing);
+    final hx = cosB * nx + sinB * ex;
+    final hy = cosB * ny + sinB * ey;
+    final hz = cosB * nz + sinB * ez;
+
+    final cosD = cos(offsetRad);
+    final sinD = sin(offsetRad);
+
+    // Move AHEAD along great circle: P' = P*cos(d) + H*sin(d)
+    final aheadX = px * cosD + hx * sinD;
+    final aheadY = py * cosD + hy * sinD;
+    final aheadZ = pz * cosD + hz * sinD;
+    final aheadLatRad = asin(aheadY.clamp(-1.0, 1.0));
+    final aheadLngRad = atan2(aheadZ, aheadX);
 
     _cameraOffsetPosition = Vector2(
-      _normalizeLng(aheadLng * rad2deg),
-      aheadLat * rad2deg,
+      _normalizeLng(aheadLngRad * rad2deg),
+      aheadLatRad * rad2deg,
     );
 
-    // Compute a point BEHIND the plane for the shader chase camera.
-    // The shader camera is behind the plane so the plane appears at
-    // planeScreenY on screen, creating a natural over-the-shoulder view.
-    final behindBearing = camBearing + pi;
-    final behindLat = asin(
-      (sinPLat * cosDist + cosPLat * sinDist * cos(behindBearing)).clamp(
-        -1.0,
-        1.0,
-      ),
-    );
-    final behindLng =
-        planeLng +
-        atan2(
-          sin(behindBearing) * sinDist * cosPLat,
-          cosDist - sinPLat * sin(behindLat),
-        );
+    // Move BEHIND along great circle: P' = P*cos(d) - H*sin(d)
+    final behindX = px * cosD - hx * sinD;
+    final behindY = py * cosD - hy * sinD;
+    final behindZ = pz * cosD - hz * sinD;
+    final behindLatRad = asin(behindY.clamp(-1.0, 1.0));
+    final behindLngRad = atan2(behindZ, behindX);
 
     _shaderCameraPosition = Vector2(
-      _normalizeLng(behindLng * rad2deg),
-      behindLat * rad2deg,
+      _normalizeLng(behindLngRad * rad2deg),
+      behindLatRad * rad2deg,
     );
   }
 

--- a/lib/game/rendering/camera_state.dart
+++ b/lib/game/rendering/camera_state.dart
@@ -264,10 +264,28 @@ class CameraState {
       uy /= len;
       uz /= len;
     } else {
-      // Fallback (shouldn't happen except exactly at poles)
-      ux = 0.0;
-      uy = 1.0;
-      uz = 0.0;
+      // Degenerate tangent basis — use East tangent which is always valid.
+      ux = eastX;
+      uy = eastY;
+      uz = eastZ;
+    }
+
+    // Safety: ensure up vector is not parallel to the camera forward direction.
+    // At the poles, if heading aligns with the radial direction, cross(up, forward)
+    // in the shader would produce a zero vector, breaking the view matrix.
+    // Camera forward = -normalize(camPos) ∝ -(cosLat*cosLng, sinLat, cosLat*sinLng).
+    final fwdX = -cosLat * cosLng;
+    final fwdY = -sinLat;
+    final fwdZ = -cosLat * sinLng;
+    final fwdLen = sqrt(fwdX * fwdX + fwdY * fwdY + fwdZ * fwdZ);
+    if (fwdLen > 1e-6) {
+      final dotUpFwd = (ux * fwdX + uy * fwdY + uz * fwdZ) / fwdLen;
+      if (dotUpFwd.abs() > 0.99) {
+        // Nearly parallel — use East tangent instead.
+        ux = eastX;
+        uy = eastY;
+        uz = eastZ;
+      }
     }
 
     _upX = ux;

--- a/shaders/globe.frag
+++ b/shaders/globe.frag
@@ -428,7 +428,9 @@ void main() {
     if (!isOcean) {
         // Land — satellite texture with diffuse lighting
         vec3 landColor = satColor.rgb;
-        float ambientLand = 0.06;
+        // Night-side ambient is near-black (0.01) so the surface is dark
+        // enough for city lights to stand out. Day-side ambient is 0.06.
+        float ambientLand = mix(0.01, 0.06, dayFactor);
         landColor *= (diffuse * 0.9 + ambientLand);
         landColor += terminatorGlow * 0.4;
         surfaceColor = landColor;
@@ -437,7 +439,8 @@ void main() {
         vec3 oceanColor = satColor.rgb * vec3(0.8, 0.9, 1.1);
 
         float oceanDiffuse = max(dot(normal, uSunDir), 0.0);
-        float ambientOcean = 0.06;
+        // Near-black ambient on night-side ocean to eliminate blue hue.
+        float ambientOcean = mix(0.01, 0.06, dayFactor);
         oceanColor *= (oceanDiffuse * 0.85 + ambientOcean);
 
         // Blinn-Phong specular (cheaper than gaussian)
@@ -455,22 +458,9 @@ void main() {
     }
 
     // =======================================================================
-    // V6: CITY LIGHTS ON NIGHT SIDE
-    // =======================================================================
-
-    {
-        float nightFactor = 1.0 - dayFactor;
-        if (uEnableNight > 0.5 && nightFactor > 0.01) {
-            vec3 cityLights = texture(uCityLights, uv).rgb;
-            cityLights *= CITY_LIGHT_BOOST;
-            vec3 lightTint = vec3(1.0, 0.85, 0.6);
-            cityLights *= lightTint;
-            surfaceColor += cityLights * nightFactor;
-        }
-    }
-
-    // =======================================================================
     // V5: CLOUD LAYER (gated: high altitude only)
+    // Rendered BEFORE city lights so night-side clouds appear as dark
+    // silhouettes against the surface, and city lights shine through gaps.
     // =======================================================================
 
     if (cloudsActive) {
@@ -493,7 +483,9 @@ void main() {
                 float cloudDayFactor = smoothstep(TERMINATOR_SOFT, TERMINATOR_HARD, cloudNdotL);
 
                 vec3 cloudColor = mix(vec3(0.25, 0.27, 0.35), vec3(CLOUD_BRIGHTNESS), cloudLight);
-                cloudColor = mix(vec3(0.03, 0.04, 0.06), cloudColor, max(cloudDayFactor, 0.05));
+                // Night-side clouds: visible as dark gray silhouettes (15% brightness)
+                // so they're clearly distinguishable against the dark surface.
+                cloudColor = mix(vec3(0.06, 0.06, 0.08), cloudColor, max(cloudDayFactor, 0.15));
 
                 float cloudTerminator = smoothstep(-0.15, 0.0, cloudNdotL) * smoothstep(0.25, 0.05, cloudNdotL);
                 cloudColor += TERMINATOR_WARM * cloudTerminator * 0.3;
@@ -512,18 +504,34 @@ void main() {
     }
 
     // =======================================================================
+    // V6: CITY LIGHTS ON NIGHT SIDE
+    // Rendered AFTER clouds so lights shine through cloud gaps.
+    // =======================================================================
+
+    {
+        float nightFactor = 1.0 - dayFactor;
+        if (uEnableNight > 0.5 && nightFactor > 0.01) {
+            vec3 cityLights = texture(uCityLights, uv).rgb;
+            cityLights *= CITY_LIGHT_BOOST;
+            vec3 lightTint = vec3(1.0, 0.85, 0.6);
+            cityLights *= lightTint;
+            surfaceColor += cityLights * nightFactor;
+        }
+    }
+
+    // =======================================================================
     // V4: AERIAL PERSPECTIVE HAZE
     // =======================================================================
 
     {
         float viewDist = length(hitPoint - ro);
         float maxDist  = camDist + uGlobeRadius;
-        float hazeFactor = smoothstep(0.0, maxDist, viewDist) * HAZE_STRENGTH;
+        // Reduce haze on night side so it doesn't add blue tint to dark areas.
+        float hazeFactor = smoothstep(0.0, maxDist, viewDist) * HAZE_STRENGTH * dayFactor;
 
         float sunViewDot = max(dot(viewDir, uSunDir), 0.0);
         float sv2 = sunViewDot * sunViewDot;
         vec3 hazeColor = mix(vec3(0.5, 0.6, 0.8), vec3(0.8, 0.7, 0.5), sv2 * sv2);
-        hazeColor *= dayFactor;
         surfaceColor = mix(surfaceColor, hazeColor, hazeFactor);
     }
 
@@ -540,7 +548,7 @@ void main() {
         vec3 dayRimColor = mix(vec3(0.3, 0.5, 1.0), vec3(0.5, 0.7, 1.0), sunAlignment);
         vec3 dayRim = dayRimColor * rim * RIM_INTENSITY * dayFactor;
 
-        vec3 nightRimColor = vec3(0.08, 0.12, 0.25);
+        vec3 nightRimColor = vec3(0.04, 0.05, 0.10);
         vec3 nightRim = nightRimColor * rim * NIGHT_RIM_STRENGTH * (1.0 - dayFactor);
 
         vec3 termRim = TERMINATOR_WARM * rim * terminatorZone * 0.4;


### PR DESCRIPTION
Poles: Rewrite _updateChaseCamera to use 3D cartesian great-circle math instead of Vincenty lat/lng formulas that degenerate at poles (cosPLat→0 causes atan2(0,small) to flip longitude by 180°). Add safety check in _computeUpVector to prevent up vector being parallel to camera forward.

Clouds at night: Move cloud rendering BEFORE city lights so clouds appear as dark silhouettes and city lights shine through gaps. Increase night-side cloud minimum brightness from 5% to 15% with neutral gray (not blue-tinted) so clouds are clearly visible at night.

Night lights: Reduce night-side ambient from fixed 0.06 to 0.01 for much blacker/darker night surface. Gate aerial haze by dayFactor so it doesn't add blue tint on night side. Reduce night rim glow blue.

Cloud defaults: Coverage 0.42→0.25, opacity 0.9→0.5.

https://claude.ai/code/session_01Sg7gAyN6EYtnM8dVGGJNUL