### PR TITLE
Fix three test failures: world altitude, region enum count, QuizSumma…

### DIFF
--- a/lib/game/rendering/region_camera_presets.dart
+++ b/lib/game/rendering/region_camera_presets.dart
@@ -56,7 +56,7 @@ abstract class RegionCameraPresets {
   static const CameraPreset _worldPreset = CameraPreset(
     centerLat: 20.0,
     centerLng: 0.0,
-    altitudeDistance: 3.0,
+    altitudeDistance: 3.5,
     maxBoundsLat: 90.0,
     maxBoundsLng: 180.0,
   );

--- a/test/unit/game/map/region_test.dart
+++ b/test/unit/game/map/region_test.dart
@@ -8,13 +8,18 @@ void main() {
   group('GameRegion enum', () {
     test('has all expected enum values', () {
       const values = GameRegion.values;
-      expect(values.length, equals(6));
+      expect(values.length, equals(11));
       expect(values, contains(GameRegion.world));
       expect(values, contains(GameRegion.usStates));
       expect(values, contains(GameRegion.ukCounties));
       expect(values, contains(GameRegion.caribbean));
       expect(values, contains(GameRegion.ireland));
       expect(values, contains(GameRegion.canadianProvinces));
+      expect(values, contains(GameRegion.europe));
+      expect(values, contains(GameRegion.africa));
+      expect(values, contains(GameRegion.asia));
+      expect(values, contains(GameRegion.latinAmerica));
+      expect(values, contains(GameRegion.oceania));
     });
 
     test('each region has a non-empty displayName', () {

--- a/test/unit/game/quiz/quiz_session_test.dart
+++ b/test/unit/game/quiz/quiz_session_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flit/game/quiz/quiz_category.dart';
+import 'package:flit/game/quiz/quiz_difficulty.dart';
 import 'package:flit/game/quiz/quiz_session.dart';
 import 'package:flit/game/map/region.dart';
 
@@ -335,12 +336,14 @@ void main() {
       const summary90 = QuizSummary(
         mode: QuizMode.allStates,
         category: QuizCategory.stateName,
+        difficulty: QuizDifficulty.medium,
         totalScore: 10000,
         correctCount: 45,
         wrongCount: 5,
         totalQuestions: 50,
         elapsedMs: 60000,
         bestStreak: 5,
+        hintsUsed: 0,
         results: [],
       );
       expect(summary90.grade, equals('A'));
@@ -348,12 +351,14 @@ void main() {
       const summary50 = QuizSummary(
         mode: QuizMode.allStates,
         category: QuizCategory.stateName,
+        difficulty: QuizDifficulty.medium,
         totalScore: 5000,
         correctCount: 25,
         wrongCount: 25,
         totalQuestions: 50,
         elapsedMs: 120000,
         bestStreak: 3,
+        hintsUsed: 0,
         results: [],
       );
       expect(summary50.grade, equals('D'));
@@ -363,12 +368,14 @@ void main() {
       const summary = QuizSummary(
         mode: QuizMode.allStates,
         category: QuizCategory.stateName,
+        difficulty: QuizDifficulty.medium,
         totalScore: 10000,
         correctCount: 50,
         wrongCount: 0,
         totalQuestions: 50,
         elapsedMs: 125000,
         bestStreak: 50,
+        hintsUsed: 0,
         results: [],
       );
       expect(summary.elapsedFormatted, equals('2:05'));


### PR DESCRIPTION
…ry params

- Bump world camera altitude from 3.0 to 3.5 so it's strictly greater than Asia's 3.0 (fixes camera_state_test world preset comparison)
- Update region_test enum count from 6 to 11 and add assertions for the 5 new continent regions (europe, africa, asia, latinAmerica, oceania)
- Add required difficulty and hintsUsed params to QuizSummary constructors in quiz_session_test to match updated class signature

https://claude.ai/code/session_01Sg7gAyN6EYtnM8dVGGJNUL