### PR TITLE
fix: update CI Flutter version to 3.29.3 to match codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: '3.16.0'
+  FLUTTER_VERSION: '3.29.3'
 
 jobs:
   # ── Lint, Test, Security (single job, one flutter create) ──


### PR DESCRIPTION
CI was using Flutter 3.16.0 where Flame's onKeyEvent expects RawKeyEvent, but the codebase uses the modern KeyEvent API (Flutter 3.29.3+). This version mismatch caused compilation failures in CI.

https://claude.ai/code/session_016dvywuRLgwzsDZPTRtf3aE