### PR TITLE
feat: darker nights, clustered clouds, settings split, clue improvements

### DIFF
--- a/lib/core/widgets/settings_sheet.dart
+++ b/lib/core/widgets/settings_sheet.dart
@@ -6,11 +6,15 @@ import '../theme/flit_colors.dart';
 
 /// Reusable settings bottom-sheet content.
 ///
-/// Used from both the profile screen and the in-game HUD so that all
-/// settings are accessible from either place without code duplication.
+/// Used from both the profile screen and the in-game HUD.
+///
+/// When [inGame] is true (default), only gameplay-relevant settings are
+/// shown (audio, controls, display).  Notifications and difficulty are
+/// omitted because notifications belong in profile preferences and
+/// difficulty should be set before starting a game, not during play.
 ///
 /// Call [showSettingsSheet] to present it as a modal bottom sheet.
-void showSettingsSheet(BuildContext context) {
+void showSettingsSheet(BuildContext context, {bool inGame = true}) {
   showModalBottomSheet<void>(
     context: context,
     backgroundColor: FlitColors.cardBackground,
@@ -23,8 +27,10 @@ void showSettingsSheet(BuildContext context) {
       minChildSize: 0.4,
       maxChildSize: 0.9,
       expand: false,
-      builder: (context, scrollController) =>
-          _SettingsSheetContent(scrollController: scrollController),
+      builder: (context, scrollController) => _SettingsSheetContent(
+        scrollController: scrollController,
+        inGame: inGame,
+      ),
     ),
   ).then((_) {
     // Flush pending settings writes when the sheet is dismissed.
@@ -35,9 +41,13 @@ void showSettingsSheet(BuildContext context) {
 }
 
 class _SettingsSheetContent extends StatefulWidget {
-  const _SettingsSheetContent({required this.scrollController});
+  const _SettingsSheetContent({
+    required this.scrollController,
+    required this.inGame,
+  });
 
   final ScrollController scrollController;
+  final bool inGame;
 
   @override
   State<_SettingsSheetContent> createState() => _SettingsSheetContentState();
@@ -103,16 +113,19 @@ class _SettingsSheetContentState extends State<_SettingsSheetContent> {
                   }
                 : null,
           ),
-          const Divider(color: FlitColors.cardBorder, height: 1),
-          _SettingsToggle(
-            label: 'Notifications',
-            icon: Icons.notifications_outlined,
-            value: GameSettings.instance.notificationsEnabled,
-            onChanged: (value) {
-              GameSettings.instance.notificationsEnabled = value;
-              setState(() {});
-            },
-          ),
+          // Notifications — profile settings only (not during gameplay)
+          if (!widget.inGame) ...[
+            const Divider(color: FlitColors.cardBorder, height: 1),
+            _SettingsToggle(
+              label: 'Notifications',
+              icon: Icons.notifications_outlined,
+              value: GameSettings.instance.notificationsEnabled,
+              onChanged: (value) {
+                GameSettings.instance.notificationsEnabled = value;
+                setState(() {});
+              },
+            ),
+          ],
           const Divider(color: FlitColors.cardBorder, height: 1),
           _SettingsToggle(
             label: 'Haptic Feedback',
@@ -178,8 +191,8 @@ class _SettingsSheetContentState extends State<_SettingsSheetContent> {
               label: 'Cloud Coverage',
               icon: Icons.cloud_queue_outlined,
               value: GameSettings.instance.cloudCoverage,
-              min: 0.1,
-              max: 0.8,
+              min: 0.0,
+              max: 1.0,
               valueLabel: GameSettings.instance.cloudCoverageLabel,
               onChanged: (value) {
                 GameSettings.instance.cloudCoverage = value;
@@ -220,16 +233,19 @@ class _SettingsSheetContentState extends State<_SettingsSheetContent> {
           ),
           const SizedBox(height: 20),
 
-          // ── Gameplay ───────────────────────────────────────
-          const _SectionHeader(title: 'Gameplay'),
-          _DifficultySelector(
-            value: GameSettings.instance.difficulty,
-            onChanged: (value) {
-              GameSettings.instance.difficulty = value;
-              setState(() {});
-            },
-          ),
-          const SizedBox(height: 24),
+          // ── Gameplay (profile only) ────────────────────────
+          // Difficulty should be set pre-game, not during gameplay.
+          if (!widget.inGame) ...[
+            const _SectionHeader(title: 'Gameplay'),
+            _DifficultySelector(
+              value: GameSettings.instance.difficulty,
+              onChanged: (value) {
+                GameSettings.instance.difficulty = value;
+                setState(() {});
+              },
+            ),
+            const SizedBox(height: 24),
+          ],
         ],
       );
 }

--- a/lib/features/explore/country_clues_screen.dart
+++ b/lib/features/explore/country_clues_screen.dart
@@ -7,13 +7,17 @@ import 'package:flutter/services.dart';
 
 import '../../core/theme/flit_colors.dart';
 import '../../game/clues/clue_types.dart';
+import '../../game/data/canada_clues.dart';
+import '../../game/data/ireland_clues.dart';
+import '../../game/data/uk_clues.dart';
+import '../../game/data/us_state_clues.dart';
 import '../../game/map/country_data.dart';
+import '../../game/map/region.dart';
 
-/// Player-facing screen showing all country game clues.
+/// Player-facing screen showing all game clues across tabs.
 ///
-/// Each country is shown as a compact card (flag + outline + name) that
-/// expands to reveal stats, capital, borders, and a "report" button so
-/// players can flag incorrect data.
+/// Tabs: Countries | US States | UK | Ireland | Canada
+/// Each tab shows the clue data used in-game for that region.
 class CountryCluesScreen extends StatefulWidget {
   const CountryCluesScreen({super.key});
 
@@ -28,7 +32,15 @@ class _CountryCluesScreenState extends State<CountryCluesScreen> {
   /// Codes known to be unsupported by the flag SVG package.
   static const _unsupportedFlagCodes = {'XC', 'XS', 'AN', 'CS', 'TP'};
 
-  List<CountryShape> get _filtered {
+  /// Flight school tabs with rich clue data.
+  static const _flightSchoolTabs = <({String label, GameRegion region})>[
+    (label: 'US States', region: GameRegion.usStates),
+    (label: 'UK', region: GameRegion.ukCounties),
+    (label: 'Ireland', region: GameRegion.ireland),
+    (label: 'Canada', region: GameRegion.canadianProvinces),
+  ];
+
+  List<CountryShape> get _filteredCountries {
     var list = CountryData.countries;
     if (_search.isNotEmpty) {
       final q = _search.toLowerCase();
@@ -44,6 +56,22 @@ class _CountryCluesScreenState extends State<CountryCluesScreen> {
     return list;
   }
 
+  List<RegionalArea> _filteredAreas(GameRegion region) {
+    var list = RegionalData.getAreas(region);
+    if (_search.isNotEmpty) {
+      final q = _search.toLowerCase();
+      list = list
+          .where(
+            (a) =>
+                a.name.toLowerCase().contains(q) ||
+                a.code.toLowerCase().contains(q) ||
+                (a.capital?.toLowerCase().contains(q) ?? false),
+          )
+          .toList();
+    }
+    return list;
+  }
+
   @override
   void dispose() {
     _searchCtl.dispose();
@@ -52,95 +80,498 @@ class _CountryCluesScreenState extends State<CountryCluesScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final countries = _filtered;
-
-    return Scaffold(
-      backgroundColor: FlitColors.backgroundDark,
-      appBar: AppBar(
-        backgroundColor: FlitColors.cardBackground,
-        title: const Text(
-          'Country Clues',
-          style: TextStyle(color: FlitColors.textPrimary),
-        ),
-        iconTheme: const IconThemeData(color: FlitColors.textPrimary),
-      ),
-      body: Column(
-        children: [
-          // Search bar
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-            child: TextField(
-              controller: _searchCtl,
-              onChanged: (v) => setState(() => _search = v.trim()),
-              style: const TextStyle(
-                color: FlitColors.textPrimary,
-                fontSize: 14,
-              ),
-              decoration: InputDecoration(
-                hintText: 'Search countries, capitals…',
-                hintStyle: const TextStyle(color: FlitColors.textMuted),
-                prefixIcon: const Icon(
-                  Icons.search,
-                  color: FlitColors.textMuted,
-                  size: 20,
-                ),
-                suffixIcon: _search.isNotEmpty
-                    ? IconButton(
-                        icon: const Icon(
-                          Icons.close,
-                          color: FlitColors.textMuted,
-                          size: 18,
-                        ),
-                        onPressed: () {
-                          _searchCtl.clear();
-                          setState(() => _search = '');
-                        },
-                      )
-                    : null,
-                filled: true,
-                fillColor: FlitColors.backgroundMid,
-                contentPadding: const EdgeInsets.symmetric(
-                  vertical: 10,
-                  horizontal: 12,
-                ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(10),
-                  borderSide: BorderSide.none,
-                ),
-              ),
-            ),
+    return DefaultTabController(
+      length: 1 + _flightSchoolTabs.length,
+      child: Scaffold(
+        backgroundColor: FlitColors.backgroundDark,
+        appBar: AppBar(
+          backgroundColor: FlitColors.cardBackground,
+          title: const Text(
+            'Clues',
+            style: TextStyle(color: FlitColors.textPrimary),
           ),
-
-          // Summary
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              children: [
-                Text(
-                  '${countries.length} countries',
-                  style: const TextStyle(
+          iconTheme: const IconThemeData(color: FlitColors.textPrimary),
+          bottom: TabBar(
+            isScrollable: true,
+            labelColor: FlitColors.accent,
+            unselectedLabelColor: FlitColors.textMuted,
+            indicatorColor: FlitColors.accent,
+            labelStyle: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+            tabAlignment: TabAlignment.start,
+            tabs: [
+              const Tab(text: 'Countries'),
+              ..._flightSchoolTabs.map((t) => Tab(text: t.label)),
+            ],
+          ),
+        ),
+        body: Column(
+          children: [
+            // Search bar (shared across tabs)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+              child: TextField(
+                controller: _searchCtl,
+                onChanged: (v) => setState(() => _search = v.trim()),
+                style: const TextStyle(
+                  color: FlitColors.textPrimary,
+                  fontSize: 14,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'Search…',
+                  hintStyle: const TextStyle(color: FlitColors.textMuted),
+                  prefixIcon: const Icon(
+                    Icons.search,
                     color: FlitColors.textMuted,
-                    fontSize: 12,
+                    size: 20,
+                  ),
+                  suffixIcon: _search.isNotEmpty
+                      ? IconButton(
+                          icon: const Icon(
+                            Icons.close,
+                            color: FlitColors.textMuted,
+                            size: 18,
+                          ),
+                          onPressed: () {
+                            _searchCtl.clear();
+                            setState(() => _search = '');
+                          },
+                        )
+                      : null,
+                  filled: true,
+                  fillColor: FlitColors.backgroundMid,
+                  contentPadding: const EdgeInsets.symmetric(
+                    vertical: 10,
+                    horizontal: 12,
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                    borderSide: BorderSide.none,
                   ),
                 ),
-              ],
+              ),
+            ),
+
+            // Tab content
+            Expanded(
+              child: TabBarView(
+                children: [
+                  _CountriesTab(
+                    countries: _filteredCountries,
+                    unsupportedFlags: _unsupportedFlagCodes,
+                  ),
+                  ..._flightSchoolTabs.map(
+                    (t) => _RegionalTab(
+                      region: t.region,
+                      areas: _filteredAreas(t.region),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Countries tab
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _CountriesTab extends StatelessWidget {
+  const _CountriesTab({
+    required this.countries,
+    required this.unsupportedFlags,
+  });
+
+  final List<CountryShape> countries;
+  final Set<String> unsupportedFlags;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Summary + outline quality legend
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              Text(
+                '${countries.length} countries',
+                style: const TextStyle(
+                  color: FlitColors.textMuted,
+                  fontSize: 12,
+                ),
+              ),
+              const Spacer(),
+              _LegendDot(color: FlitColors.accent, label: 'Good'),
+              const SizedBox(width: 8),
+              _LegendDot(color: FlitColors.warning, label: 'Fair'),
+              const SizedBox(width: 8),
+              _LegendDot(color: FlitColors.error, label: 'Poor'),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            'Outline quality — based on polygon detail',
+            style: TextStyle(
+              color: FlitColors.textMuted.withOpacity(0.6),
+              fontSize: 10,
             ),
           ),
-          const SizedBox(height: 8),
+        ),
+        const SizedBox(height: 8),
 
-          // Country list
-          Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              itemCount: countries.length,
-              itemBuilder: (context, index) => _CountryClueCard(
-                country: countries[index],
-                isUnsupportedFlag: _unsupportedFlagCodes.contains(
-                  countries[index].code,
-                ),
+        // Country list
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            itemCount: countries.length,
+            itemBuilder: (context, index) => _CountryClueCard(
+              country: countries[index],
+              isUnsupportedFlag: unsupportedFlags.contains(
+                countries[index].code,
               ),
             ),
           ),
+        ),
+      ],
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regional / flight school tab
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _RegionalTab extends StatelessWidget {
+  const _RegionalTab({required this.region, required this.areas});
+
+  final GameRegion region;
+  final List<RegionalArea> areas;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            '${areas.length} areas',
+            style: const TextStyle(color: FlitColors.textMuted, fontSize: 12),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            itemCount: areas.length,
+            itemBuilder: (context, index) => _RegionalClueCard(
+              area: areas[index],
+              region: region,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regional area clue card
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _RegionalClueCard extends StatefulWidget {
+  const _RegionalClueCard({required this.area, required this.region});
+
+  final RegionalArea area;
+  final GameRegion region;
+
+  @override
+  State<_RegionalClueCard> createState() => _RegionalClueCardState();
+}
+
+class _RegionalClueCardState extends State<_RegionalClueCard> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final a = widget.area;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Container(
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: FlitColors.cardBorder),
+        ),
+        child: Column(
+          children: [
+            InkWell(
+              onTap: () => setState(() => _expanded = !_expanded),
+              borderRadius: BorderRadius.circular(12),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  children: [
+                    // Outline
+                    SizedBox(
+                      width: 56,
+                      height: 42,
+                      child: a.points.isNotEmpty
+                          ? CustomPaint(
+                              painter: _OutlinePainter(
+                                [a.points],
+                                quality: a.points.length >= 70
+                                    ? _OutlineQuality.good
+                                    : a.points.length >= 30
+                                        ? _OutlineQuality.fair
+                                        : _OutlineQuality.poor,
+                              ),
+                            )
+                          : const Center(
+                              child: Text(
+                                '—',
+                                style: TextStyle(
+                                  color: FlitColors.textMuted,
+                                  fontSize: 18,
+                                ),
+                              ),
+                            ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            a.name,
+                            style: const TextStyle(
+                              color: FlitColors.textPrimary,
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          if (a.capital != null) ...[
+                            const SizedBox(height: 2),
+                            Text(
+                              a.capital!,
+                              style: const TextStyle(
+                                color: FlitColors.textMuted,
+                                fontSize: 11,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    Icon(
+                      _expanded
+                          ? Icons.keyboard_arrow_up
+                          : Icons.keyboard_arrow_down,
+                      color: FlitColors.textMuted,
+                      size: 20,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (_expanded) _buildRegionalDetails(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRegionalDetails(BuildContext context) {
+    final code = widget.area.code;
+    final rows = <Widget>[];
+
+    switch (widget.region) {
+      case GameRegion.usStates:
+        final d = UsStateClues.data[code];
+        if (d != null) {
+          rows.add(_DetailRow(
+            icon: Icons.badge,
+            label: 'Nickname',
+            value: d.nickname,
+          ));
+          if (d.sportsTeams.isNotEmpty) {
+            rows.add(_DetailRow(
+              icon: Icons.sports,
+              label: 'Sports',
+              value: d.sportsTeams.join(', '),
+            ));
+          }
+          rows.add(_DetailRow(
+            icon: Icons.landscape,
+            label: 'Landmark',
+            value: d.famousLandmark,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.format_quote,
+            label: 'Motto',
+            value: d.motto,
+          ));
+          if (d.senators.isNotEmpty) {
+            rows.add(_DetailRow(
+              icon: Icons.account_balance,
+              label: 'Senators',
+              value: d.senators.join(', '),
+            ));
+          }
+          rows.add(_DetailRow(
+            icon: Icons.pets,
+            label: 'State Bird',
+            value: d.stateBird,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.local_florist,
+            label: 'State Flower',
+            value: d.stateFlower,
+          ));
+          if (d.celebrities.isNotEmpty) {
+            rows.add(_DetailRow(
+              icon: Icons.star,
+              label: 'Celebrities',
+              value: d.celebrities.join(', '),
+            ));
+          }
+        }
+        break;
+      case GameRegion.ukCounties:
+        final d = UkClues.data[code];
+        if (d != null) {
+          rows.add(_DetailRow(
+            icon: Icons.flag,
+            label: 'Country',
+            value: d.country,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.badge,
+            label: 'Nickname',
+            value: d.nickname,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.star,
+            label: 'Famous Person',
+            value: d.famousPerson,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.landscape,
+            label: 'Landmark',
+            value: d.famousLandmark,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.sports_soccer,
+            label: 'Football',
+            value: d.footballTeam,
+          ));
+        }
+        break;
+      case GameRegion.ireland:
+        final d = IrelandClues.data[code];
+        if (d != null) {
+          rows.add(_DetailRow(
+            icon: Icons.map,
+            label: 'Province',
+            value: d.province,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.badge,
+            label: 'Nickname',
+            value: d.nickname,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.star,
+            label: 'Famous Person',
+            value: d.famousPerson,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.landscape,
+            label: 'Landmark',
+            value: d.famousLandmark,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.sports,
+            label: 'GAA Team',
+            value: d.gaaTeam,
+          ));
+        }
+        break;
+      case GameRegion.canadianProvinces:
+        final d = CanadaClues.data[code];
+        if (d != null) {
+          rows.add(_DetailRow(
+            icon: Icons.badge,
+            label: 'Nickname',
+            value: d.nickname,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.account_balance,
+            label: 'Premier',
+            value: d.premier,
+          ));
+          rows.add(_DetailRow(
+            icon: Icons.landscape,
+            label: 'Landmark',
+            value: d.famousLandmark,
+          ));
+          if (d.sportsTeams.isNotEmpty) {
+            rows.add(_DetailRow(
+              icon: Icons.sports,
+              label: 'Sports',
+              value: d.sportsTeams.join(', '),
+            ));
+          }
+        }
+        break;
+      default:
+        break;
+    }
+
+    if (widget.area.population != null && widget.area.population! > 0) {
+      final pop = widget.area.population!;
+      final popStr = pop >= 1000000
+          ? '${(pop / 1000000).toStringAsFixed(1)}M'
+          : pop >= 1000
+              ? '${(pop / 1000).toStringAsFixed(0)}K'
+              : pop.toString();
+      rows.add(_DetailRow(
+        icon: Icons.people,
+        label: 'Population',
+        value: popStr,
+      ));
+    }
+
+    if (widget.area.funFact != null) {
+      rows.add(_DetailRow(
+        icon: Icons.lightbulb_outline,
+        label: 'Fun Fact',
+        value: widget.area.funFact!,
+      ));
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Divider(color: FlitColors.cardBorder, height: 1),
+          const SizedBox(height: 10),
+          ...rows,
         ],
       ),
     );
@@ -308,7 +739,7 @@ class _ExpandedDetails extends StatelessWidget {
     'currency': 'Currency',
     'religion': 'Religion',
     'headOfState': 'Head of State',
-    'sport': 'Popular Sport',
+    'sport': 'Most Popular Sport',
     'language': 'Language',
     'celebrity': 'Famous Person',
   };
@@ -718,4 +1149,36 @@ class _OutlinePainter extends CustomPainter {
   @override
   bool shouldRepaint(_OutlinePainter old) =>
       polygons != old.polygons || quality != old.quality;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Legend dot
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _LegendDot extends StatelessWidget {
+  const _LegendDot({required this.color, required this.label});
+
+  final Color color;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) => Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              color: color.withOpacity(0.4),
+              shape: BoxShape.circle,
+              border: Border.all(color: color, width: 1),
+            ),
+          ),
+          const SizedBox(width: 3),
+          Text(
+            label,
+            style: TextStyle(color: color, fontSize: 10),
+          ),
+        ],
+      );
 }

--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -94,7 +94,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
     });
   }
 
-  void _openSettings() => showSettingsSheet(context);
+  void _openSettings() => showSettingsSheet(context, inGame: false);
 
   Future<void> _refreshProfile() async {
     if (_isRefreshingProfile) return;

--- a/lib/game/clues/clue_types.dart
+++ b/lib/game/clues/clue_types.dart
@@ -1816,22 +1816,195 @@ class Clue {
       },
     };
 
+    // Celebrity pool — adds variety so the same person doesn't always appear.
+    // When 'celebrity' is selected, one is picked at random from the pool.
+    const celebrityPool = <String, List<String>>{
+      'US': [
+        'Beyoncé',
+        'Taylor Swift',
+        'LeBron James',
+        'Oprah Winfrey',
+        'Tom Hanks',
+        'Elon Musk'
+      ],
+      'GB': [
+        'David Beckham',
+        'Adele',
+        'Ed Sheeran',
+        'Emma Watson',
+        'Elton John',
+        'David Attenborough'
+      ],
+      'FR': [
+        'Zinedine Zidane',
+        'Marion Cotillard',
+        'Thierry Henry',
+        'Brigitte Bardot',
+        'Kylian Mbappé',
+        'Coco Chanel'
+      ],
+      'DE': [
+        'Albert Einstein',
+        'Jürgen Klopp',
+        'Heidi Klum',
+        'Ludwig van Beethoven',
+        'Michael Schumacher',
+        'Boris Becker'
+      ],
+      'BR': [
+        'Pelé',
+        'Neymar',
+        'Gisele Bündchen',
+        'Ayrton Senna',
+        'Ronaldinho',
+        'Caetano Veloso'
+      ],
+      'IN': [
+        'Shah Rukh Khan',
+        'Sachin Tendulkar',
+        'Priyanka Chopra',
+        'Virat Kohli',
+        'Amitabh Bachchan',
+        'Sundar Pichai'
+      ],
+      'JP': [
+        'Shohei Ohtani',
+        'Hayao Miyazaki',
+        'Naomi Osaka',
+        'Yoko Ono',
+        'Marie Kondo',
+        'Akira Kurosawa'
+      ],
+      'AU': [
+        'Hugh Jackman',
+        'Nicole Kidman',
+        'Steve Irwin',
+        'Margot Robbie',
+        'Kylie Minogue',
+        'Chris Hemsworth'
+      ],
+      'CA': [
+        'Drake',
+        'Ryan Reynolds',
+        'Céline Dion',
+        'Justin Bieber',
+        'Keanu Reeves',
+        'Wayne Gretzky'
+      ],
+      'IT': [
+        'Leonardo da Vinci',
+        'Andrea Bocelli',
+        'Monica Bellucci',
+        'Roberto Baggio',
+        'Sophia Loren',
+        'Valentino Rossi'
+      ],
+      'ES': [
+        'Rafael Nadal',
+        'Penélope Cruz',
+        'Andrés Iniesta',
+        'Antonio Banderas',
+        'Pablo Picasso',
+        'Enrique Iglesias'
+      ],
+      'MX': [
+        'Salma Hayek',
+        'Guillermo del Toro',
+        'Frida Kahlo',
+        'Canelo Álvarez',
+        'Carlos Slim',
+        'Octavio Paz'
+      ],
+      'AR': [
+        'Lionel Messi',
+        'Diego Maradona',
+        'Pope Francis',
+        'Eva Perón',
+        'Che Guevara',
+        'Jorge Luis Borges'
+      ],
+      'NG': [
+        'Wizkid',
+        'Burna Boy',
+        'Chimamanda Ngozi Adichie',
+        'Tiwa Savage',
+        'Davido',
+        'Wole Soyinka'
+      ],
+      'KR': [
+        'BTS',
+        'Son Heung-min',
+        'BLACKPINK',
+        'Bong Joon-ho',
+        'Park Ji-sung',
+        'PSY'
+      ],
+      'ZA': [
+        'Nelson Mandela',
+        'Trevor Noah',
+        'Charlize Theron',
+        'Elon Musk',
+        'Siya Kolisi',
+        'Desmond Tutu'
+      ],
+      'EG': [
+        'Mohamed Salah',
+        'Omar Sharif',
+        'Cleopatra',
+        'Naguib Mahfouz',
+        'Ahmed Zewail',
+        'Tutankhamun'
+      ],
+      'CN': [
+        'Jackie Chan',
+        'Yao Ming',
+        'Jack Ma',
+        'Jet Li',
+        'Fan Bingbing',
+        'Zhang Yimou'
+      ],
+      'RU': [
+        'Maria Sharapova',
+        'Leo Tolstoy',
+        'Garry Kasparov',
+        'Anna Pavlova',
+        'Yuri Gagarin',
+        'Pyotr Tchaikovsky'
+      ],
+      'CO': [
+        'Shakira',
+        'James Rodríguez',
+        'Gabriel García Márquez',
+        'Sofía Vergara',
+        'Juan Valdez',
+        'Maluma'
+      ],
+    };
+
     final countryStats = allStats[code];
     // Return empty map if country not found - caller should handle by picking different clue type
     if (countryStats == null) return <String, dynamic>{};
 
+    // Build a mutable copy so we can swap in a random celebrity.
+    final stats = Map<String, dynamic>.from(countryStats);
+    final pool = celebrityPool[code];
+    if (pool != null && pool.isNotEmpty) {
+      final rng = random ?? Random();
+      stats['celebrity'] = pool[rng.nextInt(pool.length)];
+    }
+
     // Return all stats when requested (e.g. for the clues browser).
-    if (returnAll) return Map<String, dynamic>.from(countryStats);
+    if (returnAll) return stats;
 
     // Pick a random trio of stats from all available keys.
     // Use the provided seeded RNG when available so H2H players see the same
     // three facts; fall back to an unseeded Random for free-play.
-    final keys = countryStats.keys.toList()..shuffle(random ?? Random());
+    final keys = stats.keys.toList()..shuffle(random ?? Random());
     final selectedKeys = keys.take(3).toList();
 
     final result = <String, dynamic>{};
     for (final key in selectedKeys) {
-      result[key] = countryStats[key];
+      result[key] = stats[key];
     }
     return result;
   }

--- a/lib/game/ui/game_hud.dart
+++ b/lib/game/ui/game_hud.dart
@@ -739,10 +739,10 @@ class _HintButtonState extends State<_HintButton>
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
             decoration: BoxDecoration(
-              color: FlitColors.gold.withOpacity(0.35),
+              color: FlitColors.gold.withOpacity(0.55),
               borderRadius: BorderRadius.circular(20),
               border: Border.all(
-                color: FlitColors.gold.withOpacity(0.8),
+                color: FlitColors.gold.withOpacity(0.9),
                 width: 1.5,
               ),
             ),

--- a/shaders/globe.frag
+++ b/shaders/globe.frag
@@ -70,7 +70,7 @@ const float RIM_INTENSITY      = 0.35;
 const float HAZE_STRENGTH      = 0.15;
 
 // Clouds
-const float CLOUD_SOFTNESS     = 0.25;
+const float CLOUD_SOFTNESS     = 0.12;  // tighter edges for defined cloud shapes
 const float CLOUD_DRIFT_SPEED  = 0.008;
 const float CLOUD_BRIGHTNESS   = 1.0;
 const float CLOUD_SHADOW_STR   = 0.15;
@@ -88,8 +88,8 @@ const float NIGHT_RIM_STRENGTH = 0.3;
 
 // Night-side dark overlay — darkens the Blue Marble on the unlit hemisphere
 // so the night side looks distinctly dark, not just dimly lit.
-const float NIGHT_DARKEN       = 0.02;  // multiply factor for night surface
-const vec3  NIGHT_TINT         = vec3(0.06, 0.07, 0.12); // deep blue-black
+const float NIGHT_DARKEN       = 0.01;  // multiply factor for night surface
+const vec3  NIGHT_TINT         = vec3(0.02, 0.02, 0.03); // near-black
 
 // Sky / stars
 const float SUN_DISC_SIZE      = 0.9995;
@@ -482,12 +482,29 @@ void main() {
             vec3 cloudHit = ro + rayDir * tC;
             vec3 cloudNormal = normalize(cloudHit - GLOBE_ORIGIN);
 
-            vec3 cloudSamplePos = cloudHit * 3.0;
+            // Higher frequency = more, smaller cloud formations
+            vec3 cloudSamplePos = cloudHit * 6.0;
             cloudSamplePos.x += uTime * CLOUD_DRIFT_SPEED;
             cloudSamplePos.z += uTime * CLOUD_DRIFT_SPEED * 0.7;
 
+            // Cluster mask: cheap single-noise call at low frequency
+            // creates regions where clouds preferentially form
+            float cluster = noise3D(cloudHit * 1.8 + vec3(uTime * 0.001));
+            cluster = smoothstep(0.3, 0.7, cluster);
+
+            // Detail noise via FBM for cloud shape
             float density = fbm(cloudSamplePos);
-            float cloudMask = smoothstep(uCloudCoverage - CLOUD_SOFTNESS, uCloudCoverage + CLOUD_SOFTNESS, density);
+
+            // Apply clustering: clouds concentrate in cluster regions
+            density *= (0.15 + 0.85 * cluster);
+
+            // Log-like distribution: small clouds common, large rare
+            density = pow(density, 1.5);
+
+            // Coverage: 0 = no clouds, 1 = full coverage
+            // Invert threshold so higher coverage = more clouds
+            float coverageThreshold = 1.0 - uCloudCoverage;
+            float cloudMask = smoothstep(coverageThreshold, coverageThreshold + CLOUD_SOFTNESS, density);
 
             if (cloudMask > 0.01) {
                 float cloudNdotL = dot(cloudNormal, uSunDir);
@@ -507,11 +524,16 @@ void main() {
         }
 
         // Cloud shadows on terrain
-        vec3 shadowSamplePos = hitPoint * 3.0;
+        vec3 shadowSamplePos = hitPoint * 6.0;
         shadowSamplePos.x += uTime * CLOUD_DRIFT_SPEED;
         shadowSamplePos.z += uTime * CLOUD_DRIFT_SPEED * 0.7;
+        float shadowCluster = noise3D(hitPoint * 1.8 + vec3(uTime * 0.001));
+        shadowCluster = smoothstep(0.3, 0.7, shadowCluster);
         float shadowDensity = fbm(shadowSamplePos);
-        float shadowMask = smoothstep(uCloudCoverage - CLOUD_SOFTNESS, uCloudCoverage + CLOUD_SOFTNESS, shadowDensity);
+        shadowDensity *= (0.15 + 0.85 * shadowCluster);
+        shadowDensity = pow(shadowDensity, 1.5);
+        float shadowThreshold = 1.0 - uCloudCoverage;
+        float shadowMask = smoothstep(shadowThreshold, shadowThreshold + CLOUD_SOFTNESS, shadowDensity);
         surfaceColor *= 1.0 - shadowMask * CLOUD_SHADOW_STR * dayFactor;
     }
 


### PR DESCRIPTION
- Shader: darken night side (NIGHT_TINT near-black, reduce blue tint)
- Shader: cloud coverage with clustering, log distribution, smaller formations
  - 0% = no clouds, 100% = full coverage
  - Single noise3D call for clustering (cheap), pow() for log distribution
- Settings: split in-game vs profile — notifications and difficulty only shown in profile settings, not during gameplay
- Hint button: increase opacity (0.35→0.55 bg, 0.8→0.9 border)
- Clues: celebrity pool with 6 options for 20 major countries
- Clues: rename "Popular Sport" to "Most Popular Sport"
- Clues: add outline quality legend (Good/Fair/Poor)
- Clues: add flight school tabs (US States, UK, Ireland, Canada) showing rich regional clue data inline

https://claude.ai/code/session_01HUQy2Z5AhJdKz16MRU3zQ7