### PR TITLE
fix: world camera bounds now reach both poles

### DIFF
--- a/lib/game/rendering/region_camera_presets.dart
+++ b/lib/game/rendering/region_camera_presets.dart
@@ -52,11 +52,13 @@ abstract class RegionCameraPresets {
   // ---------------------------------------------------------------------------
 
   /// World view: high altitude, full freedom.
+  /// maxBoundsLat must be large enough so that centerLat ± maxBoundsLat
+  /// covers [-90, +90] — otherwise the camera can't reach the poles.
   static const CameraPreset _worldPreset = CameraPreset(
     centerLat: 20.0,
     centerLng: 0.0,
     altitudeDistance: 3.5,
-    maxBoundsLat: 90.0,
+    maxBoundsLat: 110.0,
     maxBoundsLng: 180.0,
   );
 


### PR DESCRIPTION
The world preset had centerLat=20 and maxBoundsLat=90, clamping the camera to [-70°, +110°] latitude. This created an invisible barrier at ~70°S that prevented flying over the south pole.

Changed maxBoundsLat to 110 so the range is [-90°, +130°], covering both poles (asin naturally caps at ±90°).

https://claude.ai/code/session_01L5Fm9BKiTrqqwpCzskyMqY