### PR TITLE
Move skip clue button inside clue card & update cloud defaults

### DIFF
--- a/lib/core/services/game_settings.dart
+++ b/lib/core/services/game_settings.dart
@@ -294,8 +294,8 @@ class GameSettings extends ChangeNotifier {
   }
 
   /// Cloud coverage threshold (0.0 = fully covered, 1.0 = clear sky).
-  /// Higher values mean fewer clouds. Default 0.25.
-  double _cloudCoverage = 0.25;
+  /// Higher values mean fewer clouds. Default 0.64.
+  double _cloudCoverage = 0.64;
 
   double get cloudCoverage => _cloudCoverage;
 
@@ -308,8 +308,8 @@ class GameSettings extends ChangeNotifier {
   String get cloudCoverageLabel => '${((_cloudCoverage) * 100).round()}%';
 
   /// Cloud blend opacity (0.0 = transparent, 1.0 = fully opaque).
-  /// Default 0.5 (50% opaque).
-  double _cloudOpacity = 0.5;
+  /// Default 0.85 (85% opaque).
+  double _cloudOpacity = 0.85;
 
   double get cloudOpacity => _cloudOpacity;
 

--- a/lib/data/services/user_preferences_service.dart
+++ b/lib/data/services/user_preferences_service.dart
@@ -1177,11 +1177,11 @@ class UserPreferencesSnapshot {
   }
 
   double get cloudCoverage {
-    return (settings?['cloud_coverage'] as num?)?.toDouble() ?? 0.42;
+    return (settings?['cloud_coverage'] as num?)?.toDouble() ?? 0.64;
   }
 
   double get cloudOpacity {
-    return (settings?['cloud_opacity'] as num?)?.toDouble() ?? 0.9;
+    return (settings?['cloud_opacity'] as num?)?.toDouble() ?? 0.85;
   }
 
   String get mapStyle {

--- a/lib/game/ui/game_hud.dart
+++ b/lib/game/ui/game_hud.dart
@@ -84,7 +84,10 @@ class GameHud extends StatelessWidget {
                   const SizedBox(width: 8),
                   // Center: Clue display (expanded to fill available space)
                   if (currentClue != null)
-                    Expanded(child: _ClueCard(clue: currentClue!))
+                    Expanded(
+                      child:
+                          _ClueCard(clue: currentClue!, onSkipClue: onSkipClue),
+                    )
                   else
                     const Spacer(),
                   const SizedBox(width: 8),
@@ -102,9 +105,7 @@ class GameHud extends StatelessWidget {
                           (totalRounds == null || totalRounds! > 1)) ...[
                         const SizedBox(height: 6),
                         _RoundIndicator(
-                          current: currentRound!,
-                          total: totalRounds,
-                        ),
+                            current: currentRound!, total: totalRounds),
                       ],
                     ],
                   ),
@@ -171,8 +172,6 @@ class GameHud extends StatelessWidget {
                   // Hint button
                   if (hintTier < 4 && onHint != null)
                     _HintButton(tier: hintTier, onTap: onHint),
-                  // Skip clue button (free flight only)
-                  if (onSkipClue != null) _SkipClueButton(onTap: onSkipClue),
                   // Speed controls
                   Flexible(
                     child: _SpeedControls(
@@ -241,9 +240,13 @@ class _GearButton extends StatelessWidget {
 }
 
 class _ClueCard extends StatelessWidget {
-  const _ClueCard({required this.clue});
+  const _ClueCard({required this.clue, this.onSkipClue});
 
   final Clue clue;
+
+  /// Callback to skip to next clue (free flight only). When null, skip button
+  /// is hidden.
+  final VoidCallback? onSkipClue;
 
   @override
   Widget build(BuildContext context) => Container(
@@ -257,15 +260,21 @@ class _ClueCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            // Clue type label
-            Text(
-              _clueTypeLabel(clue.type),
-              style: const TextStyle(
-                color: FlitColors.gold,
-                fontSize: 9,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 1.5,
-              ),
+            // Clue type label + skip button row
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  _clueTypeLabel(clue.type),
+                  style: const TextStyle(
+                    color: FlitColors.gold,
+                    fontSize: 9,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 1.5,
+                  ),
+                ),
+                if (onSkipClue != null) _SkipClueButton(onTap: onSkipClue),
+              ],
             ),
             const SizedBox(height: 4),
             // Clue content
@@ -626,8 +635,10 @@ class _SpeedControls extends StatelessWidget {
             return GestureDetector(
               onTap: () => onChanged?.call(speed),
               child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
                 decoration: BoxDecoration(
                   color: isActive
                       ? FlitColors.accent.withOpacity(0.3)
@@ -808,7 +819,7 @@ class _HintButtonState extends State<_HintButton>
   }
 }
 
-/// Skip-clue pill button for free flight mode.
+/// Compact skip-clue pill button shown inside the clue card (free flight only).
 class _SkipClueButton extends StatelessWidget {
   const _SkipClueButton({this.onTap});
 
@@ -818,25 +829,23 @@ class _SkipClueButton extends StatelessWidget {
   Widget build(BuildContext context) => GestureDetector(
         onTap: onTap,
         child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
           decoration: BoxDecoration(
-            color: FlitColors.accent.withOpacity(0.55),
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(
-              color: FlitColors.accent.withOpacity(0.9),
-              width: 1.5,
-            ),
+            color: FlitColors.gold.withOpacity(0.55),
+            borderRadius: BorderRadius.circular(12),
+            border:
+                Border.all(color: FlitColors.gold.withOpacity(0.9), width: 1),
           ),
           child: const Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(Icons.skip_next, color: FlitColors.accent, size: 16),
-              SizedBox(width: 4),
+              Icon(Icons.skip_next, color: FlitColors.gold, size: 12),
+              SizedBox(width: 2),
               Text(
                 'SKIP',
                 style: TextStyle(
-                  color: FlitColors.accent,
-                  fontSize: 11,
+                  color: FlitColors.gold,
+                  fontSize: 9,
                   fontWeight: FontWeight.w700,
                   letterSpacing: 0.5,
                 ),


### PR DESCRIPTION
- Relocated skip clue button from bottom control row into the top-right corner of the clue card, alongside the clue type label. This prevents it from compressing the speed controls on mobile screens.
- Made the button more compact (smaller padding, font, icon) to fit within the card header. Styled with gold color to match existing buttons (hint button).
- Button only appears in free flight mode (unchanged logic).
- Updated default cloud coverage from 25% to 64% (GameSettings) and 42% to 64% (UserPreferencesService fallback).
- Updated default cloud opacity from 50% to 85% (GameSettings) and 90% to 85% (UserPreferencesService fallback).

https://claude.ai/code/session_019ksMakXwCpXSiZGWYTZPHJ