### PR TITLE
Fix border artefacts in flight school levels caused by multi-polygon …

### DIFF
--- a/lib/game/map/region.dart
+++ b/lib/game/map/region.dart
@@ -166,6 +166,7 @@ class RegionalArea {
     required this.code,
     required this.name,
     required this.points,
+    this.polygons,
     this.capital,
     this.population,
     this.funFact,
@@ -173,7 +174,13 @@ class RegionalArea {
 
   final String code;
   final String name;
+
+  /// Flat list of all points (used for hit-testing, centroids, etc.)
   final List<Vector2> points;
+
+  /// Separate polygon rings. When non-null, renderers should draw each ring
+  /// as its own sub-path to avoid artefacts between disjoint polygons.
+  final List<List<Vector2>>? polygons;
   final String? capital;
   final int? population;
   final String? funFact;
@@ -191,6 +198,7 @@ abstract class RegionalData {
                 code: c.code,
                 name: c.name,
                 points: c.allPoints,
+                polygons: c.polygons,
                 capital: c.capital,
               ),
             )
@@ -226,6 +234,7 @@ abstract class RegionalData {
             code: c.code,
             name: c.name,
             points: c.allPoints,
+            polygons: c.polygons,
             capital: c.capital,
           ),
         )

--- a/lib/game/quiz/quiz_region_map_widget.dart
+++ b/lib/game/quiz/quiz_region_map_widget.dart
@@ -166,7 +166,7 @@ class _RegionMapPainter extends CustomPainter {
 
     for (final area in areas) {
       if (eliminatedCodes.contains(area.code)) continue;
-      final path = _buildPath(area.points, transform);
+      final path = _buildPath(area.points, transform, polygons: area.polygons);
       canvas.drawPath(path, borderPaint);
     }
 
@@ -246,7 +246,7 @@ class _RegionMapPainter extends CustomPainter {
     final isHighlighted = highlightCode == area.code;
     final isCorrectlyGuessed = correctCodes.contains(area.code);
 
-    final path = _buildPath(area.points, transform);
+    final path = _buildPath(area.points, transform, polygons: area.polygons);
     final fillColor = _getFillColor(status, isHighlighted, isCorrectlyGuessed);
     canvas.drawPath(path, Paint()..color = fillColor);
   }
@@ -320,10 +320,29 @@ class _RegionMapPainter extends CustomPainter {
     }
   }
 
-  Path _buildPath(List<Vector2> points, _GeoTransform transform) {
+  Path _buildPath(List<Vector2> points, _GeoTransform transform,
+      {List<List<Vector2>>? polygons}) {
     final path = Path();
-    if (points.isEmpty) return path;
 
+    // When separate polygon rings are available, draw each as its own
+    // sub-path so disjoint polygons (islands, exclaves) don't produce
+    // stretching artefacts.
+    if (polygons != null && polygons.isNotEmpty) {
+      for (final ring in polygons) {
+        if (ring.isEmpty) continue;
+        final first = transform.toCanvas(ring.first.x, ring.first.y);
+        path.moveTo(first.dx, first.dy);
+        for (var i = 1; i < ring.length; i++) {
+          final p = transform.toCanvas(ring[i].x, ring[i].y);
+          path.lineTo(p.dx, p.dy);
+        }
+        path.close();
+      }
+      return path;
+    }
+
+    // Fallback: single flat list of points.
+    if (points.isEmpty) return path;
     final first = transform.toCanvas(points.first.x, points.first.y);
     path.moveTo(first.dx, first.dy);
 

--- a/lib/game/rendering/flat_map_renderer.dart
+++ b/lib/game/rendering/flat_map_renderer.dart
@@ -123,24 +123,32 @@ class FlatMapRenderer extends Component with HasGameRef<FlitGame> {
     for (final area in areas) {
       if (area.points.length < 3) continue;
 
-      final path = ui.Path();
-      var started = false;
+      // When separate polygon rings are available, draw each as its own
+      // sub-path so disjoint polygons don't produce stretching artefacts.
+      final rings = area.polygons ?? [area.points];
 
-      for (var i = 0; i < area.points.length; i++) {
-        final screenPos = worldToScreen(area.points[i], screenW, screenH);
-        if (screenPos.x < -500) continue;
+      for (final ring in rings) {
+        if (ring.length < 3) continue;
 
-        if (!started) {
-          path.moveTo(screenPos.x, screenPos.y);
-          started = true;
-        } else {
-          path.lineTo(screenPos.x, screenPos.y);
+        final path = ui.Path();
+        var started = false;
+
+        for (var i = 0; i < ring.length; i++) {
+          final screenPos = worldToScreen(ring[i], screenW, screenH);
+          if (screenPos.x < -500) continue;
+
+          if (!started) {
+            path.moveTo(screenPos.x, screenPos.y);
+            started = true;
+          } else {
+            path.lineTo(screenPos.x, screenPos.y);
+          }
         }
-      }
 
-      if (started) {
-        path.close();
-        canvas.drawPath(path, borderPaint);
+        if (started) {
+          path.close();
+          canvas.drawPath(path, borderPaint);
+        }
       }
     }
   }

--- a/lib/game/session/game_session.dart
+++ b/lib/game/session/game_session.dart
@@ -224,7 +224,7 @@ class GameSession {
       final country = CountryShape(
         code: area.code,
         name: area.name,
-        polygons: [area.points],
+        polygons: area.polygons ?? [area.points],
         capital: area.capital,
       );
 


### PR DESCRIPTION
…countries

Countries with multiple polygon rings (islands, exclaves) had all their vertices flattened into a single list via `allPoints`. The renderers drew this as one continuous path, connecting the last vertex of one ring to the first vertex of the next — producing large triangular stretching artefacts across the map.

Added an optional `polygons` field to `RegionalArea` that preserves separate polygon rings from `CountryShape`. Updated all three renderers (quiz_region_map_widget, flat_map_renderer, game_session) to draw each ring as its own sub-path when polygon data is available.

https://claude.ai/code/session_019ksMakXwCpXSiZGWYTZPHJ