### PR TITLE
feat: replace sketch/pencil/crosshatch style with watercolor vector a…

### DIFF
--- a/lib/features/debug/companion_preview_screen.dart
+++ b/lib/features/debug/companion_preview_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
 import '../../data/models/avatar_config.dart';
+import '../../game/rendering/watercolor_style.dart';
 
 /// Debug screen that renders every companion creature side-by-side at large
 /// scale with animated wing flapping.
@@ -244,16 +245,13 @@ class _CompanionPreviewPainter extends CustomPainter {
     const cream = Color(0xFFF5E8D0);
     const darkBrown = Color(0xFF6B5238);
 
-    canvas.drawOval(
-      Rect.fromCenter(
+    final shadowPath = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(0.5, s * 0.22),
         width: s * 1.0,
         height: s * 0.3,
-      ),
-      Paint()
-        ..color = const Color(0xFF000000).withOpacity(0.1)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2),
-    );
+      ));
+    WatercolorStyle.softShadow(canvas, shadowPath);
 
     _drawTailFeathers(canvas, s, darkBrown, 3, 0.35, 0.12);
     _drawWing(canvas, s, flapOffset, darkBrown.withOpacity(0.85), true, 0.7, 2);
@@ -268,16 +266,21 @@ class _CompanionPreviewPainter extends CustomPainter {
     );
     _drawBody(canvas, s * 0.95, s * 0.6, brown, cream);
 
-    canvas.drawCircle(
-      const Offset(0, -s * 0.32),
-      s * 0.28,
-      Paint()..color = brown,
-    );
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.18,
-      Paint()..color = cream,
-    );
+    final pidgeyHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+        center: const Offset(0, -s * 0.32),
+        radius: s * 0.28,
+      ));
+    WatercolorStyle.washFill(canvas, pidgeyHeadPath, brown,
+        seed: 'pidgey_head');
+    WatercolorStyle.wetEdge(canvas, pidgeyHeadPath, brown, opacity: 0.15);
+    final pidgeyFacePath = Path()
+      ..addOval(Rect.fromCircle(
+        center: const Offset(0, -s * 0.28),
+        radius: s * 0.18,
+      ));
+    WatercolorStyle.washFill(canvas, pidgeyFacePath, cream,
+        seed: 'pidgey_face');
     canvas.drawCircle(
       const Offset(-s * 0.05, -s * 0.42),
       s * 0.08,
@@ -328,27 +331,30 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..quadraticBezierTo(s * 0.2, s * 0.55, s * 0.18, s * 0.7)
       ..quadraticBezierTo(s * 0.12, s * 0.5, s * 0.02, s * 0.35)
       ..close();
-    canvas.drawPath(leftFork, Paint()..color = navy);
-    canvas.drawPath(rightFork, Paint()..color = navy);
+    WatercolorStyle.washFill(canvas, leftFork, navy, seed: 'sparrow_lf');
+    WatercolorStyle.washFill(canvas, rightFork, navy, seed: 'sparrow_rf');
 
     _drawWing(canvas, s, flapOffset, navy.withOpacity(0.9), true, 0.85, 3);
     _drawWing(canvas, s, flapOffset, navy.withOpacity(0.9), false, 0.85, 3);
     _drawBody(canvas, s * 0.7, s * 0.5, navy, cream);
 
-    canvas.drawOval(
-      Rect.fromCenter(
+    final sparrowThroatPath = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(0, -s * 0.05),
         width: s * 0.35,
         height: s * 0.15,
-      ),
-      Paint()..color = russet,
-    );
+      ));
+    WatercolorStyle.washFill(canvas, sparrowThroatPath, russet,
+        seed: 'sparrow_throat');
 
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.2,
-      Paint()..color = navy,
-    );
+    final sparrowHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+        center: const Offset(0, -s * 0.28),
+        radius: s * 0.2,
+      ));
+    WatercolorStyle.washFill(canvas, sparrowHeadPath, navy,
+        seed: 'sparrow_head');
+    WatercolorStyle.wetEdge(canvas, sparrowHeadPath, navy, opacity: 0.15);
     canvas.drawCircle(
       const Offset(-s * 0.04, -s * 0.35),
       s * 0.06,
@@ -404,11 +410,13 @@ class _CompanionPreviewPainter extends CustomPainter {
 
     _drawBody(canvas, s * 0.75, s * 0.55, golden, _lighten(golden, 0.2));
 
-    canvas.drawCircle(
-      const Offset(0, -s * 0.3),
-      s * 0.22,
-      Paint()..color = white,
-    );
+    final eagleHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+        center: const Offset(0, -s * 0.3),
+        radius: s * 0.22,
+      ));
+    WatercolorStyle.washFill(canvas, eagleHeadPath, white, seed: 'eagle_head');
+    WatercolorStyle.wetEdge(canvas, eagleHeadPath, white, opacity: 0.12);
     canvas.drawCircle(
       const Offset(-s * 0.04, -s * 0.38),
       s * 0.07,
@@ -450,7 +458,8 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..quadraticBezierTo(i * s * 0.04, s * 0.6, i * s * 0.02, s * 0.25)
         ..close();
       final c = [scarlet, blue, green][i + 1];
-      canvas.drawPath(streamer, Paint()..color = c.withOpacity(0.8));
+      WatercolorStyle.washFill(canvas, streamer, c.withOpacity(0.85),
+          seed: 'parrot_tail_$i');
     }
 
     _drawWing(
@@ -476,19 +485,21 @@ class _CompanionPreviewPainter extends CustomPainter {
 
     _drawBody(canvas, s * 0.7, s * 0.5, scarlet, gold.withOpacity(0.5));
 
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.22,
-      Paint()..color = scarlet,
-    );
-    canvas.drawOval(
-      Rect.fromCenter(
+    final parrotHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+        center: const Offset(0, -s * 0.28),
+        radius: s * 0.22,
+      ));
+    WatercolorStyle.washFill(canvas, parrotHeadPath, scarlet, seed: 'parrot_h');
+    WatercolorStyle.wetEdge(canvas, parrotHeadPath, scarlet, opacity: 0.15);
+    final parrotFacePath = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(0, -s * 0.25),
         width: s * 0.3,
         height: s * 0.2,
-      ),
-      Paint()..color = const Color(0xFFF8F4F0),
-    );
+      ));
+    WatercolorStyle.washFill(canvas, parrotFacePath, const Color(0xFFF8F4F0),
+        seed: 'parrot_face');
     canvas.drawCircle(
       const Offset(-s * 0.04, -s * 0.36),
       s * 0.06,
@@ -534,7 +545,8 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..close();
       final t = (i + 2) / 4.0;
       final c = Color.lerp(flameRed, flameYellow, t)!;
-      canvas.drawPath(streamer, Paint()..color = c.withOpacity(0.7));
+      WatercolorStyle.washFill(canvas, streamer, c.withOpacity(0.7),
+          seed: 'phx_tail_$i');
     }
 
     _drawWing(
@@ -560,10 +572,19 @@ class _CompanionPreviewPainter extends CustomPainter {
 
     _drawBody(canvas, s * 0.7, s * 0.5, goldenOrange, flameYellow);
 
-    canvas.drawCircle(
+    final phxHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+        center: const Offset(0, -s * 0.3),
+        radius: s * 0.22,
+      ));
+    WatercolorStyle.washFill(canvas, phxHeadPath, goldenOrange,
+        seed: 'phx_head');
+    WatercolorStyle.auraGlow(
+      canvas,
       const Offset(0, -s * 0.3),
-      s * 0.22,
-      Paint()..color = goldenOrange,
+      s * 0.35,
+      flameYellow,
+      opacity: 0.18,
     );
     canvas.drawCircle(
       const Offset(-s * 0.04, -s * 0.38),
@@ -603,7 +624,7 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..cubicTo(-s * 0.1, s * 0.5, s * 0.15, s * 0.7, -s * 0.05, s * 0.9)
       ..cubicTo(-s * 0.08, s * 0.75, s * 0.08, s * 0.5, 0, s * 0.25)
       ..close();
-    canvas.drawPath(tail, Paint()..color = darkPurple);
+    WatercolorStyle.washFill(canvas, tail, darkPurple, seed: 'drag_tail');
 
     // Scaled wings.
     _drawWing(
@@ -652,11 +673,13 @@ class _CompanionPreviewPainter extends CustomPainter {
       }
     }
 
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.2,
-      Paint()..color = purple,
-    );
+    final dragHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+        center: const Offset(0, -s * 0.28),
+        radius: s * 0.2,
+      ));
+    WatercolorStyle.washFill(canvas, dragHeadPath, purple, seed: 'drag_head');
+    WatercolorStyle.wetEdge(canvas, dragHeadPath, purple, opacity: 0.15);
     canvas.drawCircle(
       const Offset(-s * 0.04, -s * 0.36),
       s * 0.06,
@@ -689,7 +712,7 @@ class _CompanionPreviewPainter extends CustomPainter {
           -s * 0.38,
         )
         ..close();
-      canvas.drawPath(horn, Paint()..color = darkPurple);
+      WatercolorStyle.washFill(canvas, horn, darkPurple, seed: 'drag_horn');
     }
 
     // Fire breath effect.
@@ -709,7 +732,15 @@ class _CompanionPreviewPainter extends CustomPainter {
         -s * 0.45,
       )
       ..close();
-    canvas.drawPath(flame, Paint()..color = teal.withOpacity(0.5));
+    WatercolorStyle.washFill(canvas, flame, teal.withOpacity(0.5),
+        seed: 'drag_flame');
+    WatercolorStyle.auraGlow(
+      canvas,
+      Offset(0, -s * 0.55 * breathScale),
+      s * 0.15,
+      teal,
+      opacity: 0.2,
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -728,7 +759,7 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..quadraticBezierTo(-s * 0.08, s * 0.55, -s * 0.05, s * 0.7)
       ..quadraticBezierTo(s * 0.02, s * 0.55, 0, s * 0.25)
       ..close();
-    canvas.drawPath(tail, Paint()..color = darkOrange);
+    WatercolorStyle.washFill(canvas, tail, darkOrange, seed: 'char_tail');
 
     final breathScale = 0.8 + sin(breathPhase) * 0.2;
     final flameTip = Path()
@@ -741,9 +772,15 @@ class _CompanionPreviewPainter extends CustomPainter {
       )
       ..quadraticBezierTo(s * 0.05, s * 0.8 * breathScale, -s * 0.02, s * 0.65)
       ..close();
-    canvas.drawPath(
-      flameTip,
-      Paint()..color = const Color(0xFFFFAA30).withOpacity(0.8),
+    WatercolorStyle.washFill(
+        canvas, flameTip, const Color(0xFFFFAA30).withOpacity(0.8),
+        seed: 'char_flame');
+    WatercolorStyle.auraGlow(
+      canvas,
+      Offset(-s * 0.03, s * 0.75 * breathScale),
+      s * 0.12,
+      const Color(0xFFFFAA30),
+      opacity: 0.2,
     );
 
     _drawWing(
@@ -769,11 +806,13 @@ class _CompanionPreviewPainter extends CustomPainter {
 
     _drawBody(canvas, s * 0.65, s * 0.5, orange, cream);
 
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.2,
-      Paint()..color = orange,
-    );
+    final charHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+        center: const Offset(0, -s * 0.28),
+        radius: s * 0.2,
+      ));
+    WatercolorStyle.washFill(canvas, charHeadPath, orange, seed: 'char_head');
+    WatercolorStyle.wetEdge(canvas, charHeadPath, orange, opacity: 0.15);
     canvas.drawCircle(
       const Offset(-s * 0.04, -s * 0.36),
       s * 0.06,
@@ -802,7 +841,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..lineTo(sign * s * 0.2, -s * 0.52)
         ..lineTo(sign * s * 0.1, -s * 0.38)
         ..close();
-      canvas.drawPath(spike, Paint()..color = darkOrange);
+      WatercolorStyle.washFill(canvas, spike, darkOrange, seed: 'char_spike');
     }
   }
 
@@ -851,7 +890,9 @@ class _CompanionPreviewPainter extends CustomPainter {
     wing
       ..lineTo(sign * size * 0.1, size * 0.05)
       ..close();
-    canvas.drawPath(wing, paint);
+    WatercolorStyle.washFill(canvas, wing, paint.color,
+        seed: isLeft ? 'wing_l' : 'wing_r');
+    WatercolorStyle.wetEdge(canvas, wing, paint.color, opacity: 0.2);
 
     if (tipColor != null) {
       final tip = Path()
@@ -866,7 +907,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..lineTo(sign * size * (spread - 0.12), flapOffset - size * 0.12)
         ..close();
-      canvas.drawPath(tip, Paint()..color = tipColor);
+      WatercolorStyle.washFill(canvas, tip, tipColor, seed: 'tip');
     }
   }
 
@@ -877,26 +918,25 @@ class _CompanionPreviewPainter extends CustomPainter {
     Color baseColor,
     Color bellyColor,
   ) {
-    canvas.drawOval(
-      Rect.fromCenter(
+    final shadowPath = Path()
+      ..addOval(Rect.fromCenter(
         center: Offset(0, height * 0.08),
         width: width * 0.95,
         height: height * 0.6,
-      ),
-      Paint()..color = _darken(baseColor, 0.3),
-    );
-    canvas.drawOval(
-      Rect.fromCenter(center: Offset.zero, width: width, height: height),
-      Paint()..color = baseColor,
-    );
-    canvas.drawOval(
-      Rect.fromCenter(
+      ));
+    WatercolorStyle.softShadow(canvas, shadowPath);
+    final bodyPath = Path()
+      ..addOval(
+          Rect.fromCenter(center: Offset.zero, width: width, height: height));
+    WatercolorStyle.washFill(canvas, bodyPath, baseColor, seed: 'body');
+    WatercolorStyle.wetEdge(canvas, bodyPath, baseColor, opacity: 0.18);
+    final bellyPath = Path()
+      ..addOval(Rect.fromCenter(
         center: Offset(0, height * 0.06),
         width: width * 0.6,
         height: height * 0.45,
-      ),
-      Paint()..color = bellyColor,
-    );
+      ));
+    WatercolorStyle.washFill(canvas, bellyPath, bellyColor, seed: 'belly');
     canvas.drawOval(
       Rect.fromCenter(
         center: Offset(0, -height * 0.12),
@@ -986,7 +1026,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..close();
     }
-    canvas.drawPath(upperBeak, Paint()..color = color);
+    WatercolorStyle.washFill(canvas, upperBeak, color, seed: 'beak');
     final lower = Path()
       ..moveTo(tip.dx - size * 0.25, tip.dy + size * 0.45)
       ..quadraticBezierTo(
@@ -996,7 +1036,8 @@ class _CompanionPreviewPainter extends CustomPainter {
         tip.dy + size * 0.45,
       )
       ..close();
-    canvas.drawPath(lower, Paint()..color = _darken(color, 0.2));
+    WatercolorStyle.washFill(canvas, lower, _darken(color, 0.2),
+        seed: 'beak_lower');
   }
 
   void _drawTailFeathers(
@@ -1025,7 +1066,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..close();
       final featherColor = i.isEven ? color : _darken(color, 0.1);
-      canvas.drawPath(feather, Paint()..color = featherColor);
+      WatercolorStyle.washFill(canvas, feather, featherColor, seed: 'tail_$i');
     }
   }
 

--- a/lib/features/shop/shop_screen.dart
+++ b/lib/features/shop/shop_screen.dart
@@ -9,6 +9,7 @@ import '../../data/models/economy_config.dart';
 import '../../data/providers/account_provider.dart';
 import '../../data/services/economy_config_service.dart';
 import '../../game/rendering/plane_renderer.dart';
+import '../../game/rendering/watercolor_style.dart';
 
 /// Shop screen for purchasing cosmetics and gold.
 class ShopScreen extends ConsumerStatefulWidget {
@@ -1806,16 +1807,13 @@ class _CompanionPreviewPainter extends CustomPainter {
     const darkBrown = Color(0xFF6B5238);
 
     // Soft drop shadow.
-    canvas.drawOval(
-      Rect.fromCenter(
+    final shadowPath = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(0.5, s * 0.22),
         width: s * 1.0,
         height: s * 0.3,
-      ),
-      Paint()
-        ..color = const Color(0xFF000000).withOpacity(0.1)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2),
-    );
+      ));
+    WatercolorStyle.softShadow(canvas, shadowPath);
 
     // Tail feathers.
     _drawTailFeathers(canvas, s, darkBrown, 3, 0.35, 0.12);
@@ -1828,16 +1826,15 @@ class _CompanionPreviewPainter extends CustomPainter {
     _drawBody(canvas, s * 0.95, s * 0.6, brown, cream);
 
     // Round head.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.32),
-      s * 0.28,
-      Paint()..color = brown,
-    );
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.18,
-      Paint()..color = cream,
-    );
+    final headPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.32), radius: s * 0.28));
+    WatercolorStyle.washFill(canvas, headPath, brown, seed: 'head');
+    WatercolorStyle.wetEdge(canvas, headPath, brown, opacity: 0.18);
+    final facePath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.28), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, facePath, cream, seed: 'face');
     canvas.drawCircle(
       const Offset(-s * 0.05, -s * 0.42),
       s * 0.08,
@@ -1893,8 +1890,8 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..quadraticBezierTo(s * 0.2, s * 0.55, s * 0.18, s * 0.7)
       ..quadraticBezierTo(s * 0.12, s * 0.5, s * 0.02, s * 0.35)
       ..close();
-    canvas.drawPath(leftFork, Paint()..color = navy);
-    canvas.drawPath(rightFork, Paint()..color = navy);
+    WatercolorStyle.washFill(canvas, leftFork, navy, seed: 'tail_l');
+    WatercolorStyle.washFill(canvas, rightFork, navy, seed: 'tail_r');
 
     // Long swept wings.
     _drawWing(
@@ -1922,20 +1919,19 @@ class _CompanionPreviewPainter extends CustomPainter {
     _drawBody(canvas, s * 0.8, s * 0.45, navy, cream);
 
     // Head.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.18,
-      Paint()..color = navy,
-    );
+    final sparrowHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.28), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, sparrowHeadPath, navy, seed: 'head');
+    WatercolorStyle.wetEdge(canvas, sparrowHeadPath, navy, opacity: 0.18);
     // Russet throat patch.
-    canvas.drawOval(
-      Rect.fromCenter(
+    final throatPath = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(0, -s * 0.2),
         width: s * 0.2,
         height: s * 0.12,
-      ),
-      Paint()..color = russet,
-    );
+      ));
+    WatercolorStyle.washFill(canvas, throatPath, russet, seed: 'throat');
 
     // Sharp eyes.
     _drawEyes(
@@ -1998,23 +1994,24 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..lineTo(sign * s * 0.82, -s * 0.27)
         ..lineTo(sign * s * 0.42, -s * 0.15)
         ..close();
-      canvas.drawPath(bar, Paint()..color = gold.withOpacity(0.3));
+      WatercolorStyle.washFill(canvas, bar, gold.withOpacity(0.3),
+          seed: 'bar$sign');
     }
 
     // Powerful body.
     _drawBody(canvas, s * 0.85, s * 0.5, goldenBrown, const Color(0xFFE8D8B8));
 
     // White head.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.32),
-      s * 0.22,
-      Paint()..color = white,
-    );
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.18,
-      Paint()..color = const Color(0xFFE8E0D0),
-    );
+    final eagleHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.32), radius: s * 0.22));
+    WatercolorStyle.washFill(canvas, eagleHeadPath, white, seed: 'head');
+    WatercolorStyle.wetEdge(canvas, eagleHeadPath, white, opacity: 0.18);
+    final eagleFacePath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.28), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, eagleFacePath, const Color(0xFFE8E0D0),
+        seed: 'face');
 
     // Fierce eyes.
     _drawEyes(
@@ -2087,7 +2084,8 @@ class _CompanionPreviewPainter extends CustomPainter {
           s * 0.2,
         )
         ..close();
-      canvas.drawPath(streamer, Paint()..color = colors[i].withOpacity(0.85));
+      WatercolorStyle.washFill(canvas, streamer, colors[i].withOpacity(0.85),
+          seed: 'tail$i');
     }
 
     // Multicolored wings.
@@ -2110,7 +2108,8 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..lineTo(sign * s * 0.58, -s * 0.18)
         ..lineTo(sign * s * 0.28, s * 0.02)
         ..close();
-      canvas.drawPath(greenBand, Paint()..color = emerald.withOpacity(0.7));
+      WatercolorStyle.washFill(canvas, greenBand, emerald.withOpacity(0.7),
+          seed: 'green$sign');
       // Gold covert stripe.
       final goldStripe = Path()
         ..moveTo(sign * s * 0.2, 0)
@@ -2118,18 +2117,19 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..lineTo(sign * s * 0.47, -s * 0.08)
         ..lineTo(sign * s * 0.22, s * 0.04)
         ..close();
-      canvas.drawPath(goldStripe, Paint()..color = gold.withOpacity(0.5));
+      WatercolorStyle.washFill(canvas, goldStripe, gold.withOpacity(0.5),
+          seed: 'gold$sign');
     }
 
     // Scarlet body.
     _drawBody(canvas, s * 0.8, s * 0.48, scarlet, const Color(0xFFEE5555));
 
     // Round head.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.3),
-      s * 0.2,
-      Paint()..color = scarlet,
-    );
+    final parrotHeadPath = Path()
+      ..addOval(
+          Rect.fromCircle(center: const Offset(0, -s * 0.3), radius: s * 0.2));
+    WatercolorStyle.washFill(canvas, parrotHeadPath, scarlet, seed: 'head');
+    WatercolorStyle.wetEdge(canvas, parrotHeadPath, scarlet, opacity: 0.18);
     canvas.drawCircle(
       const Offset(-s * 0.04, -s * 0.38),
       s * 0.06,
@@ -2137,22 +2137,22 @@ class _CompanionPreviewPainter extends CustomPainter {
     );
 
     // White eye patches.
-    canvas.drawOval(
-      Rect.fromCenter(
+    final leftEyePatch = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(-s * 0.09, -s * 0.3),
         width: s * 0.12,
         height: s * 0.14,
-      ),
-      Paint()..color = white.withOpacity(0.85),
-    );
-    canvas.drawOval(
-      Rect.fromCenter(
+      ));
+    WatercolorStyle.washFill(canvas, leftEyePatch, white.withOpacity(0.85),
+        seed: 'eyeL');
+    final rightEyePatch = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(s * 0.09, -s * 0.3),
         width: s * 0.12,
         height: s * 0.14,
-      ),
-      Paint()..color = white.withOpacity(0.85),
-    );
+      ));
+    WatercolorStyle.washFill(canvas, rightEyePatch, white.withOpacity(0.85),
+        seed: 'eyeR');
 
     // Eyes.
     _drawEyes(
@@ -2168,12 +2168,14 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..moveTo(0, -s * 0.42)
       ..cubicTo(-s * 0.1, -s * 0.48, -s * 0.08, -s * 0.56, 0, -s * 0.58)
       ..cubicTo(s * 0.08, -s * 0.56, s * 0.1, -s * 0.48, 0, -s * 0.42);
-    canvas.drawPath(upperBeak, Paint()..color = const Color(0xFF1A1A1A));
+    WatercolorStyle.washFill(canvas, upperBeak, const Color(0xFF1A1A1A),
+        seed: 'beak_u');
     final lowerBeak = Path()
       ..moveTo(-s * 0.04, -s * 0.42)
       ..quadraticBezierTo(0, -s * 0.46, s * 0.04, -s * 0.42)
       ..quadraticBezierTo(0, -s * 0.39, -s * 0.04, -s * 0.42);
-    canvas.drawPath(lowerBeak, Paint()..color = const Color(0xFF333333));
+    WatercolorStyle.washFill(canvas, lowerBeak, const Color(0xFF333333),
+        seed: 'beak_l');
   }
 
   // ---------------------------------------------------------------------------
@@ -2188,20 +2190,11 @@ class _CompanionPreviewPainter extends CustomPainter {
     const crimson = Color(0xFFCC1100);
 
     // Warm aura.
-    canvas.drawCircle(
-      Offset.zero,
-      s * 0.9,
-      Paint()
-        ..color = const Color(0xFFFF6600).withOpacity(0.08)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 12),
-    );
-    canvas.drawCircle(
-      const Offset(0, -s * 0.1),
-      s * 0.5,
-      Paint()
-        ..color = gold.withOpacity(0.12)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 6),
-    );
+    WatercolorStyle.auraGlow(
+        canvas, Offset.zero, s * 0.9, const Color(0xFFFF6600),
+        opacity: 0.08, blur: 12);
+    WatercolorStyle.auraGlow(canvas, const Offset(0, -s * 0.1), s * 0.5, gold,
+        opacity: 0.12, blur: 6);
 
     // Flame tail tongues.
     final tongueColors = [crimson, deepOrange, gold, brightOrange, crimson];
@@ -2219,10 +2212,8 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..quadraticBezierTo(s * t, s * (0.6 + i * 0.03), s * t * 0.5, s * 0.2)
         ..close();
-      canvas.drawPath(
-        tongue,
-        Paint()..color = tongueColors[i].withOpacity(0.7),
-      );
+      WatercolorStyle.washFill(canvas, tongue, tongueColors[i].withOpacity(0.7),
+          seed: 'tongue$i');
     }
 
     // Flame wings.
@@ -2241,12 +2232,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..lineTo(sign * s * 0.1, s * 0.05)
         ..close();
-      canvas.drawPath(
-        glowWing,
-        Paint()
-          ..color = gold.withOpacity(0.15)
-          ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4),
-      );
+      WatercolorStyle.colorBleed(canvas, glowWing, gold, opacity: 0.15);
       _drawWing(
         canvas,
         s,
@@ -2261,26 +2247,21 @@ class _CompanionPreviewPainter extends CustomPainter {
 
     // Luminous body.
     _drawBody(canvas, s * 0.75, s * 0.42, deepOrange, paleGold);
-    canvas.drawOval(
-      Rect.fromCenter(center: Offset.zero, width: s * 0.5, height: s * 0.25),
-      Paint()
-        ..color = gold.withOpacity(0.15)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 3),
-    );
+    final bodyGlowPath = Path()
+      ..addOval(Rect.fromCenter(
+          center: Offset.zero, width: s * 0.5, height: s * 0.25));
+    WatercolorStyle.colorBleed(canvas, bodyGlowPath, gold, opacity: 0.15);
 
     // Elegant head.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.18,
-      Paint()..color = brightOrange,
-    );
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.12,
-      Paint()
-        ..color = gold.withOpacity(0.2)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2),
-    );
+    final phoenixHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.28), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, phoenixHeadPath, brightOrange,
+        seed: 'head');
+    WatercolorStyle.wetEdge(canvas, phoenixHeadPath, brightOrange,
+        opacity: 0.18);
+    WatercolorStyle.auraGlow(canvas, const Offset(0, -s * 0.28), s * 0.12, gold,
+        opacity: 0.2);
 
     // Crown crest — three flame plumes.
     final plumeColors = [crimson, gold, deepOrange];
@@ -2302,7 +2283,8 @@ class _CompanionPreviewPainter extends CustomPainter {
           -s * 0.42,
         )
         ..close();
-      canvas.drawPath(plume, Paint()..color = plumeColors[i].withOpacity(0.8));
+      WatercolorStyle.washFill(canvas, plume, plumeColors[i].withOpacity(0.8),
+          seed: 'plume$i');
     }
 
     // Bright eyes.
@@ -2342,7 +2324,7 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..lineTo(s * 0.08, s * 0.85)
       ..cubicTo(s * 0.15, s * 0.7, s * 0.08, s * 0.5, 0, s * 0.25)
       ..close();
-    canvas.drawPath(tail, Paint()..color = forestGreen);
+    WatercolorStyle.washFill(canvas, tail, forestGreen, seed: 'tail');
     // Tail spines.
     for (var i = 0; i < 3; i++) {
       final t = 0.35 + i * 0.15;
@@ -2351,7 +2333,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..lineTo(-s * 0.06, s * t - s * 0.04)
         ..lineTo(0, s * t - s * 0.01)
         ..close();
-      canvas.drawPath(spine, Paint()..color = darkGreen);
+      WatercolorStyle.washFill(canvas, spine, darkGreen, seed: 'spine$i');
     }
     // Flame tail tip.
     final flameTip = Path()
@@ -2361,13 +2343,10 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..lineTo(s * 0.1, s * 0.96)
       ..lineTo(s * 0.08, s * 0.82)
       ..close();
-    canvas.drawPath(flameTip, Paint()..color = const Color(0xFFFF6600));
-    canvas.drawPath(
-      flameTip,
-      Paint()
-        ..color = amber.withOpacity(0.4)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 3),
-    );
+    WatercolorStyle.washFill(canvas, flameTip, const Color(0xFFFF6600),
+        seed: 'flame_tip');
+    WatercolorStyle.auraGlow(canvas, const Offset(0, s * 0.89), s * 0.1, amber,
+        opacity: 0.4);
 
     // Bat-like membrane wings with finger bones.
     for (final isLeft in [true, false]) {
@@ -2391,11 +2370,10 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..lineTo(sign * s * 1.05, -s * 0.15)
         ..quadraticBezierTo(sign * s * 0.7, s * 0.05, sign * s * 0.15, s * 0.02)
         ..close();
-      canvas.drawPath(
-        membrane,
-        Paint()..color = const Color(0xFF3D8B55).withOpacity(0.7),
-      );
-      canvas.drawPath(membrane, Paint()..color = paleGreen.withOpacity(0.1));
+      WatercolorStyle.washFill(
+          canvas, membrane, const Color(0xFF3D8B55).withOpacity(0.7),
+          seed: 'mem$sign');
+      WatercolorStyle.colorBleed(canvas, membrane, paleGreen, opacity: 0.06);
 
       // Finger bones.
       final bonePaint = Paint()
@@ -2450,20 +2428,20 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..moveTo(-s * 0.12, -s * 0.32)
       ..quadraticBezierTo(0, -s * 0.55, s * 0.12, -s * 0.32)
       ..quadraticBezierTo(0, -s * 0.28, -s * 0.12, -s * 0.32);
-    canvas.drawPath(snout, Paint()..color = forestGreen);
-    canvas.drawCircle(
-      const Offset(0, -s * 0.34),
-      s * 0.18,
-      Paint()..color = forestGreen,
-    );
-    canvas.drawOval(
-      Rect.fromCenter(
+    WatercolorStyle.washFill(canvas, snout, forestGreen, seed: 'snout');
+    final dragonHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.34), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, dragonHeadPath, forestGreen, seed: 'head');
+    WatercolorStyle.wetEdge(canvas, dragonHeadPath, forestGreen, opacity: 0.18);
+    final jawPath = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(0, -s * 0.3),
         width: s * 0.18,
         height: s * 0.08,
-      ),
-      Paint()..color = paleGreen.withOpacity(0.6),
-    );
+      ));
+    WatercolorStyle.washFill(canvas, jawPath, paleGreen.withOpacity(0.6),
+        seed: 'jaw');
 
     // Horns.
     for (final sign in [-1.0, 1.0]) {
@@ -2479,7 +2457,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..lineTo(sign * s * 0.08, -s * 0.5)
         ..close();
-      canvas.drawPath(horn, Paint()..color = hornColor);
+      WatercolorStyle.washFill(canvas, horn, hornColor, seed: 'horn$sign');
     }
 
     // Fierce slit eyes.
@@ -2525,20 +2503,12 @@ class _CompanionPreviewPainter extends CustomPainter {
     const fireGold = Color(0xFFFFCC00);
 
     // Fiery aura.
-    canvas.drawCircle(
-      Offset.zero,
-      s * 1.0,
-      Paint()
-        ..color = const Color(0xFFFF4400).withOpacity(0.06)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 16),
-    );
-    canvas.drawCircle(
-      const Offset(0, -s * 0.15),
-      s * 0.55,
-      Paint()
-        ..color = fireGold.withOpacity(0.08)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 8),
-    );
+    WatercolorStyle.auraGlow(
+        canvas, Offset.zero, s * 1.0, const Color(0xFFFF4400),
+        opacity: 0.06, blur: 16);
+    WatercolorStyle.auraGlow(
+        canvas, const Offset(0, -s * 0.15), s * 0.55, fireGold,
+        opacity: 0.08, blur: 8);
 
     // Thick tail with multi-layered flame.
     final tail = Path()
@@ -2548,7 +2518,7 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..lineTo(s * 0.1, s * 0.9)
       ..cubicTo(s * 0.18, s * 0.75, s * 0.1, s * 0.55, 0, s * 0.25)
       ..close();
-    canvas.drawPath(tail, Paint()..color = deepOrange);
+    WatercolorStyle.washFill(canvas, tail, deepOrange, seed: 'tail');
     // Tail belly stripe.
     final tailBelly = Path()
       ..moveTo(-s * 0.03, s * 0.3)
@@ -2556,21 +2526,19 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..lineTo(s * 0.03, s * 0.82)
       ..cubicTo(s * 0.06, s * 0.75, s * 0.04, s * 0.55, s * 0.03, s * 0.3)
       ..close();
-    canvas.drawPath(tailBelly, Paint()..color = paleYellow.withOpacity(0.4));
+    WatercolorStyle.washFill(canvas, tailBelly, paleYellow.withOpacity(0.4),
+        seed: 'tail_belly');
     // Tail flame.
     final flameCore = Path()
       ..moveTo(-s * 0.04, s * 0.88)
       ..lineTo(0, s * 1.05)
       ..lineTo(s * 0.04, s * 0.88)
       ..close();
-    canvas.drawPath(flameCore, Paint()..color = const Color(0xFFFFEE88));
-    canvas.drawCircle(
-      const Offset(0, s * 0.95),
-      s * 0.12,
-      Paint()
-        ..color = fireRed.withOpacity(0.25)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 5),
-    );
+    WatercolorStyle.washFill(canvas, flameCore, const Color(0xFFFFEE88),
+        seed: 'flame_core');
+    WatercolorStyle.auraGlow(
+        canvas, const Offset(0, s * 0.95), s * 0.12, fireRed,
+        opacity: 0.25);
 
     // Massive bat-membrane wings with scalloped edges.
     for (final isLeft in [true, false]) {
@@ -2598,7 +2566,9 @@ class _CompanionPreviewPainter extends CustomPainter {
         s * 0.05,
       );
       membrane.close();
-      canvas.drawPath(membrane, Paint()..color = tealWing.withOpacity(0.8));
+      WatercolorStyle.washFill(canvas, membrane, tealWing.withOpacity(0.8),
+          seed: 'mem$sign');
+      WatercolorStyle.colorBleed(canvas, membrane, tealWing, opacity: 0.06);
       // Inner membrane lighter.
       final inner = Path()
         ..moveTo(sign * s * 0.35, -s * 0.05)
@@ -2606,10 +2576,9 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..lineTo(sign * s * 1.0, -s * 0.12)
         ..quadraticBezierTo(sign * s * 0.6, s * 0.06, sign * s * 0.15, s * 0.03)
         ..close();
-      canvas.drawPath(
-        inner,
-        Paint()..color = const Color(0xFF40C4B0).withOpacity(0.2),
-      );
+      WatercolorStyle.washFill(
+          canvas, inner, const Color(0xFF40C4B0).withOpacity(0.2),
+          seed: 'inner$sign');
 
       // Finger bones.
       final bonePaint = Paint()
@@ -2643,7 +2612,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         ..lineTo(sign * s * 0.62, -s * 0.48)
         ..lineTo(sign * s * 0.72, -s * 0.42)
         ..close();
-      canvas.drawPath(claw, Paint()..color = hornColor);
+      WatercolorStyle.washFill(canvas, claw, hornColor, seed: 'claw$sign');
     }
 
     // Powerful body.
@@ -2672,20 +2641,23 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..moveTo(-s * 0.14, -s * 0.33)
       ..cubicTo(-s * 0.08, -s * 0.52, s * 0.08, -s * 0.52, s * 0.14, -s * 0.33)
       ..quadraticBezierTo(0, -s * 0.3, -s * 0.14, -s * 0.33);
-    canvas.drawPath(snout, Paint()..color = deepOrange);
-    canvas.drawCircle(
-      const Offset(0, -s * 0.36),
-      s * 0.2,
-      Paint()..color = deepOrange,
-    );
-    canvas.drawOval(
-      Rect.fromCenter(
+    WatercolorStyle.washFill(canvas, snout, deepOrange, seed: 'snout');
+    final charizardHeadPath = Path()
+      ..addOval(
+          Rect.fromCircle(center: const Offset(0, -s * 0.36), radius: s * 0.2));
+    WatercolorStyle.washFill(canvas, charizardHeadPath, deepOrange,
+        seed: 'head');
+    WatercolorStyle.wetEdge(canvas, charizardHeadPath, deepOrange,
+        opacity: 0.18);
+    final charizardJawPath = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(0, -s * 0.32),
         width: s * 0.2,
         height: s * 0.08,
-      ),
-      Paint()..color = paleYellow.withOpacity(0.5),
-    );
+      ));
+    WatercolorStyle.washFill(
+        canvas, charizardJawPath, paleYellow.withOpacity(0.5),
+        seed: 'jaw');
 
     // Prominent double horns.
     for (final sign in [-1.0, 1.0]) {
@@ -2701,13 +2673,15 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..lineTo(sign * s * 0.08, -s * 0.54)
         ..close();
-      canvas.drawPath(outerHorn, Paint()..color = hornColor);
+      WatercolorStyle.washFill(canvas, outerHorn, hornColor,
+          seed: 'ohorn$sign');
       final innerHorn = Path()
         ..moveTo(sign * s * 0.06, -s * 0.52)
         ..lineTo(sign * s * 0.1, -s * 0.66)
         ..lineTo(sign * s * 0.03, -s * 0.54)
         ..close();
-      canvas.drawPath(innerHorn, Paint()..color = _lighten(hornColor, 0.1));
+      WatercolorStyle.washFill(canvas, innerHorn, _lighten(hornColor, 0.1),
+          seed: 'ihorn$sign');
     }
 
     // Fierce glowing slit eyes.
@@ -2759,7 +2733,8 @@ class _CompanionPreviewPainter extends CustomPainter {
       ..moveTo(-s * 0.07, -s * 0.48)
       ..quadraticBezierTo(0, -s * 0.52, s * 0.07, -s * 0.48)
       ..quadraticBezierTo(0, -s * 0.46, -s * 0.07, -s * 0.48);
-    canvas.drawPath(mouth, Paint()..color = const Color(0xFFBB1100));
+    WatercolorStyle.washFill(canvas, mouth, const Color(0xFFBB1100),
+        seed: 'mouth');
   }
 
   // ---------------------------------------------------------------------------
@@ -2777,7 +2752,6 @@ class _CompanionPreviewPainter extends CustomPainter {
     Color? tipColor,
   }) {
     final sign = isLeft ? -1.0 : 1.0;
-    final paint = Paint()..color = color;
     final wing = Path()
       ..moveTo(sign * size * 0.2, 0)
       ..cubicTo(
@@ -2807,7 +2781,8 @@ class _CompanionPreviewPainter extends CustomPainter {
     wing
       ..lineTo(sign * size * 0.1, size * 0.05)
       ..close();
-    canvas.drawPath(wing, paint);
+    WatercolorStyle.washFill(canvas, wing, color,
+        seed: 'wing${isLeft ? 'L' : 'R'}');
 
     if (tipColor != null) {
       final tip = Path()
@@ -2822,7 +2797,8 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..lineTo(sign * size * (spread - 0.12), flapOffset - size * 0.12)
         ..close();
-      canvas.drawPath(tip, Paint()..color = tipColor);
+      WatercolorStyle.washFill(canvas, tip, tipColor,
+          seed: 'tip${isLeft ? 'L' : 'R'}');
     }
   }
 
@@ -2834,28 +2810,27 @@ class _CompanionPreviewPainter extends CustomPainter {
     Color bellyColor,
   ) {
     // Shadow.
-    canvas.drawOval(
-      Rect.fromCenter(
+    final bodyShadowPath = Path()
+      ..addOval(Rect.fromCenter(
         center: Offset(0, height * 0.08),
         width: width * 0.95,
         height: height * 0.6,
-      ),
-      Paint()..color = _darken(baseColor, 0.3),
-    );
+      ));
+    WatercolorStyle.softShadow(canvas, bodyShadowPath);
     // Main body.
-    canvas.drawOval(
-      Rect.fromCenter(center: Offset.zero, width: width, height: height),
-      Paint()..color = baseColor,
-    );
+    final bodyPath = Path()
+      ..addOval(
+          Rect.fromCenter(center: Offset.zero, width: width, height: height));
+    WatercolorStyle.washFill(canvas, bodyPath, baseColor, seed: 'body');
+    WatercolorStyle.wetEdge(canvas, bodyPath, baseColor, opacity: 0.18);
     // Belly.
-    canvas.drawOval(
-      Rect.fromCenter(
+    final bellyPath = Path()
+      ..addOval(Rect.fromCenter(
         center: Offset(0, height * 0.06),
         width: width * 0.6,
         height: height * 0.45,
-      ),
-      Paint()..color = bellyColor,
-    );
+      ));
+    WatercolorStyle.washFill(canvas, bellyPath, bellyColor, seed: 'belly');
     // Top highlight.
     canvas.drawOval(
       Rect.fromCenter(
@@ -2946,7 +2921,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..close();
     }
-    canvas.drawPath(upperBeak, Paint()..color = color);
+    WatercolorStyle.washFill(canvas, upperBeak, color, seed: 'beak');
     final lower = Path()
       ..moveTo(tip.dx - size * 0.25, tip.dy + size * 0.45)
       ..quadraticBezierTo(
@@ -2956,7 +2931,8 @@ class _CompanionPreviewPainter extends CustomPainter {
         tip.dy + size * 0.45,
       )
       ..close();
-    canvas.drawPath(lower, Paint()..color = _darken(color, 0.2));
+    WatercolorStyle.washFill(canvas, lower, _darken(color, 0.2),
+        seed: 'beak_lower');
   }
 
   void _drawTailFeathers(
@@ -2985,7 +2961,7 @@ class _CompanionPreviewPainter extends CustomPainter {
         )
         ..close();
       final featherColor = i.isEven ? color : _darken(color, 0.1);
-      canvas.drawPath(feather, Paint()..color = featherColor);
+      WatercolorStyle.washFill(canvas, feather, featherColor, seed: 'tail$i');
     }
   }
 

--- a/lib/game/components/companion_renderer.dart
+++ b/lib/game/components/companion_renderer.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../../data/models/avatar_config.dart';
 import '../flit_game.dart';
+import '../rendering/watercolor_style.dart';
 
 /// Renders the player's companion creature flying behind and slightly to the
 /// side of the plane. The companion follows the plane with a slight delay,
@@ -244,6 +245,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
   // ---------------------------------------------------------------------------
 
   /// Draw a smooth wing using cubic bezier curves with feathered tips.
+  /// Uses watercolour wash fills for soft, organic-looking wings.
   void _drawWing({
     required Canvas canvas,
     required double size,
@@ -288,7 +290,10 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..lineTo(sign * size * 0.1, size * 0.05)
       ..close();
 
-    canvas.drawPath(wing, paint);
+    // Watercolour wash instead of solid fill.
+    WatercolorStyle.washFill(canvas, wing, paint.color,
+        seed: '${isLeft ? "L" : "R"}wing');
+    WatercolorStyle.wetEdge(canvas, wing, paint.color, opacity: 0.2);
 
     // Optional wing tip accent.
     if (tipPaint != null) {
@@ -304,11 +309,11 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         )
         ..lineTo(sign * size * (spread - 0.12), flapOffset - size * 0.12)
         ..close();
-      canvas.drawPath(tip, tipPaint);
+      WatercolorStyle.washFill(canvas, tip, tipPaint.color, seed: 'tip');
     }
   }
 
-  /// Draw a layered body for depth (base + shadow + belly + highlight).
+  /// Draw a layered body with watercolour washes for soft, organic depth.
   void _drawBody({
     required Canvas canvas,
     required double width,
@@ -317,37 +322,41 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
     required Color bellyColor,
     Offset center = Offset.zero,
   }) {
-    // Shadow under body.
-    canvas.drawOval(
-      Rect.fromCenter(
+    // Soft shadow under body.
+    final shadowPath = Path()
+      ..addOval(Rect.fromCenter(
         center: Offset(center.dx, center.dy + height * 0.08),
         width: width * 0.95,
         height: height * 0.6,
-      ),
-      Paint()..color = _darken(baseColor, 0.3),
-    );
-    // Main body.
-    canvas.drawOval(
-      Rect.fromCenter(center: center, width: width, height: height),
-      Paint()..color = baseColor,
-    );
-    // Belly highlight.
-    canvas.drawOval(
-      Rect.fromCenter(
+      ));
+    WatercolorStyle.softShadow(canvas, shadowPath);
+
+    // Main body — watercolour wash.
+    final bodyPath = Path()
+      ..addOval(Rect.fromCenter(center: center, width: width, height: height));
+    WatercolorStyle.washFill(canvas, bodyPath, baseColor, seed: 'body');
+    WatercolorStyle.wetEdge(canvas, bodyPath, baseColor, opacity: 0.18);
+
+    // Belly highlight — softer wash.
+    final bellyPath = Path()
+      ..addOval(Rect.fromCenter(
         center: Offset(center.dx, center.dy + height * 0.06),
         width: width * 0.6,
         height: height * 0.45,
-      ),
-      Paint()..color = bellyColor,
-    );
-    // Top highlight (simulates light from above).
+      ));
+    WatercolorStyle.washFill(canvas, bellyPath, bellyColor,
+        seed: 'belly', opacity: 0.25);
+
+    // Top highlight — soft light wash.
     canvas.drawOval(
       Rect.fromCenter(
         center: Offset(center.dx, center.dy - height * 0.12),
         width: width * 0.35,
         height: height * 0.15,
       ),
-      Paint()..color = _lighten(baseColor, 0.2).withOpacity(0.4),
+      Paint()
+        ..color = _lighten(baseColor, 0.2).withOpacity(0.3)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 1.5),
     );
   }
 
@@ -439,7 +448,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         )
         ..close();
     }
-    canvas.drawPath(upperBeak, Paint()..color = color);
+    WatercolorStyle.washFill(canvas, upperBeak, color, seed: 'beak');
     // Lower mandible (darker).
     final lower = Path()
       ..moveTo(tip.dx - size * 0.25, tip.dy + size * 0.45)
@@ -450,7 +459,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         tip.dy + size * 0.45,
       )
       ..close();
-    canvas.drawPath(lower, Paint()..color = _darken(color, 0.2));
+    WatercolorStyle.washFill(canvas, lower, _darken(color, 0.2),
+        seed: 'beak_lo');
   }
 
   /// Draw a stylized tail with separated feathers.
@@ -481,7 +491,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..close();
       // Alternate slightly lighter/darker for depth.
       final featherColor = i.isEven ? color : _darken(color, 0.1);
-      canvas.drawPath(feather, Paint()..color = featherColor);
+      WatercolorStyle.washFill(canvas, feather, featherColor, seed: 'tail$i');
     }
   }
 
@@ -509,16 +519,15 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
     const cream = Color(0xFFF5E8D0);
     const darkBrown = Color(0xFF6B5238);
 
-    // Soft drop shadow.
-    canvas.drawOval(
-      Rect.fromCenter(
-        center: const Offset(0.5, 1.5),
-        width: s * 1.0,
-        height: s * 0.3,
-      ),
-      Paint()
-        ..color = const Color(0xFF000000).withOpacity(0.1)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2),
+    // Soft watercolour drop shadow.
+    WatercolorStyle.softShadow(
+      canvas,
+      Path()
+        ..addOval(Rect.fromCenter(
+          center: const Offset(0.5, 1.5),
+          width: s * 1.0,
+          height: s * 0.3,
+        )),
     );
 
     // Tail feathers (behind body).
@@ -560,23 +569,24 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       bellyColor: cream,
     );
 
-    // Round head (oversized for cuteness).
-    canvas.drawCircle(
-      const Offset(0, -s * 0.32),
-      s * 0.28,
-      Paint()..color = brown,
-    );
-    // Cream face.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.18,
-      Paint()..color = cream,
-    );
-    // Head highlight.
+    // Round head — watercolour wash (oversized for cuteness).
+    final headPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.32), radius: s * 0.28));
+    WatercolorStyle.washFill(canvas, headPath, brown, seed: 'pidgey_head');
+    WatercolorStyle.wetEdge(canvas, headPath, brown, opacity: 0.15);
+    // Cream face wash.
+    final facePath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.28), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, facePath, cream, seed: 'pidgey_face');
+    // Head highlight — soft glow.
     canvas.drawCircle(
       const Offset(-s * 0.05, -s * 0.42),
       s * 0.08,
-      Paint()..color = _lighten(brown, 0.15).withOpacity(0.5),
+      Paint()
+        ..color = _lighten(brown, 0.15).withOpacity(0.4)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 1.5),
     );
 
     // Big cute eyes.
@@ -629,8 +639,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..quadraticBezierTo(s * 0.2, s * 0.55, s * 0.18, s * 0.7)
       ..quadraticBezierTo(s * 0.12, s * 0.5, s * 0.02, s * 0.35)
       ..close();
-    canvas.drawPath(leftFork, Paint()..color = navy);
-    canvas.drawPath(rightFork, Paint()..color = navy);
+    WatercolorStyle.washFill(canvas, leftFork, navy, seed: 'sparrow_lf');
+    WatercolorStyle.washFill(canvas, rightFork, navy, seed: 'sparrow_rf');
 
     // Long swept wings.
     _drawWing(
@@ -663,21 +673,21 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       bellyColor: cream,
     );
 
-    // Small neat head.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.18,
-      Paint()..color = navy,
-    );
-    // Russet throat patch.
-    canvas.drawOval(
-      Rect.fromCenter(
+    // Small neat head — watercolour wash.
+    final headPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.28), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, headPath, navy, seed: 'sparrow_head');
+    WatercolorStyle.wetEdge(canvas, headPath, navy, opacity: 0.15);
+    // Russet throat patch — wash.
+    final throatPath = Path()
+      ..addOval(Rect.fromCenter(
         center: const Offset(0, -s * 0.2),
         width: s * 0.2,
         height: s * 0.12,
-      ),
-      Paint()..color = russet,
-    );
+      ));
+    WatercolorStyle.washFill(canvas, throatPath, russet,
+        seed: 'sparrow_throat');
 
     // Sharp eyes.
     _drawEyes(
@@ -770,18 +780,18 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       bellyColor: const Color(0xFFE8D8B8),
     );
 
-    // White head (bald eagle style).
-    canvas.drawCircle(
-      const Offset(0, -s * 0.32),
-      s * 0.22,
-      Paint()..color = white,
-    );
-    // Subtle head shadow.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.18,
-      Paint()..color = const Color(0xFFE8E0D0),
-    );
+    // White head (bald eagle style) — watercolour wash.
+    final eagleHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.32), radius: s * 0.22));
+    WatercolorStyle.washFill(canvas, eagleHeadPath, white, seed: 'eagle_head');
+    WatercolorStyle.wetEdge(canvas, eagleHeadPath, white, opacity: 0.12);
+    // Subtle head shadow wash.
+    final eagleFacePath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.28), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, eagleFacePath, const Color(0xFFE8E0D0),
+        seed: 'eagle_face');
 
     // Fierce piercing eyes.
     _drawEyes(
@@ -855,7 +865,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
           s * 0.2,
         )
         ..close();
-      canvas.drawPath(streamer, Paint()..color = colors[i].withOpacity(0.85));
+      WatercolorStyle.washFill(canvas, streamer, colors[i].withOpacity(0.85),
+          seed: 'parrot_s$i');
     }
 
     // Wings — multicolored like a real macaw.
@@ -879,7 +890,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..lineTo(sign * s * 0.58, flapOffset - s * 0.18)
         ..lineTo(sign * s * 0.28, flapOffset * 0.3 + s * 0.02)
         ..close();
-      canvas.drawPath(greenBand, Paint()..color = emerald.withOpacity(0.7));
+      WatercolorStyle.washFill(canvas, greenBand, emerald.withOpacity(0.7),
+          seed: 'parrot_gb');
       // Gold covert stripe.
       final goldStripe = Path()
         ..moveTo(sign * s * 0.2, flapOffset * 0.2)
@@ -887,7 +899,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..lineTo(sign * s * 0.47, flapOffset - s * 0.08)
         ..lineTo(sign * s * 0.22, flapOffset * 0.2 + s * 0.04)
         ..close();
-      canvas.drawPath(goldStripe, Paint()..color = gold.withOpacity(0.5));
+      WatercolorStyle.washFill(canvas, goldStripe, gold.withOpacity(0.5),
+          seed: 'parrot_gs');
     }
 
     // Scarlet body.
@@ -899,17 +912,19 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       bellyColor: const Color(0xFFEE5555),
     );
 
-    // Round head.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.3),
-      s * 0.2,
-      Paint()..color = scarlet,
-    );
+    // Round head — watercolour.
+    final parrotHeadPath = Path()
+      ..addOval(
+          Rect.fromCircle(center: const Offset(0, -s * 0.3), radius: s * 0.2));
+    WatercolorStyle.washFill(canvas, parrotHeadPath, scarlet, seed: 'parrot_h');
+    WatercolorStyle.wetEdge(canvas, parrotHeadPath, scarlet, opacity: 0.15);
     // Head highlight.
     canvas.drawCircle(
       const Offset(-s * 0.04, -s * 0.38),
       s * 0.06,
-      Paint()..color = _lighten(scarlet, 0.15).withOpacity(0.4),
+      Paint()
+        ..color = _lighten(scarlet, 0.15).withOpacity(0.3)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 1),
     );
 
     // White eye patches (bare skin like real macaw).
@@ -972,21 +987,21 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
     const paleGold = Color(0xFFFFE888);
     const crimson = Color(0xFFCC1100);
 
-    // Outer warm aura (pulses gently).
-    canvas.drawCircle(
+    // Outer warm aura (pulses gently) — watercolour radial glow.
+    WatercolorStyle.auraGlow(
+      canvas,
       Offset.zero,
       s * 0.9 * breathPulse,
-      Paint()
-        ..color = const Color(0xFFFF6600).withOpacity(0.08 * breathPulse)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 12),
+      const Color(0xFFFF6600),
+      opacity: 0.10 * breathPulse,
     );
     // Inner bright glow.
-    canvas.drawCircle(
+    WatercolorStyle.auraGlow(
+      canvas,
       const Offset(0, -s * 0.1),
       s * 0.5 * breathPulse,
-      Paint()
-        ..color = gold.withOpacity(0.12 * breathPulse)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 6),
+      gold,
+      opacity: 0.14 * breathPulse,
     );
 
     // Flame tail — multiple flickering tongues.
@@ -1006,10 +1021,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..quadraticBezierTo(s * t, s * (0.6 + i * 0.03), s * t * 0.5, s * 0.2)
         ..close();
       final tongueColors = [crimson, deepOrange, gold, brightOrange, crimson];
-      canvas.drawPath(
-        tongue,
-        Paint()..color = tongueColors[i].withOpacity(0.7),
-      );
+      WatercolorStyle.washFill(canvas, tongue, tongueColors[i].withOpacity(0.7),
+          seed: 'phx_t$i');
     }
     // Tail glow.
     canvas.drawCircle(
@@ -1088,19 +1101,19 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 3),
     );
 
-    // Elegant head.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.28),
-      s * 0.18,
-      Paint()..color = brightOrange,
-    );
+    // Elegant head — watercolour wash.
+    final phxHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.28), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, phxHeadPath, brightOrange,
+        seed: 'phx_head');
     // Head glow.
-    canvas.drawCircle(
+    WatercolorStyle.auraGlow(
+      canvas,
       const Offset(0, -s * 0.28),
       s * 0.12,
-      Paint()
-        ..color = gold.withOpacity(0.2)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2),
+      gold,
+      opacity: 0.22,
     );
 
     // Crown crest — three flame plumes.
@@ -1159,13 +1172,13 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
     const amber = Color(0xFFE8A820);
     const hornColor = Color(0xFF5C4A32);
 
-    // Fire breath glow near mouth.
-    canvas.drawCircle(
+    // Fire breath glow near mouth — watercolour radial glow.
+    WatercolorStyle.auraGlow(
+      canvas,
       const Offset(0, -s * 0.65),
       s * 0.2 * breathPulse,
-      Paint()
-        ..color = const Color(0xFFFF6600).withOpacity(0.12 * breathPulse)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 5),
+      const Color(0xFFFF6600),
+      opacity: 0.14 * breathPulse,
     );
 
     // Spined tail with flame tip.
@@ -1176,7 +1189,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..lineTo(s * 0.08, s * 0.95)
       ..cubicTo(s * 0.15, s * 0.7, s * 0.08, s * 0.5, 0, s * 0.25)
       ..close();
-    canvas.drawPath(tail, Paint()..color = forestGreen);
+    WatercolorStyle.washFill(canvas, tail, forestGreen, seed: 'drag_tail');
     // Tail spines.
     for (var i = 0; i < 3; i++) {
       final t = 0.35 + i * 0.2;
@@ -1186,7 +1199,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..lineTo(spineX - s * 0.06, s * t - s * 0.04)
         ..lineTo(spineX, s * t - s * 0.01)
         ..close();
-      canvas.drawPath(spine, Paint()..color = darkGreen);
+      WatercolorStyle.washFill(canvas, spine, darkGreen, seed: 'drag_sp');
     }
     // Flame tail tip.
     final flameTip = Path()
@@ -1196,7 +1209,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..lineTo(s * 0.12, s * 1.08)
       ..lineTo(s * 0.1, s * 0.9)
       ..close();
-    canvas.drawPath(flameTip, Paint()..color = const Color(0xFFFF6600));
+    WatercolorStyle.washFill(canvas, flameTip, const Color(0xFFFF6600),
+        seed: 'drag_flame');
     canvas.drawPath(
       flameTip,
       Paint()
@@ -1239,13 +1253,12 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
           s * 0.02,
         )
         ..close();
-      canvas.drawPath(
-        membrane,
-        Paint()..color = const Color(0xFF3D8B55).withOpacity(0.7),
-      );
+      WatercolorStyle.washFill(
+          canvas, membrane, const Color(0xFF3D8B55).withOpacity(0.7),
+          seed: 'drag_mem');
 
       // Wing membrane inner (lighter, translucent for membrane feel).
-      canvas.drawPath(membrane, Paint()..color = paleGreen.withOpacity(0.1));
+      WatercolorStyle.colorBleed(canvas, membrane, paleGreen, opacity: 0.1);
 
       // Finger bones (dark lines).
       final bonePaint = Paint()
@@ -1283,7 +1296,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..lineTo(sign * s * 0.58, flapOffset - s * 0.42)
         ..lineTo(sign * s * 0.67, flapOffset - s * 0.37)
         ..close();
-      canvas.drawPath(claw, Paint()..color = hornColor);
+      WatercolorStyle.washFill(canvas, claw, hornColor, seed: 'claw');
     }
 
     // Muscular body with scale texture.
@@ -1322,7 +1335,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..lineTo(sx, sy - s * 0.06)
         ..lineTo(sx + s * 0.015, sy)
         ..close();
-      canvas.drawPath(spine, Paint()..color = darkGreen);
+      WatercolorStyle.washFill(canvas, spine, darkGreen, seed: 'drag_dsp');
     }
 
     // Powerful head.
@@ -1331,13 +1344,13 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..moveTo(-s * 0.12, -s * 0.32)
       ..quadraticBezierTo(0, -s * 0.55, s * 0.12, -s * 0.32)
       ..quadraticBezierTo(0, -s * 0.28, -s * 0.12, -s * 0.32);
-    canvas.drawPath(snout, Paint()..color = forestGreen);
-    // Head dome.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.34),
-      s * 0.18,
-      Paint()..color = forestGreen,
-    );
+    WatercolorStyle.washFill(canvas, snout, forestGreen, seed: 'drag_snout');
+    // Head dome — watercolour.
+    final dragHeadPath = Path()
+      ..addOval(Rect.fromCircle(
+          center: const Offset(0, -s * 0.34), radius: s * 0.18));
+    WatercolorStyle.washFill(canvas, dragHeadPath, forestGreen,
+        seed: 'drag_head');
     // Jaw underside (lighter).
     canvas.drawOval(
       Rect.fromCenter(
@@ -1362,7 +1375,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         )
         ..lineTo(sign * s * 0.08, -s * 0.5)
         ..close();
-      canvas.drawPath(horn, Paint()..color = hornColor);
+      WatercolorStyle.washFill(canvas, horn, hornColor, seed: 'drag_horn');
       // Horn highlight.
       canvas.drawLine(
         Offset(sign * s * 0.1, -s * 0.48),
@@ -1430,21 +1443,21 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
     const fireRed = Color(0xFFEE2200);
     const fireGold = Color(0xFFFFCC00);
 
-    // Massive fiery aura (outer).
-    canvas.drawCircle(
+    // Massive fiery aura (outer) — watercolour glow.
+    WatercolorStyle.auraGlow(
+      canvas,
       Offset.zero,
       s * 1.0 * breathPulse,
-      Paint()
-        ..color = const Color(0xFFFF4400).withOpacity(0.06 * breathPulse)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 16),
+      const Color(0xFFFF4400),
+      opacity: 0.08 * breathPulse,
     );
     // Inner warm glow.
-    canvas.drawCircle(
+    WatercolorStyle.auraGlow(
+      canvas,
       const Offset(0, -s * 0.15),
       s * 0.55 * breathPulse,
-      Paint()
-        ..color = fireGold.withOpacity(0.08 * breathPulse)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 8),
+      fireGold,
+      opacity: 0.10 * breathPulse,
     );
 
     // Ember particles (small dots floating up from body).
@@ -1474,7 +1487,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..lineTo(s * 0.1, s * 1.0)
       ..cubicTo(s * 0.18, s * 0.75, s * 0.1, s * 0.55, 0, s * 0.25)
       ..close();
-    canvas.drawPath(tail, Paint()..color = deepOrange);
+    WatercolorStyle.washFill(canvas, tail, deepOrange, seed: 'char_tail');
     // Tail belly stripe.
     final tailBelly = Path()
       ..moveTo(-s * 0.03, s * 0.3)
@@ -1482,7 +1495,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..lineTo(s * 0.03, s * 0.9)
       ..cubicTo(s * 0.06, s * 0.75, s * 0.04, s * 0.55, s * 0.03, s * 0.3)
       ..close();
-    canvas.drawPath(tailBelly, Paint()..color = paleYellow.withOpacity(0.4));
+    WatercolorStyle.washFill(canvas, tailBelly, paleYellow,
+        seed: 'char_tbelly', opacity: 0.25);
 
     // Massive tail flame.
     canvas.drawCircle(
@@ -1520,7 +1534,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         brightOrange,
         fireRed,
       ];
-      canvas.drawPath(flame, Paint()..color = flameColors[i].withOpacity(0.7));
+      WatercolorStyle.washFill(canvas, flame, flameColors[i],
+          seed: 'char_fl$i', opacity: 0.22);
     }
     // Bright core.
     final core = Path()
@@ -1528,7 +1543,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..lineTo(0, s * 1.18)
       ..lineTo(s * 0.04, s * 1.0)
       ..close();
-    canvas.drawPath(core, Paint()..color = const Color(0xFFFFEE88));
+    WatercolorStyle.washFill(canvas, core, const Color(0xFFFFEE88),
+        seed: 'char_core', opacity: 0.25);
 
     // Massive bat-membrane wings with scalloped edges.
     for (final isLeft in [true, false]) {
@@ -1582,7 +1598,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         s * 0.05,
       );
       membrane.close();
-      canvas.drawPath(membrane, Paint()..color = tealWing.withOpacity(0.8));
+      WatercolorStyle.washFill(canvas, membrane, tealWing.withOpacity(0.8),
+          seed: 'char_mem');
 
       // Inner membrane (lighter, more translucent).
       final inner = Path()
@@ -1596,10 +1613,10 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
           s * 0.03,
         )
         ..close();
-      canvas.drawPath(
-        inner,
-        Paint()..color = const Color(0xFF40C4B0).withOpacity(0.2),
-      );
+      WatercolorStyle.washFill(canvas, inner, const Color(0xFF40C4B0),
+          seed: 'char_inner', opacity: 0.15);
+      WatercolorStyle.colorBleed(canvas, inner, const Color(0xFF40C4B0),
+          opacity: 0.06);
 
       // Finger bones.
       final bonePaint = Paint()
@@ -1637,7 +1654,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..lineTo(sign * s * 0.62, flapOffset - s * 0.48)
         ..lineTo(sign * s * 0.72, flapOffset - s * 0.42)
         ..close();
-      canvas.drawPath(claw, Paint()..color = hornColor);
+      WatercolorStyle.washFill(canvas, claw, hornColor, seed: 'claw');
     }
 
     // Powerful muscular body.
@@ -1676,7 +1693,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..lineTo(0, sy - spineHeight)
         ..lineTo(s * 0.018, sy)
         ..close();
-      canvas.drawPath(spine, Paint()..color = _darken(deepOrange, 0.15));
+      WatercolorStyle.washFill(canvas, spine, _darken(deepOrange, 0.15),
+          seed: 'char_sp');
     }
 
     // Powerful head with elongated snout.
@@ -1684,13 +1702,16 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..moveTo(-s * 0.14, -s * 0.33)
       ..cubicTo(-s * 0.08, -s * 0.52, s * 0.08, -s * 0.52, s * 0.14, -s * 0.33)
       ..quadraticBezierTo(0, -s * 0.3, -s * 0.14, -s * 0.33);
-    canvas.drawPath(snout, Paint()..color = deepOrange);
+    WatercolorStyle.washFill(canvas, snout, deepOrange, seed: 'char_snout');
+    WatercolorStyle.wetEdge(canvas, snout, deepOrange, opacity: 0.15);
     // Head dome.
-    canvas.drawCircle(
-      const Offset(0, -s * 0.36),
-      s * 0.2,
-      Paint()..color = deepOrange,
-    );
+    final headDome = Path()
+      ..addOval(Rect.fromCenter(
+        center: const Offset(0, -s * 0.36),
+        width: s * 0.4,
+        height: s * 0.4,
+      ));
+    WatercolorStyle.washFill(canvas, headDome, deepOrange, seed: 'char_head');
     // Jaw underside.
     canvas.drawOval(
       Rect.fromCenter(
@@ -1716,7 +1737,7 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         )
         ..lineTo(sign * s * 0.08, -s * 0.54)
         ..close();
-      canvas.drawPath(outerHorn, Paint()..color = hornColor);
+      WatercolorStyle.washFill(canvas, outerHorn, hornColor, seed: 'char_oh');
       // Horn highlight.
       canvas.drawLine(
         Offset(sign * s * 0.12, -s * 0.52),
@@ -1731,7 +1752,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
         ..lineTo(sign * s * 0.1, -s * 0.66)
         ..lineTo(sign * s * 0.03, -s * 0.54)
         ..close();
-      canvas.drawPath(innerHorn, Paint()..color = _lighten(hornColor, 0.1));
+      WatercolorStyle.washFill(canvas, innerHorn, _lighten(hornColor, 0.1),
+          seed: 'char_ih');
     }
 
     // Fierce glowing slit eyes.
@@ -1787,7 +1809,8 @@ class CompanionRenderer extends Component with HasGameRef<FlitGame> {
       ..moveTo(-s * 0.07, -s * 0.48)
       ..quadraticBezierTo(0, -s * 0.52, s * 0.07, -s * 0.48)
       ..quadraticBezierTo(0, -s * 0.46, -s * 0.07, -s * 0.48);
-    canvas.drawPath(mouth, Paint()..color = const Color(0xFFBB1100));
+    WatercolorStyle.washFill(canvas, mouth, const Color(0xFFBB1100),
+        seed: 'char_mouth');
     // Fire breath glow.
     canvas.drawCircle(
       const Offset(0, -s * 0.62),

--- a/lib/game/rendering/plane_renderer.dart
+++ b/lib/game/rendering/plane_renderer.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
+import 'watercolor_style.dart';
 
 /// Shared plane rendering utility used by both in-game [PlaneComponent] and
 /// shop [PlanePainter]. All methods draw with (0, 0) as the plane's center,
@@ -50,13 +51,12 @@ class PlaneRenderer {
   static Random _sketchRng(String planeId) =>
       Random(planeId.codeUnits.fold<int>(0, (h, c) => h * 31 + c));
 
-  /// Draws [path] with a subtle random offset on each segment endpoint to
-  /// simulate the slight imprecision of hand-drawn line work.
+  /// Draws a soft watercolor edge along [path] — replaces the old hand-drawn
+  /// sketch wobble with a blurred, paint-like edge that simulates pigment
+  /// settling along a wet boundary.
   ///
-  /// [wobble] controls the maximum displacement in logical pixels (0.3–0.5 is
-  /// subtle; stay under 0.6 to avoid changing the apparent shape).
-  ///
-  /// Uses [rng] so the same path always produces identical wobble (stable).
+  /// [rng] and [wobble] are kept in the signature for backward-compat but
+  /// are no longer used; the watercolor blur handles visual softness.
   static void _sketchPath(
     Path path,
     Canvas canvas,
@@ -64,37 +64,20 @@ class PlaneRenderer {
     Random rng, {
     double wobble = 0.4,
   }) {
-    final metrics = path.computeMetrics();
-    for (final metric in metrics) {
-      final len = metric.length;
-      if (len < 1) continue;
-
-      // Sample points along the path and add tiny perpendicular jitter.
-      const step = 4.0; // sample every 4px of path length
-      final sketched = Path();
-      bool first = true;
-      for (double t = 0; t <= len; t += step) {
-        final tangent = metric.getTangentForOffset(t.clamp(0, len));
-        if (tangent == null) continue;
-        final pos = tangent.position;
-        final dx = (rng.nextDouble() - 0.5) * 2 * wobble;
-        final dy = (rng.nextDouble() - 0.5) * 2 * wobble;
-        if (first) {
-          sketched.moveTo(pos.dx + dx, pos.dy + dy);
-          first = false;
-        } else {
-          sketched.lineTo(pos.dx + dx, pos.dy + dy);
-        }
-      }
-      canvas.drawPath(sketched, paint);
-    }
+    WatercolorStyle.wetEdge(
+      canvas,
+      path,
+      paint.color,
+      width: paint.strokeWidth > 0 ? paint.strokeWidth : 1.2,
+      blur: 2.0,
+      opacity: (paint.color.opacity * 0.7).clamp(0.1, 0.5),
+    );
   }
 
-  /// Draws a pencil-sketch outline pass around [path]: a slightly offset,
-  /// slightly darker stroke with [StrokeCap.round] to simulate ink-on-pencil
-  /// hand-drawn lines.
+  /// Draws a soft watercolor wet-edge around [path] — paint darkens where it
+  /// pools at boundaries, creating the characteristic watercolour outline.
   ///
-  /// Call this AFTER the fill pass so the outline sits on top.
+  /// Replaces the old pencil-sketch outline with a blurred, organic edge.
   static void _pencilOutline(
     Path path,
     Canvas canvas,
@@ -104,34 +87,21 @@ class PlaneRenderer {
     double offsetY = 0.3,
     double opacity = 0.55,
   }) {
-    final outlinePaint = Paint()
-      ..color = _darken(baseColor, 0.45).withOpacity(opacity)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = strokeWidth
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
-
-    // Primary outline (sits exactly on the path)
-    canvas.drawPath(path, outlinePaint);
-
-    // Offset shadow stroke — creates the "ink bleed" hand-drawn feel
-    final shadowPaint = Paint()
-      ..color = _darken(baseColor, 0.55).withOpacity(opacity * 0.35)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = strokeWidth * 0.7
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
-
-    canvas.save();
-    canvas.translate(offsetX, offsetY);
-    canvas.drawPath(path, shadowPaint);
-    canvas.restore();
+    WatercolorStyle.wetEdge(
+      canvas,
+      path,
+      baseColor,
+      width: strokeWidth * 1.4,
+      blur: 2.2,
+      opacity: opacity * 0.55,
+    );
   }
 
-  /// Draws light diagonal cross-hatch lines inside [bounds] to simulate
-  /// fabric-covered wing surfaces (biplanes, triplanes, paper planes).
+  /// Draws a subtle watercolour wash gradient inside [bounds] to simulate
+  /// uneven pigment distribution across a painted surface.
   ///
-  /// [opacity] should stay in the 0.08–0.12 range — extremely subtle.
+  /// Replaces the old diagonal cross-hatch lines with a soft colour variation
+  /// that reads as natural watercolour texture rather than fabric weave.
   static void _crossHatch(
     Canvas canvas,
     Rect bounds,
@@ -139,7 +109,7 @@ class PlaneRenderer {
     double spacing = 5.0,
     double opacity = 0.10,
   }) {
-    // Normalise so left < right, top < bottom (avoid degenerate rects)
+    // Normalise so left < right, top < bottom
     final normalised = Rect.fromLTRB(
       bounds.left < bounds.right ? bounds.left : bounds.right,
       bounds.top < bounds.bottom ? bounds.top : bounds.bottom,
@@ -149,28 +119,33 @@ class PlaneRenderer {
 
     if (normalised.width < 1 || normalised.height < 1) return;
 
-    final paint = Paint()
-      ..color = lineColor.withOpacity(opacity)
-      ..strokeWidth = 0.5
-      ..strokeCap = StrokeCap.butt;
+    final clipPath = Path()..addRect(normalised);
+    WatercolorStyle.washTexture(canvas, clipPath, lineColor, opacity: opacity);
+    WatercolorStyle.granulate(
+      canvas,
+      clipPath,
+      lineColor,
+      count: 8,
+      maxRadius: 1.2,
+      opacity: opacity * 0.6,
+      seed: '${normalised.hashCode}',
+    );
+  }
 
-    final w = normalised.width;
-    final h = normalised.height;
-    final diag = w + h;
+  /// Draw a path with watercolour wash layers — the primary way to fill
+  /// large surfaces (wings, fuselage, tail) in the watercolour style.
+  static void _wash(
+    Canvas canvas,
+    Path path,
+    Color color, {
+    String seed = '',
+  }) {
+    WatercolorStyle.washFill(canvas, path, color, seed: seed);
+  }
 
-    // Clip to the bounds so lines don't bleed outside
-    canvas.save();
-    canvas.clipRect(normalised);
-
-    // 45° lines going bottom-left to top-right
-    for (double t = -diag; t <= diag; t += spacing) {
-      canvas.drawLine(
-        Offset(normalised.left + t, normalised.bottom),
-        Offset(normalised.left + t + h, normalised.top),
-        paint,
-      );
-    }
-    canvas.restore();
+  /// Draw a soft watercolour shadow under a shape.
+  static void _softShadow(Canvas canvas, Path path) {
+    WatercolorStyle.softShadow(canvas, path);
   }
 
   /// Draws a soft ambient-occlusion shadow where a wing meets the fuselage.
@@ -412,10 +387,7 @@ class PlaneRenderer {
       )
       ..lineTo(-4, 7 + leftDip * 0.2)
       ..close();
-    canvas.drawPath(
-      lowerLeftWing,
-      Paint()..color = _darken(leftWingColor, 0.15),
-    );
+    _wash(canvas, lowerLeftWing, _darken(leftWingColor, 0.15), seed: planeId);
     _crossHatch(
       canvas,
       Rect.fromLTRB(-lowerLeftSpan, 3 + leftDip, -4, 9 + leftDip),
@@ -462,7 +434,7 @@ class PlaneRenderer {
       )
       ..lineTo(-4, 3 + leftDip * 0.2)
       ..close();
-    canvas.drawPath(leftWing, Paint()..color = leftWingColor);
+    _wash(canvas, leftWing, leftWingColor, seed: planeId);
 
     // Left wing cross-hatch (fabric texture)
     _crossHatch(
@@ -523,10 +495,7 @@ class PlaneRenderer {
       )
       ..lineTo(4, 7 + rightDip * 0.2)
       ..close();
-    canvas.drawPath(
-      lowerRightWing,
-      Paint()..color = _darken(rightWingColor, 0.15),
-    );
+    _wash(canvas, lowerRightWing, _darken(rightWingColor, 0.15), seed: planeId);
     _crossHatch(
       canvas,
       Rect.fromLTRB(4, 3 + rightDip, lowerRightSpan, 9 + rightDip),
@@ -570,7 +539,7 @@ class PlaneRenderer {
       )
       ..lineTo(4, 3 + rightDip * 0.2)
       ..close();
-    canvas.drawPath(rightWing, Paint()..color = rightWingColor);
+    _wash(canvas, rightWing, rightWingColor, seed: planeId);
 
     // Right wing cross-hatch (fabric texture)
     _crossHatch(
@@ -649,7 +618,7 @@ class PlaneRenderer {
       ..lineTo(tailSpan, 18 - wingDip * 0.3)
       ..quadraticBezierTo(tailSpan + 2, 16, tailSpan, 14 - wingDip * 0.3)
       ..close();
-    canvas.drawPath(tailPath, Paint()..color = _darken(detail, 0.1));
+    _wash(canvas, tailPath, _darken(detail, 0.1), seed: planeId);
     _pencilOutline(tailPath, canvas, _darken(detail, 0.1), strokeWidth: 0.9);
 
     // Vertical fin
@@ -671,7 +640,7 @@ class PlaneRenderer {
       ..quadraticBezierTo(-4 + bodyShift, 10, -5 + bodyShift, -2)
       ..quadraticBezierTo(-5 + bodyShift, -12, bodyShift, -16)
       ..close();
-    canvas.drawPath(fuselagePath, bodyPaint);
+    _wash(canvas, fuselagePath, bodyPaint.color, seed: planeId);
 
     // Sketch outline on fuselage — slightly wobbly hand-drawn feel
     final sketchOutlinePaint = Paint()
@@ -778,7 +747,7 @@ class PlaneRenderer {
       ..lineTo(-leftSpan + 2, 5 + wingDip) // sharp trailing edge
       ..lineTo(bodyShift, 4) // center trailing edge
       ..close();
-    canvas.drawPath(leftWing, Paint()..color = leftWingColor);
+    _wash(canvas, leftWing, leftWingColor, seed: planeId);
 
     // Paper wing cross-hatch (fold crease texture)
     _crossHatch(
@@ -813,7 +782,7 @@ class PlaneRenderer {
       ..lineTo(rightSpan - 2, 5 - wingDip) // sharp trailing edge
       ..lineTo(bodyShift, 4) // center trailing edge
       ..close();
-    canvas.drawPath(rightWing, Paint()..color = rightWingColor);
+    _wash(canvas, rightWing, rightWingColor, seed: planeId);
 
     _crossHatch(
       canvas,
@@ -856,7 +825,7 @@ class PlaneRenderer {
       ..lineTo(bodyShift - 1.5, 6)
       ..lineTo(bodyShift - 2, -10)
       ..close();
-    canvas.drawPath(keelPath, Paint()..color = primary);
+    _wash(canvas, keelPath, primary, seed: planeId);
 
     // Sketch wobble on keel — paper creases are imprecise
     final keelSketchPaint = Paint()
@@ -927,7 +896,7 @@ class PlaneRenderer {
       ..lineTo(-leftSpan + 2, 5 + wingDip) // narrow tip trailing edge
       ..lineTo(-3 + bodyShift, 3) // root trailing edge (wider)
       ..close();
-    canvas.drawPath(leftWing, Paint()..color = leftWingColor);
+    _wash(canvas, leftWing, leftWingColor, seed: planeId);
     _pencilOutline(leftWing, canvas, leftWingColor, strokeWidth: 0.9);
     _wingJointAO(canvas, Offset(-4 + bodyShift, 0), radius: 4.0);
 
@@ -939,7 +908,7 @@ class PlaneRenderer {
       ..lineTo(rightSpan - 2, 5 - wingDip) // narrow tip trailing edge
       ..lineTo(3 + bodyShift, 3) // root trailing edge
       ..close();
-    canvas.drawPath(rightWing, Paint()..color = rightWingColor);
+    _wash(canvas, rightWing, rightWingColor, seed: planeId);
     _pencilOutline(rightWing, canvas, rightWingColor, strokeWidth: 0.9);
     _wingJointAO(canvas, Offset(4 + bodyShift, 0), radius: 4.0);
 
@@ -951,7 +920,7 @@ class PlaneRenderer {
       ..lineTo(-stabSpan + 3 + bodyShift, 15 + wingDip * 0.2)
       ..lineTo(-1 + bodyShift, 13)
       ..close();
-    canvas.drawPath(stabLeft, Paint()..color = leftWingColor);
+    _wash(canvas, stabLeft, leftWingColor, seed: planeId);
     _pencilOutline(stabLeft, canvas, leftWingColor, strokeWidth: 0.9);
     final stabRight = Path()
       ..moveTo(2 + bodyShift, 12)
@@ -959,7 +928,7 @@ class PlaneRenderer {
       ..lineTo(stabSpan - 3 + bodyShift, 15 - wingDip * 0.2)
       ..lineTo(1 + bodyShift, 13)
       ..close();
-    canvas.drawPath(stabRight, Paint()..color = rightWingColor);
+    _wash(canvas, stabRight, rightWingColor, seed: planeId);
     _pencilOutline(stabRight, canvas, rightWingColor, strokeWidth: 0.9);
 
     // --- Body group ---
@@ -976,7 +945,7 @@ class PlaneRenderer {
       ..lineTo(bodyShift + 1, 16)
       ..quadraticBezierTo(bodyShift + 2.5, 12, bodyShift, 9)
       ..close();
-    canvas.drawPath(finPath, Paint()..color = secondary);
+    _wash(canvas, finPath, secondary, seed: planeId);
     _pencilOutline(finPath, canvas, secondary, strokeWidth: 0.8);
 
     // Sleek fuselage
@@ -988,7 +957,7 @@ class PlaneRenderer {
       ..quadraticBezierTo(-2.5 + bodyShift, 8, -3 + bodyShift, -4)
       ..quadraticBezierTo(-3 + bodyShift, -14, bodyShift, -18)
       ..close();
-    canvas.drawPath(fuselagePath, Paint()..color = primary);
+    _wash(canvas, fuselagePath, primary, seed: planeId);
 
     // Sketch outline on fuselage
     final fuselageSketchPaint = Paint()
@@ -1101,7 +1070,7 @@ class PlaneRenderer {
       ..lineTo(-leftSpan * 0.5, 3 + wingDip * 0.5) // inner notch of W
       ..lineTo(bodyShift, 7) // center trailing edge
       ..close();
-    canvas.drawPath(leftWing, Paint()..color = leftWingColor);
+    _wash(canvas, leftWing, leftWingColor, seed: planeId);
 
     // Stealth panels — subtle radar-absorbing panel lines
     final leftSketchPaint = Paint()
@@ -1125,7 +1094,7 @@ class PlaneRenderer {
       ..lineTo(rightSpan * 0.5, 3 - wingDip * 0.5)
       ..lineTo(bodyShift, 7)
       ..close();
-    canvas.drawPath(rightWing, Paint()..color = rightWingColor);
+    _wash(canvas, rightWing, rightWingColor, seed: planeId);
 
     final rightSketchPaint = Paint()
       ..color = const Color(0xFF555555).withOpacity(0.30)
@@ -1148,7 +1117,7 @@ class PlaneRenderer {
       ..lineTo(bodyShift + 3, 6)
       ..quadraticBezierTo(bodyShift + 4, 0, bodyShift + 5, -8)
       ..close();
-    canvas.drawPath(centerBody, Paint()..color = detail);
+    _wash(canvas, centerBody, detail, seed: planeId);
     _pencilOutline(centerBody, canvas, detail, strokeWidth: 0.8, opacity: 0.40);
 
     // Exhaust slots on trailing edge (flush with wing, not protruding)
@@ -1326,7 +1295,7 @@ class PlaneRenderer {
       ..lineTo(4, 16)
       ..lineTo(4, 12)
       ..close();
-    canvas.drawPath(tailPath, Paint()..color = wingColor);
+    _wash(canvas, tailPath, wingColor, seed: planeId);
     _pencilOutline(tailPath, canvas, wingColor, strokeWidth: 0.9);
 
     // Fuselage
@@ -1338,7 +1307,7 @@ class PlaneRenderer {
       ..quadraticBezierTo(-3 + bodyShift, 10, -4 + bodyShift, -2)
       ..quadraticBezierTo(-4 + bodyShift, -12, bodyShift, -16)
       ..close();
-    canvas.drawPath(fuselagePath, Paint()..color = primary);
+    _wash(canvas, fuselagePath, primary, seed: planeId);
 
     // Sketch outline on fuselage
     final fuselageSketchPaint = Paint()
@@ -1457,7 +1426,7 @@ class PlaneRenderer {
       ..lineTo(-leftSpan + 3, 12 + wingDip)
       ..lineTo(bodyShift - 2, 14)
       ..close();
-    canvas.drawPath(leftWing, Paint()..color = leftWingColor);
+    _wash(canvas, leftWing, leftWingColor, seed: planeId);
     _pencilOutline(leftWing, canvas, leftWingColor, strokeWidth: 1.0);
     _wingJointAO(canvas, Offset(bodyShift - 2, -4), radius: 5.5);
 
@@ -1480,7 +1449,7 @@ class PlaneRenderer {
       ..lineTo(rightSpan - 3, 12 - wingDip)
       ..lineTo(bodyShift + 2, 14)
       ..close();
-    canvas.drawPath(rightWing, Paint()..color = rightWingColor);
+    _wash(canvas, rightWing, rightWingColor, seed: planeId);
     _pencilOutline(rightWing, canvas, rightWingColor, strokeWidth: 1.0);
     _wingJointAO(canvas, Offset(bodyShift + 2, -4), radius: 5.5);
 
@@ -1500,7 +1469,7 @@ class PlaneRenderer {
       ..lineTo(-2.5 + bodyShift, 0)
       ..quadraticBezierTo(-2.5 + bodyShift, -12, bodyShift, -20)
       ..close();
-    canvas.drawPath(fuselagePath, Paint()..color = primary);
+    _wash(canvas, fuselagePath, primary, seed: planeId);
 
     // Sketch outline on fuselage
     final fuselageSketchPaint = Paint()
@@ -1517,7 +1486,7 @@ class PlaneRenderer {
       ..quadraticBezierTo(bodyShift - 0.5, -23, bodyShift, -25)
       ..quadraticBezierTo(bodyShift + 0.5, -23, bodyShift + 1.5, -20)
       ..close();
-    canvas.drawPath(droopNose, Paint()..color = secondary);
+    _wash(canvas, droopNose, secondary, seed: planeId);
     _pencilOutline(droopNose, canvas, secondary, strokeWidth: 0.8);
 
     // Accent stripe running along fuselage
@@ -1606,7 +1575,7 @@ class PlaneRenderer {
       ..lineTo(lx - 3.5, ly - 2)
       ..quadraticBezierTo(lx - 3.5, ly - 7, lx, ly - 9) // back to bow
       ..close();
-    canvas.drawPath(leftFloat, pontoonPaint);
+    _wash(canvas, leftFloat, pontoonPaint.color, seed: planeId);
     _pencilOutline(leftFloat, canvas, detail, strokeWidth: 0.9, opacity: 0.45);
     // Step line indicator
     canvas.drawLine(
@@ -1631,7 +1600,7 @@ class PlaneRenderer {
       ..lineTo(rx - 3.5, ry - 2)
       ..quadraticBezierTo(rx - 3.5, ry - 7, rx, ry - 9)
       ..close();
-    canvas.drawPath(rightFloat, pontoonPaint);
+    _wash(canvas, rightFloat, pontoonPaint.color, seed: planeId);
     _pencilOutline(rightFloat, canvas, detail, strokeWidth: 0.9, opacity: 0.45);
     canvas.drawLine(
       Offset(rx - 3, ry),
@@ -1719,7 +1688,7 @@ class PlaneRenderer {
       ..lineTo(-leftSpan + 5, 8 + wingDip)
       ..quadraticBezierTo(-leftSpan * 0.4, 5 + wingDip * 0.5, -5 + bodyShift, 2)
       ..close();
-    canvas.drawPath(leftWing, Paint()..color = leftWingColor);
+    _wash(canvas, leftWing, leftWingColor, seed: planeId);
     _pencilOutline(leftWing, canvas, leftWingColor, strokeWidth: 1.0);
     _wingJointAO(canvas, Offset(-6 + bodyShift, 1), radius: 5.0);
 
@@ -1746,7 +1715,7 @@ class PlaneRenderer {
       ..lineTo(rightSpan - 5, 8 - wingDip)
       ..quadraticBezierTo(rightSpan * 0.4, 5 - wingDip * 0.5, 5 + bodyShift, 2)
       ..close();
-    canvas.drawPath(rightWing, Paint()..color = rightWingColor);
+    _wash(canvas, rightWing, rightWingColor, seed: planeId);
     _pencilOutline(rightWing, canvas, rightWingColor, strokeWidth: 1.0);
     _wingJointAO(canvas, Offset(6 + bodyShift, 1), radius: 5.0);
 
@@ -1778,7 +1747,7 @@ class PlaneRenderer {
       ..lineTo(-stabSpan + 4 + bodyShift, 16 + wingDip * 0.2)
       ..lineTo(-2 + bodyShift, 14)
       ..close();
-    canvas.drawPath(stabLeft, Paint()..color = detail);
+    _wash(canvas, stabLeft, detail, seed: planeId);
     _pencilOutline(stabLeft, canvas, detail, strokeWidth: 0.9);
     final stabRight = Path()
       ..moveTo(3 + bodyShift, 13)
@@ -1786,7 +1755,7 @@ class PlaneRenderer {
       ..lineTo(stabSpan - 4 + bodyShift, 16 - wingDip * 0.2)
       ..lineTo(2 + bodyShift, 14)
       ..close();
-    canvas.drawPath(stabRight, Paint()..color = detail);
+    _wash(canvas, stabRight, detail, seed: planeId);
     _pencilOutline(stabRight, canvas, detail, strokeWidth: 0.9);
 
     // Vertical stabilizer
@@ -1795,7 +1764,7 @@ class PlaneRenderer {
       ..quadraticBezierTo(-2 + bodyShift, 14, bodyShift, 17)
       ..quadraticBezierTo(2 + bodyShift, 14, bodyShift, 12)
       ..close();
-    canvas.drawPath(finPath, Paint()..color = secondary);
+    _wash(canvas, finPath, secondary, seed: planeId);
     _pencilOutline(finPath, canvas, secondary, strokeWidth: 0.9);
 
     // Wide fuselage
@@ -1807,7 +1776,7 @@ class PlaneRenderer {
       ..quadraticBezierTo(-5 + bodyShift, 10, -6 + bodyShift, 0)
       ..quadraticBezierTo(-6 + bodyShift, -12, bodyShift, -17)
       ..close();
-    canvas.drawPath(fuselagePath, Paint()..color = primary);
+    _wash(canvas, fuselagePath, primary, seed: planeId);
 
     // Sketch outline on fuselage
     final fuselageSketchPaint = Paint()
@@ -1921,7 +1890,7 @@ class PlaneRenderer {
         1,
       )
       ..close();
-    canvas.drawPath(leftWing, Paint()..color = leftWingColor);
+    _wash(canvas, leftWing, leftWingColor, seed: planeId);
     _pencilOutline(leftWing, canvas, leftWingColor, strokeWidth: 1.0);
     _wingJointAO(canvas, Offset(-5 + bodyShift, 0), radius: 5.5);
 
@@ -1938,7 +1907,7 @@ class PlaneRenderer {
       ..lineTo(rightSpan - 4, 7 - wingDip)
       ..quadraticBezierTo(rightSpan * 0.35, 4 - wingDip * 0.5, 4 + bodyShift, 1)
       ..close();
-    canvas.drawPath(rightWing, Paint()..color = rightWingColor);
+    _wash(canvas, rightWing, rightWingColor, seed: planeId);
     _pencilOutline(rightWing, canvas, rightWingColor, strokeWidth: 1.0);
     _wingJointAO(canvas, Offset(5 + bodyShift, 0), radius: 5.5);
 
@@ -1957,7 +1926,7 @@ class PlaneRenderer {
       ..lineTo(-stabSpan + 3 + bodyShift, 18 + wingDip * 0.2)
       ..lineTo(-1 + bodyShift, 16)
       ..close();
-    canvas.drawPath(stabLeft, Paint()..color = primary);
+    _wash(canvas, stabLeft, primary, seed: planeId);
     _pencilOutline(stabLeft, canvas, primary, strokeWidth: 0.9);
     final stabRight = Path()
       ..moveTo(2 + bodyShift, 15)
@@ -1965,7 +1934,7 @@ class PlaneRenderer {
       ..lineTo(stabSpan - 3 + bodyShift, 18 - wingDip * 0.2)
       ..lineTo(1 + bodyShift, 16)
       ..close();
-    canvas.drawPath(stabRight, Paint()..color = primary);
+    _wash(canvas, stabRight, primary, seed: planeId);
     _pencilOutline(stabRight, canvas, primary, strokeWidth: 0.9);
 
     // Tall vertical fin — distinctive T-tail
@@ -1975,7 +1944,7 @@ class PlaneRenderer {
       ..lineTo(bodyShift + 1.5, 19)
       ..quadraticBezierTo(bodyShift + 3, 14, bodyShift + 1, 11)
       ..close();
-    canvas.drawPath(finPath, Paint()..color = secondary);
+    _wash(canvas, finPath, secondary, seed: planeId);
     _pencilOutline(finPath, canvas, secondary, strokeWidth: 0.9);
     // Gold accent on fin
     canvas.drawLine(
@@ -1995,7 +1964,7 @@ class PlaneRenderer {
       ..quadraticBezierTo(-6 + bodyShift, 10, -7 + bodyShift, 0)
       ..quadraticBezierTo(-7 + bodyShift, -14, bodyShift, -19)
       ..close();
-    canvas.drawPath(fuselagePath, Paint()..color = primary);
+    _wash(canvas, fuselagePath, primary, seed: planeId);
 
     // Sketch outline on fuselage
     final fuselageSketchPaint = Paint()
@@ -2013,7 +1982,7 @@ class PlaneRenderer {
       ..lineTo(-7 + bodyShift, -6)
       ..quadraticBezierTo(-7 + bodyShift, -14, bodyShift, -19)
       ..close();
-    canvas.drawPath(blueHead, Paint()..color = secondary);
+    _wash(canvas, blueHead, secondary, seed: planeId);
 
     // Red accent stripe across the middle
     final redStripe = Path()
@@ -2022,7 +1991,7 @@ class PlaneRenderer {
       ..lineTo(bodyShift + 6, 2)
       ..lineTo(bodyShift - 6, 2)
       ..close();
-    canvas.drawPath(redStripe, Paint()..color = const Color(0xFFCC3333));
+    _wash(canvas, redStripe, const Color(0xFFCC3333), seed: planeId);
 
     // Gold pinstripe borders on the red stripe
     canvas.drawLine(
@@ -2047,7 +2016,7 @@ class PlaneRenderer {
       ..lineTo(bodyShift + 3, 18)
       ..quadraticBezierTo(bodyShift + 5, 10, bodyShift + 6, 2)
       ..close();
-    canvas.drawPath(blueBelly, Paint()..color = secondary.withOpacity(0.35));
+    _wash(canvas, blueBelly, secondary.withOpacity(0.35), seed: planeId);
 
     // Cockpit windows — larger, more prominent
     canvas.drawOval(
@@ -2193,7 +2162,7 @@ class PlaneRenderer {
       ..lineTo(-leftSpan * 0.3, 4 + wingDip * 0.3)
       ..lineTo(-4 + bodyShift, 2)
       ..close();
-    canvas.drawPath(leftWing, Paint()..color = leftWingColor);
+    _wash(canvas, leftWing, leftWingColor, seed: planeId);
 
     // Feather detail lines on wing
     final featherPaint = Paint()
@@ -2236,7 +2205,7 @@ class PlaneRenderer {
       ..lineTo(rightSpan * 0.3, 4 - wingDip * 0.3)
       ..lineTo(4 + bodyShift, 2)
       ..close();
-    canvas.drawPath(rightWing, Paint()..color = rightWingColor);
+    _wash(canvas, rightWing, rightWingColor, seed: planeId);
 
     // Right wing feather details
     for (var i = 0; i < 4; i++) {
@@ -2269,7 +2238,7 @@ class PlaneRenderer {
       ..lineTo(bodyShift + 7, 17) // right outer feather
       ..lineTo(bodyShift + 3, 10)
       ..close();
-    canvas.drawPath(tailPath, Paint()..color = secondary);
+    _wash(canvas, tailPath, secondary, seed: planeId);
     _pencilOutline(tailPath, canvas, secondary, strokeWidth: 1.0);
     // Tail feather detail lines
     for (final dx in [-5.0, -2.0, 0.0, 2.0, 5.0]) {
@@ -2291,7 +2260,7 @@ class PlaneRenderer {
       ..quadraticBezierTo(-3 + bodyShift, 6, -4 + bodyShift, -2)
       ..quadraticBezierTo(-4 + bodyShift, -10, bodyShift, -16)
       ..close();
-    canvas.drawPath(fuselagePath, Paint()..color = primary);
+    _wash(canvas, fuselagePath, primary, seed: planeId);
 
     // Sketch outline on body — feathered, slightly organic
     final fuselageSketchPaint = Paint()
@@ -2308,7 +2277,7 @@ class PlaneRenderer {
       ..quadraticBezierTo(bodyShift + 1, -18, bodyShift, -20) // beak tip
       ..quadraticBezierTo(bodyShift - 0.5, -18, bodyShift, -16)
       ..close();
-    canvas.drawPath(beakPath, Paint()..color = const Color(0xFFDAA520));
+    _wash(canvas, beakPath, const Color(0xFFDAA520), seed: planeId);
     _pencilOutline(beakPath, canvas, const Color(0xFFDAA520), strokeWidth: 0.7);
 
     // Eagle eye (fierce, forward-facing)
@@ -2405,7 +2374,7 @@ class PlaneRenderer {
         -22,
       ) // Left bulge back to crown
       ..close();
-    canvas.drawPath(envelopePath, Paint()..color = primary);
+    _wash(canvas, envelopePath, primary, seed: planeId);
 
     // Coloured gore stripes (vertical panels) — alternating secondary colour
     canvas.save();
@@ -2461,7 +2430,7 @@ class PlaneRenderer {
       ..lineTo(basketShift + 3, 20) // Bottom right
       ..lineTo(basketShift - 3, 20) // Bottom left
       ..close();
-    canvas.drawPath(basketPath, Paint()..color = detail);
+    _wash(canvas, basketPath, detail, seed: planeId);
 
     // Basket weave texture — horizontal lines
     final weavePaint = Paint()
@@ -2528,7 +2497,7 @@ class PlaneRenderer {
       ..lineTo(-leftSpan + 2, 8 + wingDip) // Trailing edge tip
       ..lineTo(-2 + bodyShift, 8) // Wing root trailing edge
       ..close();
-    canvas.drawPath(leftWing, Paint()..color = leftWingColor);
+    _wash(canvas, leftWing, leftWingColor, seed: planeId);
     _pencilOutline(leftWing, canvas, leftWingColor, strokeWidth: 0.9);
     _wingJointAO(canvas, Offset(-3 + bodyShift, 2), radius: 3.5);
 
@@ -2540,7 +2509,7 @@ class PlaneRenderer {
       ..lineTo(rightSpan - 2, 8 - wingDip)
       ..lineTo(2 + bodyShift, 8)
       ..close();
-    canvas.drawPath(rightWing, Paint()..color = rightWingColor);
+    _wash(canvas, rightWing, rightWingColor, seed: planeId);
     _pencilOutline(rightWing, canvas, rightWingColor, strokeWidth: 0.9);
     _wingJointAO(canvas, Offset(3 + bodyShift, 2), radius: 3.5);
 
@@ -2558,7 +2527,7 @@ class PlaneRenderer {
       ..lineTo(bodyShift + 1, 18)
       ..quadraticBezierTo(bodyShift + 1, 14, bodyShift, 8)
       ..close();
-    canvas.drawPath(finPath, Paint()..color = primary);
+    _wash(canvas, finPath, primary, seed: planeId);
     _pencilOutline(finPath, canvas, primary, strokeWidth: 0.8);
 
     // OMS pods (small bumps on either side of tail)
@@ -2590,7 +2559,7 @@ class PlaneRenderer {
         -20,
       ) // Left side of nose
       ..close();
-    canvas.drawPath(fuselagePath, Paint()..color = primary);
+    _wash(canvas, fuselagePath, primary, seed: planeId);
 
     // Sketch outline on fuselage
     final fuselageSketchPaint = Paint()
@@ -2608,7 +2577,7 @@ class PlaneRenderer {
       ..lineTo(bodyShift - 2.5, -12)
       ..quadraticBezierTo(bodyShift - 2, -17, bodyShift, -20)
       ..close();
-    canvas.drawPath(heatShieldPath, Paint()..color = secondary);
+    _wash(canvas, heatShieldPath, secondary, seed: planeId);
 
     // Payload bay doors (lines along body)
     final doorPaint = Paint()

--- a/lib/game/rendering/watercolor_style.dart
+++ b/lib/game/rendering/watercolor_style.dart
@@ -1,0 +1,258 @@
+import 'dart:math';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+/// Watercolor rendering utilities for painting planes and companions.
+///
+/// Replaces the old sketch/pencil/crosshatch hand-drawn style with a softer,
+/// more organic watercolor vector aesthetic. Each method produces layered
+/// semi-transparent washes, soft edges, and subtle pigment effects that
+/// complement the realistic satellite-globe backdrop.
+class WatercolorStyle {
+  WatercolorStyle._();
+
+  // ---------------------------------------------------------------------------
+  // Core wash effects
+  // ---------------------------------------------------------------------------
+
+  /// Paint a path with layered semi-transparent washes to simulate watercolor.
+  ///
+  /// Draws [layers] copies of the path with slight scale/offset jitter and
+  /// reduced opacity, producing the uneven, translucent look of wet pigment
+  /// on paper. The final solid layer sits on top for legibility.
+  static void washFill(
+    Canvas canvas,
+    Path path,
+    Color color, {
+    int layers = 3,
+    double opacity = 0.30,
+    double spread = 1.2,
+    String seed = '',
+  }) {
+    final rng = Random(seed.hashCode);
+
+    // Under-layers: slightly offset, slightly scaled, translucent.
+    for (var i = 0; i < layers; i++) {
+      final dx = (rng.nextDouble() - 0.5) * spread;
+      final dy = (rng.nextDouble() - 0.5) * spread;
+      final layerOpacity = opacity * (1.0 - i * 0.08);
+
+      canvas.save();
+      canvas.translate(dx, dy);
+      canvas.drawPath(
+        path,
+        Paint()
+          ..color = color.withOpacity(layerOpacity.clamp(0.05, 1.0))
+          ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 0.8),
+      );
+      canvas.restore();
+    }
+
+    // Top solid-ish layer — the "dry" pigment that settles.
+    canvas.drawPath(path, Paint()..color = color.withOpacity(0.85));
+  }
+
+  /// Draw a wet-edge effect along a path — simulates paint pooling at
+  /// boundaries where watercolor darkens along the edge of a stroke.
+  static void wetEdge(
+    Canvas canvas,
+    Path path,
+    Color color, {
+    double width = 1.8,
+    double blur = 2.5,
+    double opacity = 0.30,
+  }) {
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = _darken(color, 0.35).withOpacity(opacity)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = width
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, blur),
+    );
+  }
+
+  /// Subtle pigment granulation: scattered semi-transparent dots inside
+  /// [clipPath] that simulate the grainy texture of watercolor pigment.
+  static void granulate(
+    Canvas canvas,
+    Path clipPath,
+    Color color, {
+    int count = 20,
+    double maxRadius = 1.5,
+    double opacity = 0.06,
+    String seed = '',
+  }) {
+    final rng = Random(seed.hashCode ^ 0xCAFE);
+    final bounds = clipPath.getBounds();
+    if (bounds.isEmpty) return;
+
+    canvas.save();
+    canvas.clipPath(clipPath);
+    for (var i = 0; i < count; i++) {
+      final x = bounds.left + rng.nextDouble() * bounds.width;
+      final y = bounds.top + rng.nextDouble() * bounds.height;
+      final r = rng.nextDouble() * maxRadius + 0.3;
+      canvas.drawCircle(
+        Offset(x, y),
+        r,
+        Paint()
+          ..color = _darken(color, 0.2).withOpacity(opacity)
+          ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 0.5),
+      );
+    }
+    canvas.restore();
+  }
+
+  /// Soft shadow beneath a shape — blurred, offset, low-opacity.
+  static void softShadow(
+    Canvas canvas,
+    Path path, {
+    Offset offset = const Offset(0.5, 1.5),
+    double blur = 4.0,
+    double opacity = 0.12,
+  }) {
+    canvas.save();
+    canvas.translate(offset.dx, offset.dy);
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = Colors.black.withOpacity(opacity)
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, blur),
+    );
+    canvas.restore();
+  }
+
+  /// Wash texture: a subtle gradient overlay inside a clipped area,
+  /// simulating colour variation across a watercolor wash.
+  static void washTexture(
+    Canvas canvas,
+    Path clipPath,
+    Color color, {
+    double opacity = 0.08,
+  }) {
+    final bounds = clipPath.getBounds();
+    if (bounds.isEmpty) return;
+
+    canvas.save();
+    canvas.clipPath(clipPath);
+    final gradient = LinearGradient(
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+      colors: [
+        _lighten(color, 0.15).withOpacity(opacity),
+        _darken(color, 0.15).withOpacity(opacity * 0.5),
+      ],
+    );
+    canvas.drawRect(
+      bounds,
+      Paint()..shader = gradient.createShader(bounds),
+    );
+    canvas.restore();
+  }
+
+  /// Colour bleed: draw a soft blurred halo around a path in a tinted colour.
+  /// Simulates paint bleeding beyond its intended boundary.
+  static void colorBleed(
+    Canvas canvas,
+    Path path,
+    Color color, {
+    double blur = 3.0,
+    double opacity = 0.10,
+  }) {
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = color.withOpacity(opacity)
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, blur),
+    );
+  }
+
+  /// Draw a watercolor-style stroke — a slightly irregular, soft-edged stroke
+  /// that varies in width along its length.
+  static void watercolorStroke(
+    Canvas canvas,
+    Path path,
+    Color color, {
+    double width = 1.5,
+    double opacity = 0.55,
+    String seed = '',
+  }) {
+    // Soft wide under-stroke.
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = color.withOpacity(opacity * 0.4)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = width * 2.0
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, width * 0.8),
+    );
+    // Crisp centre line.
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = color.withOpacity(opacity)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = width * 0.6
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round,
+    );
+  }
+
+  /// Aura glow — soft radial glow around a point, useful for magical
+  /// effects (phoenix fire, dragon breath, etc.).
+  static void auraGlow(
+    Canvas canvas,
+    Offset center,
+    double radius,
+    Color color, {
+    double opacity = 0.15,
+    double blur = 8.0,
+  }) {
+    final gradient = ui.Gradient.radial(
+      center,
+      radius,
+      [
+        color.withOpacity(opacity),
+        color.withOpacity(0),
+      ],
+    );
+    canvas.drawCircle(
+      center,
+      radius,
+      Paint()..shader = gradient,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Colour helpers (shared)
+  // ---------------------------------------------------------------------------
+
+  static Color darken(Color c, double amount) => _darken(c, amount);
+  static Color lighten(Color c, double amount) => _lighten(c, amount);
+
+  static Color _darken(Color c, double amount) {
+    final f = (1.0 - amount).clamp(0.0, 1.0);
+    return Color.fromARGB(
+      c.alpha,
+      (c.red * f).round(),
+      (c.green * f).round(),
+      (c.blue * f).round(),
+    );
+  }
+
+  static Color _lighten(Color c, double amount) {
+    final f = amount.clamp(0.0, 1.0);
+    return Color.fromARGB(
+      c.alpha,
+      (c.red + (255 - c.red) * f * 0.4).round().clamp(0, 255),
+      (c.green + (255 - c.green) * f * 0.4).round().clamp(0, 255),
+      (c.blue + (255 - c.blue) * f * 0.4).round().clamp(0, 255),
+    );
+  }
+}


### PR DESCRIPTION
…esthetic

Introduce WatercolorStyle utility class with layered wash fills, wet edges, pigment granulation, soft shadows, color bleed, and aura glows. Convert all 26 plane renderers and 7 companion creatures (pidgey, sparrow, eagle, parrot, phoenix, dragon, charizard) from solid fills to watercolor washes across the game renderer, shop preview, and debug preview painters. All animations (barrel roll, banking, propeller, wing flap, bob, breath, fuel-fetch) are preserved unchanged.

https://claude.ai/code/session_014rQ5QiRjgKdnwLbpMfHW7e