### PR TITLE
fix: use actual zoom scale for Flight School hit-testing

### DIFF
--- a/lib/game/quiz/quiz_map_widget.dart
+++ b/lib/game/quiz/quiz_map_widget.dart
@@ -155,6 +155,10 @@ class _QuizMapWidgetState extends State<QuizMapWidget>
     // so localPosition is already in content coordinates. No inverse
     // transform needed — applying one would double-invert and shift the
     // tap point proportionally to the zoom level.
+    //
+    // Pass the real zoom scale so any zoom-dependent hit-test logic
+    // (e.g. stroke tolerance) uses the correct value.
+    final scale = _transformController.value.getMaxScaleOnAxis();
     final painter = _UsaMapPainter(
       stateVisuals: widget.stateVisuals,
       highlightCode: widget.highlightCode,
@@ -162,7 +166,7 @@ class _QuizMapWidgetState extends State<QuizMapWidget>
       showLabels: widget.showLabels,
       eliminatedCodes: widget.eliminatedCodes,
       correctCodes: widget.correctCodes,
-      zoomScale: 1.0,
+      zoomScale: scale,
       satelliteImage: _satelliteImage,
     );
 

--- a/lib/game/quiz/quiz_region_map_widget.dart
+++ b/lib/game/quiz/quiz_region_map_widget.dart
@@ -117,6 +117,11 @@ class _QuizRegionMapWidgetState extends State<QuizRegionMapWidget>
     // so localPosition is already in content coordinates. No inverse
     // transform needed — applying one would double-invert and shift the
     // tap point proportionally to the zoom level.
+    //
+    // However, the actual zoom scale IS needed so that tiny-area marker
+    // hit targets shrink as the user zooms in (countries that are too
+    // small to tap at 1× become normal polygons at 5×).
+    final scale = _transformController.value.getMaxScaleOnAxis();
     final painter = _RegionMapPainter(
       region: widget.region,
       stateVisuals: widget.stateVisuals,
@@ -125,7 +130,7 @@ class _QuizRegionMapWidgetState extends State<QuizRegionMapWidget>
       showLabels: widget.showLabels,
       eliminatedCodes: widget.eliminatedCodes,
       correctCodes: widget.correctCodes,
-      zoomScale: 1.0,
+      zoomScale: scale,
       satelliteImage: _satelliteImage,
     );
 
@@ -467,8 +472,8 @@ class _RegionMapPainter extends CustomPainter {
       if (cp.dy < minY) minY = cp.dy;
       if (cp.dy > maxY) maxY = cp.dy;
     }
-    final w = (maxX - minX) / zoomScale;
-    final h = (maxY - minY) / zoomScale;
+    final w = (maxX - minX) * zoomScale;
+    final h = (maxY - minY) * zoomScale;
     return w < _tinyThreshold && h < _tinyThreshold;
   }
 


### PR DESCRIPTION
Two bugs caused taps on one country to register as a neighbor when
zoomed in:

1. _handleTap created a hit-test painter with zoomScale: 1.0 instead
   of the real InteractiveViewer zoom. Tiny-area markers (like
   Montenegro) kept their full 15px tap radius regardless of zoom,
   overlapping into neighboring countries (Bosnia).

2. _isTinyArea divided canvas span by zoomScale instead of
   multiplying, making MORE areas "tiny" when zoomed IN (backwards).
   At 5× zoom, areas up to 90px were marked tiny instead of fewer.

Fix: pass the real zoom scale to the hit-test painter and multiply
(not divide) in _isTinyArea so expanded markers shrink as the user
zooms in and countries become large enough to tap directly.

https://claude.ai/code/session_01U4EqA3tZBM5C9FL2SVdDZ9