### PR TITLE
Fix Android build + add debug reset for campaign testing

### DIFF
--- a/lib/data/providers/account_provider.dart
+++ b/lib/data/providers/account_provider.dart
@@ -788,6 +788,22 @@ class AccountNotifier extends StateNotifier<AccountState> {
     return state.isGameModeUnlocked(modeId);
   }
 
+  /// Debug-only: reset player level, XP, and campaign progress.
+  /// Only available in debug/profile builds.
+  void debugResetProgress() {
+    assert(() {
+      // ignore: avoid_print
+      print('[DEBUG] Resetting level, XP, and campaign progress');
+      return true;
+    }());
+    state = state.copyWith(
+      currentPlayer: state.currentPlayer.copyWith(level: 1, xp: 0),
+      campaignProgress: {},
+    );
+    _syncProfile();
+    _syncAccountState();
+  }
+
   /// Unlock a flight school level with coins (early unlock).
   /// Returns true if successful, false if insufficient funds.
   bool unlockFlightSchoolLevel(String levelId, int cost) {

--- a/lib/features/campaign/campaign_screen.dart
+++ b/lib/features/campaign/campaign_screen.dart
@@ -1,11 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
 import '../../data/providers/account_provider.dart';
+import '../../game/clues/clue_types.dart';
 import '../../game/tutorial/campaign_mission.dart';
 import '../../game/tutorial/campaign_missions.dart';
-import '../../game/tutorial/coach.dart';
 import '../play/play_screen.dart';
 import '../../game/map/region.dart';
 import 'mission_dialog.dart';
@@ -33,6 +34,55 @@ class CampaignScreen extends ConsumerWidget {
           ),
         ),
         centerTitle: true,
+        actions: [
+          // Debug-only reset button (tree-shaken in release builds).
+          if (!kReleaseMode)
+            IconButton(
+              icon: const Icon(Icons.restart_alt, color: FlitColors.accent),
+              tooltip: 'Reset level & campaign (debug)',
+              onPressed: () {
+                showDialog<void>(
+                  context: context,
+                  builder: (ctx) => AlertDialog(
+                    backgroundColor: FlitColors.cardBackground,
+                    title: const Text(
+                      'Reset Progress?',
+                      style: TextStyle(color: FlitColors.textPrimary),
+                    ),
+                    content: const Text(
+                      'This will set your level to 1, XP to 0, and clear all '
+                      'campaign progress. Debug only.',
+                      style: TextStyle(color: FlitColors.textSecondary),
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(ctx).pop(),
+                        child: const Text('Cancel'),
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          ref
+                              .read(accountProvider.notifier)
+                              .debugResetProgress();
+                          Navigator.of(ctx).pop();
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content:
+                                  Text('Reset to Level 1 — campaign cleared'),
+                            ),
+                          );
+                        },
+                        child: const Text(
+                          'Reset',
+                          style: TextStyle(color: FlitColors.error),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+        ],
       ),
       body: ListView.builder(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),


### PR DESCRIPTION
- Add missing ClueType import in campaign_screen.dart (broke Android build)
- Remove unused coach.dart import from campaign_screen.dart
- Add debugResetProgress() to AccountNotifier (level→1, XP→0, clear campaign)
- Add debug-only reset button in campaign screen AppBar (tree-shaken in release)

https://claude.ai/code/session_01FJcnRJ861R81H6LQMGz7sP