### PR TITLE
fix: return mutable copy from _effectiveBaseline to prevent iOS Safar…

### DIFF
--- a/lib/game/quiz/alias_service.dart
+++ b/lib/game/quiz/alias_service.dart
@@ -67,10 +67,14 @@ class AliasService {
   }
 
   /// The effective baseline aliases for a name, with removals applied.
+  ///
+  /// Always returns a mutable copy — the source [countryAliases] map is
+  /// `const`, so returning its lists directly would crash on mutation
+  /// (e.g. on iOS Safari / Dart2JS where const lists are strictly immutable).
   List<String> _effectiveBaseline(String canonicalName) {
     final baseline = countryAliases[canonicalName] ?? <String>[];
     final removed = _removedBaseline[canonicalName] ?? <String>[];
-    if (removed.isEmpty) return baseline;
+    if (removed.isEmpty) return List<String>.of(baseline);
     return baseline.where((a) => !removed.contains(a)).toList();
   }
 


### PR DESCRIPTION
…i crash

The countryAliases map is declared const, so its list values are immutable. _effectiveBaseline() was returning these const lists directly when there were no removals, but mergedAliases() later calls .add() on them — crashing on iOS Safari (Dart2JS) with "Unsupported operation: 'add': Cannot add to a constant list".

Fix: use List.of() to always return a mutable copy.

https://claude.ai/code/session_01Jnmi2AoVKb2LPN6P9ZSQPh