### PR TITLE
Fix stray border lines on large countries (USA, Russia)

### DIFF
--- a/lib/game/components/country_border_overlay.dart
+++ b/lib/game/components/country_border_overlay.dart
@@ -160,6 +160,9 @@ class CountryBorderOverlay extends Component with HasGameRef<FlitGame> {
         final path = ui.Path();
         var started = false;
         var anyVisible = false;
+        var hasOccluded = false;
+        var lastX = 0.0;
+        var lastY = 0.0;
 
         for (var i = 0; i < polygon.length; i += stride) {
           final screenPos = gameRef.worldToScreenGlobe(polygon[i]);
@@ -167,6 +170,7 @@ class CountryBorderOverlay extends Component with HasGameRef<FlitGame> {
           // Occluded (far side of globe)
           if (screenPos.x < -500 || screenPos.y < -500) {
             started = false;
+            hasOccluded = true;
             continue;
           }
 
@@ -181,12 +185,26 @@ class CountryBorderOverlay extends Component with HasGameRef<FlitGame> {
             path.moveTo(screenPos.x, screenPos.y);
             started = true;
           } else {
-            path.lineTo(screenPos.x, screenPos.y);
+            // Guard against huge screen-space jumps (antimeridian wrap or
+            // vertices straddling the globe limb). Start a new sub-path
+            // instead of drawing a line across the screen.
+            final dx = screenPos.x - lastX;
+            final dy = screenPos.y - lastY;
+            if (dx * dx + dy * dy > screenW * screenW * 0.25) {
+              path.moveTo(screenPos.x, screenPos.y);
+              hasOccluded = true;
+            } else {
+              path.lineTo(screenPos.x, screenPos.y);
+            }
           }
+          lastX = screenPos.x;
+          lastY = screenPos.y;
         }
 
-        if (anyVisible && started) {
-          path.close();
+        if (anyVisible) {
+          if (!hasOccluded) {
+            path.close();
+          }
           canvas.drawPath(path, outlinePaint);
         }
       }
@@ -273,6 +291,8 @@ class CountryBorderOverlay extends Component with HasGameRef<FlitGame> {
       var started = false;
       var anyVisible = false;
       var hasOccluded = false;
+      var lastX = 0.0;
+      var lastY = 0.0;
 
       for (var i = 0; i < polygon.length; i += stride) {
         final screenPos = gameRef.worldToScreenGlobe(polygon[i]);
@@ -294,8 +314,18 @@ class CountryBorderOverlay extends Component with HasGameRef<FlitGame> {
           path.moveTo(screenPos.x, screenPos.y);
           started = true;
         } else {
-          path.lineTo(screenPos.x, screenPos.y);
+          // Guard against huge screen-space jumps (antimeridian wrap).
+          final dx = screenPos.x - lastX;
+          final dy = screenPos.y - lastY;
+          if (dx * dx + dy * dy > screenW * screenW * 0.25) {
+            path.moveTo(screenPos.x, screenPos.y);
+            hasOccluded = true;
+          } else {
+            path.lineTo(screenPos.x, screenPos.y);
+          }
         }
+        lastX = screenPos.x;
+        lastY = screenPos.y;
       }
 
       if (anyVisible) {


### PR DESCRIPTION
Two bugs in the outline renderer caused random straight lines across the screen for countries partially behind the globe:

1. path.close() was called even when the polygon was split by occluded vertices, drawing a line from the last visible vertex back to the first moveTo across the entire screen. Added hasOccluded guard (matching the active highlight renderer which already had it).

2. No screen-space jump detection — consecutive vertices straddling the antimeridian (e.g. Russia +179° to -179°) drew a line across the globe. Now breaks into a new sub-path when the distance between consecutive projected vertices exceeds half the screen width.

https://claude.ai/code/session_01JufpX6LmXg7nH3snSiYLve