### PR TITLE
Improve coach mission UX: speech bubbles, hints, farewell, and perfor…

### DIFF
--- a/lib/features/campaign/campaign_screen.dart
+++ b/lib/features/campaign/campaign_screen.dart
@@ -84,27 +84,52 @@ class CampaignScreen extends ConsumerWidget {
             ),
         ],
       ),
-      body: ListView.builder(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-        itemCount: campaignMissions.length,
-        itemBuilder: (context, index) {
-          final mission = campaignMissions[index];
-          final result = progress[mission.id];
-          final isCompleted = result != null;
+      body: Column(
+        children: [
+          // Clue type legend
+          const Padding(
+            padding: EdgeInsets.fromLTRB(20, 12, 20, 4),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _LegendItem(icon: Icons.flag, label: 'Flag'),
+                SizedBox(width: 10),
+                _LegendItem(icon: Icons.crop_square, label: 'Outline'),
+                SizedBox(width: 10),
+                _LegendItem(icon: Icons.border_all, label: 'Borders'),
+                SizedBox(width: 10),
+                _LegendItem(icon: Icons.location_city, label: 'Capital'),
+                SizedBox(width: 10),
+                _LegendItem(icon: Icons.bar_chart, label: 'Stats'),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+              itemCount: campaignMissions.length,
+              itemBuilder: (context, index) {
+                final mission = campaignMissions[index];
+                final result = progress[mission.id];
+                final isCompleted = result != null;
 
-          // A mission is unlocked if it's the first, or the previous one is complete.
-          final isUnlocked = index == 0 ||
-              progress.containsKey(campaignMissions[index - 1].id);
+                // A mission is unlocked if it's the first, or the previous one is complete.
+                final isUnlocked = index == 0 ||
+                    progress.containsKey(campaignMissions[index - 1].id);
 
-          return _MissionCard(
-            mission: mission,
-            result: result,
-            isUnlocked: isUnlocked,
-            isCompleted: isCompleted,
-            onTap:
-                isUnlocked ? () => _startMission(context, ref, mission) : null,
-          );
-        },
+                return _MissionCard(
+                  mission: mission,
+                  result: result,
+                  isUnlocked: isUnlocked,
+                  isCompleted: isCompleted,
+                  onTap: isUnlocked
+                      ? () => _startMission(context, ref, mission)
+                      : null,
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -349,6 +374,24 @@ class _ClueIcons extends StatelessWidget {
     }
   }
 
+  static String _labelFor(ClueType type) {
+    switch (type) {
+      case ClueType.flag:
+      case ClueType.flagDescription:
+        return 'Flag';
+      case ClueType.outline:
+        return 'Outline';
+      case ClueType.borders:
+        return 'Borders';
+      case ClueType.capital:
+        return 'Capital';
+      case ClueType.stats:
+        return 'Stats';
+      default:
+        return 'Clue';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -356,9 +399,42 @@ class _ClueIcons extends StatelessWidget {
       children: clues
           .map((c) => Padding(
                 padding: const EdgeInsets.only(left: 4),
-                child: Icon(_iconFor(c), size: 14, color: FlitColors.textMuted),
+                child: Tooltip(
+                  message: _labelFor(c),
+                  preferBelow: false,
+                  child: Icon(
+                    _iconFor(c),
+                    size: 14,
+                    color: FlitColors.textMuted,
+                  ),
+                ),
               ))
           .toList(),
+    );
+  }
+}
+
+class _LegendItem extends StatelessWidget {
+  const _LegendItem({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 12, color: FlitColors.textMuted),
+        const SizedBox(width: 3),
+        Text(
+          label,
+          style: const TextStyle(
+            color: FlitColors.textMuted,
+            fontSize: 10,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/campaign/coach_overlay.dart
+++ b/lib/features/campaign/coach_overlay.dart
@@ -17,14 +17,27 @@ const _dismissLabels = [
   '10-4!',
 ];
 
+/// Hint tier descriptions — the coach explains what each hint tier does.
+const _hintExplanations = [
+  'That hint just revealed a new clue about this country. '
+      'Study it carefully — it might be all you need!',
+  'I\'ve revealed the name of the target country for you. '
+      'Now you know exactly where to fly — head there!',
+  'See that dashed line? It\'s a wayline pointing straight '
+      'to your target. Follow it!',
+  'I\'ve set your course automatically. Sit back and let the '
+      'plane fly straight to the destination.',
+];
+
 /// Semi-transparent overlay that shows coach tips during campaign missions.
 ///
-/// The coach's avatar sits in the top-right corner of the screen. When a tip
-/// is active, a speech bubble appears below the avatar with an aviation-themed
-/// dismiss button. Tips auto-dismiss after a delay or when the button is tapped.
+/// The coach's avatar sits below the compass. When a tip is active, a speech
+/// bubble appears centred on screen. Tips auto-dismiss after a delay or when
+/// the button is tapped.
 ///
 /// Also supports time-based "lost" detection: if no correct answer is given
-/// within a configurable interval, the coach proactively offers help.
+/// within a configurable interval, the coach proactively offers help by
+/// highlighting the hint button and forcing the player to use it.
 class CoachOverlay extends StatefulWidget {
   const CoachOverlay({super.key, required this.mission});
 
@@ -41,6 +54,14 @@ class CoachOverlayState extends State<CoachOverlay>
   bool _visible = false;
   final Set<String> _shownTriggers = {};
 
+  /// When true, the hint button is highlighted and the dismiss button is
+  /// hidden — the player must tap the hint button to progress.
+  bool _hintForceMode = false;
+
+  /// Whether we're waiting for a hint to be used (after showing a hint
+  /// suggestion). When the hint is used, we show an explanation.
+  bool _awaitingHintUse = false;
+
   late final AnimationController _animController;
   late final Animation<double> _slideAnim;
 
@@ -50,11 +71,16 @@ class CoachOverlayState extends State<CoachOverlay>
   /// How long without progress before showing a "lost" hint.
   static const _lostThreshold = Duration(seconds: 20);
 
-  /// Number of "lost" hints shown this session (caps at 3 to avoid nagging).
+  /// Number of "lost" nudges shown this session — no cap, coach always returns.
   int _lostHintCount = 0;
-  static const _maxLostHints = 3;
+
+  // Reserved for future hint-tier-specific explanations.
+  // int _currentHintTier = 0;
 
   static final _rng = Random();
+
+  /// Whether the hint button highlight overlay should be shown.
+  bool get isHintForced => _hintForceMode;
 
   @override
   void initState() {
@@ -80,7 +106,6 @@ class CoachOverlayState extends State<CoachOverlay>
   /// Resets any existing timer.
   void startLostTimer() {
     _lostTimer?.cancel();
-    if (_lostHintCount >= _maxLostHints) return;
     _lostTimer = Timer(_lostThreshold, _onPlayerLost);
   }
 
@@ -96,31 +121,63 @@ class CoachOverlayState extends State<CoachOverlay>
     _lostTimer = null;
   }
 
-  void _onPlayerLost() {
-    if (!mounted || _lostHintCount >= _maxLostHints) return;
-    _lostHintCount++;
+  /// Notify the coach that a hint was just used. Shows an explanation of
+  /// what the hint tier does and dismisses the hint-force overlay.
+  void onHintUsed(int hintTier) {
+    // hintTier tracked for future use.
+    if (_awaitingHintUse || _hintForceMode) {
+      _awaitingHintUse = false;
+      setState(() => _hintForceMode = false);
 
-    // Try to show the 'lost' trigger first, then fall back to encouragement.
-    if (!showTip('lost')) {
-      _showMessage(_lostEncouragement());
+      // Show explanation of what that hint tier did.
+      final tierIndex = (hintTier - 1).clamp(0, _hintExplanations.length - 1);
+      _showMessage(_hintExplanations[tierIndex]);
+
+      // Restart lost timer — coach will come back if still stuck.
+      startLostTimer();
     }
-    // Restart for another potential nudge.
-    startLostTimer();
   }
 
-  String _lostEncouragement() {
+  void _onPlayerLost() {
+    if (!mounted) return;
+    _lostHintCount++;
+
+    // Always suggest using a hint and force them to press it.
     final coach = widget.mission.coach.shortName;
+    final message = _lostSuggestion(coach);
+    _showHintForceMessage(message);
+
+    // Don't restart timer yet — wait until they use the hint.
+  }
+
+  String _lostSuggestion(String coach) {
     switch (_lostHintCount) {
       case 1:
-        return 'Take your time — study the clues carefully. '
-            'You\'ve got this!';
+        return 'Taking your time? That\'s wise — but let me help. '
+            'Try using a hint to narrow it down. Tap the hint button below!';
       case 2:
-        return 'Stuck? Try using a hint to narrow things down. '
-            '$coach believes in you.';
+        return 'Still searching? Every pilot needs instruments. '
+            'Use another hint — each one gets you closer. '
+            'Tap the hint button!';
+      case 3:
+        return 'No shame in asking for help, cadet. Even $coach '
+            'checked the charts. Use a hint!';
       default:
-        return 'Don\'t give up. Look at the clue again and think about '
-            'which region of the world it points to.';
+        return 'Let\'s get you there. Tap the hint button — '
+            'I\'ll guide you closer with each one.';
     }
+  }
+
+  /// Show a message that forces the player to use the hint button.
+  void _showHintForceMessage(String message) {
+    setState(() {
+      _currentMessage = message;
+      _hintForceMode = true;
+      _awaitingHintUse = true;
+      _visible = true;
+    });
+    _animController.forward(from: 0);
+    // No auto-dismiss — the player must tap the hint button.
   }
 
   /// Show a tip for the given trigger, if one exists for this mission and
@@ -146,12 +203,16 @@ class CoachOverlayState extends State<CoachOverlay>
       _currentMessage = message;
       _dismissLabel = _dismissLabels[_rng.nextInt(_dismissLabels.length)];
       _visible = true;
+      _hintForceMode = false;
     });
     _animController.forward(from: 0);
 
     // Auto-dismiss after 8 seconds (slightly longer to give time to read).
     Future.delayed(const Duration(seconds: 8), () {
-      if (mounted && _visible && _currentMessage == message) {
+      if (mounted &&
+          _visible &&
+          _currentMessage == message &&
+          !_hintForceMode) {
         _dismiss();
       }
     });
@@ -163,6 +224,7 @@ class CoachOverlayState extends State<CoachOverlay>
         setState(() {
           _visible = false;
           _currentMessage = null;
+          _hintForceMode = false;
         });
       }
     });
@@ -172,46 +234,75 @@ class CoachOverlayState extends State<CoachOverlay>
   Widget build(BuildContext context) {
     final coach = widget.mission.coach;
     final safePadding = MediaQuery.of(context).padding;
+    final screenSize = MediaQuery.of(context).size;
 
-    // Always show the coach avatar in the top-right. Speech bubble appears
-    // below it only when a tip is active.
-    return Positioned(
-      top: safePadding.top + 40,
-      right: 12,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Coach avatar — always visible during campaign
-          _CoachAvatar(coach: coach),
-
-          // Speech bubble — slides in when a tip is active
-          if (_visible && _currentMessage != null)
-            SlideTransition(
-              position: Tween<Offset>(
-                begin: const Offset(0, -0.3),
-                end: Offset.zero,
-              ).animate(_slideAnim),
-              child: FadeTransition(
-                opacity: _slideAnim,
-                child: Padding(
-                  padding: const EdgeInsets.only(top: 4),
-                  child: _SpeechBubble(
-                    coachName: coach.name,
-                    message: _currentMessage!,
-                    dismissLabel: _dismissLabel,
-                    onDismiss: _dismiss,
+    return Stack(
+      children: [
+        // Hint button highlight overlay — semi-transparent scrim with a
+        // spotlight cutout over the hint button, forcing the player to tap it.
+        if (_hintForceMode)
+          Positioned.fill(
+            child: IgnorePointer(
+              ignoring: false,
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: () {}, // Absorb taps outside the hint button
+                child: CustomPaint(
+                  painter: _HintSpotlightPainter(
+                    screenSize: screenSize,
+                    safePadding: safePadding,
                   ),
                 ),
               ),
             ),
-        ],
-      ),
+          ),
+
+        // Coach avatar sits below the compass (top-right area). Speech bubble
+        // appears centred on screen below the avatar.
+        Positioned(
+          top: safePadding.top + 110,
+          right: 12,
+          left: 12,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Coach avatar — always visible during campaign
+              _CoachAvatar(coach: coach),
+
+              // Speech bubble — slides in when a tip is active, centred
+              if (_visible && _currentMessage != null)
+                Align(
+                  alignment: Alignment.center,
+                  child: SlideTransition(
+                    position: Tween<Offset>(
+                      begin: const Offset(0, -0.3),
+                      end: Offset.zero,
+                    ).animate(_slideAnim),
+                    child: FadeTransition(
+                      opacity: _slideAnim,
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: _SpeechBubble(
+                          coachName: coach.name,
+                          message: _currentMessage!,
+                          dismissLabel: _dismissLabel,
+                          onDismiss: _dismiss,
+                          showDismiss: !_hintForceMode,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }
 
-/// Small circular coach avatar shown in the top-right corner.
+/// Small circular coach avatar shown below the compass.
 ///
 /// Shows the coach's portrait image when available, falling back to styled
 /// initials with a flag badge.
@@ -289,46 +380,40 @@ class _SpeechBubble extends StatelessWidget {
     required this.message,
     required this.dismissLabel,
     required this.onDismiss,
+    this.showDismiss = true,
   });
 
   final String coachName;
   final String message;
   final String dismissLabel;
   final VoidCallback onDismiss;
+  final bool showDismiss;
 
   @override
   Widget build(BuildContext context) {
     // Constrain width so it doesn't stretch the full screen on tablets.
     final screenWidth = MediaQuery.of(context).size.width;
-    final maxWidth = (screenWidth * 0.7).clamp(200.0, 320.0);
+    final maxWidth = (screenWidth * 0.75).clamp(220.0, 340.0);
 
     return SizedBox(
       width: maxWidth,
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
+        crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisSize: MainAxisSize.min,
         children: [
-          // Tail triangle pointing up toward the avatar
-          Padding(
-            padding: const EdgeInsets.only(right: 14),
-            child: CustomPaint(
-              size: const Size(14, 8),
-              painter: _BubbleTailPainter(),
-            ),
-          ),
-          // Bubble body
+          // Bubble body — light colour scheme
           Container(
             width: maxWidth,
             padding: const EdgeInsets.fromLTRB(12, 10, 12, 8),
             decoration: BoxDecoration(
-              color: FlitColors.cardBackground.withValues(alpha: 0.95),
+              color: const Color(0xFFF5F0E8),
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: FlitColors.accent.withValues(alpha: 0.3),
+                color: const Color(0xFFD4C9B8),
               ),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.35),
+                  color: Colors.black.withValues(alpha: 0.2),
                   blurRadius: 12,
                   offset: const Offset(0, 4),
                 ),
@@ -342,7 +427,7 @@ class _SpeechBubble extends StatelessWidget {
                 Text(
                   coachName,
                   style: const TextStyle(
-                    color: FlitColors.accent,
+                    color: Color(0xFFC45E2C),
                     fontSize: 11,
                     fontWeight: FontWeight.w700,
                   ),
@@ -352,39 +437,41 @@ class _SpeechBubble extends StatelessWidget {
                 Text(
                   message,
                   style: const TextStyle(
-                    color: FlitColors.textPrimary,
+                    color: Color(0xFF2D2D2D),
                     fontSize: 13,
                     height: 1.3,
                   ),
                 ),
-                const SizedBox(height: 8),
-                // Aviation-themed dismiss button
-                Center(
-                  child: GestureDetector(
-                    onTap: onDismiss,
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 6,
-                      ),
-                      decoration: BoxDecoration(
-                        color: FlitColors.accent.withValues(alpha: 0.15),
-                        borderRadius: BorderRadius.circular(16),
-                        border: Border.all(
-                          color: FlitColors.accent.withValues(alpha: 0.4),
+                if (showDismiss) ...[
+                  const SizedBox(height: 8),
+                  // Aviation-themed dismiss button
+                  Center(
+                    child: GestureDetector(
+                      onTap: onDismiss,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 6,
                         ),
-                      ),
-                      child: Text(
-                        dismissLabel,
-                        style: const TextStyle(
-                          color: FlitColors.accent,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w700,
+                        decoration: BoxDecoration(
+                          color: FlitColors.accent.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(
+                            color: FlitColors.accent.withValues(alpha: 0.4),
+                          ),
+                        ),
+                        child: Text(
+                          dismissLabel,
+                          style: const TextStyle(
+                            color: FlitColors.accent,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                          ),
                         ),
                       ),
                     ),
                   ),
-                ),
+                ],
               ],
             ),
           ),
@@ -394,34 +481,47 @@ class _SpeechBubble extends StatelessWidget {
   }
 }
 
-/// Paints the small triangular tail that connects the speech bubble to the
-/// coach avatar above.
-class _BubbleTailPainter extends CustomPainter {
+/// Paints a semi-transparent overlay with a spotlight cutout over the hint
+/// button in the bottom-left of the HUD.
+class _HintSpotlightPainter extends CustomPainter {
+  _HintSpotlightPainter({
+    required this.screenSize,
+    required this.safePadding,
+  });
+
+  final Size screenSize;
+  final EdgeInsets safePadding;
+
   @override
   void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = FlitColors.cardBackground.withValues(alpha: 0.95)
-      ..style = PaintingStyle.fill;
+    final darkPaint = Paint()..color = Colors.black.withValues(alpha: 0.5);
 
-    final path = Path()
-      ..moveTo(0, size.height)
-      ..lineTo(size.width / 2, 0)
-      ..lineTo(size.width, size.height)
-      ..close();
-    canvas.drawPath(path, paint);
+    // Hint button approximate position: bottom-left area of the HUD.
+    final bottom = size.height - safePadding.bottom - 16;
+    const pad = 12.0;
+    final hintRect = Rect.fromLTRB(
+      safePadding.left + 4,
+      bottom - 44 - pad,
+      size.width * 0.32 + pad,
+      bottom + pad,
+    );
 
-    // Border on the tail edges (not the bottom, which merges with the bubble).
-    final borderPaint = Paint()
-      ..color = FlitColors.accent.withValues(alpha: 0.3)
+    canvas.saveLayer(Offset.zero & size, Paint());
+    canvas.drawRect(Offset.zero & size, darkPaint);
+
+    final cutoutPaint = Paint()..blendMode = BlendMode.clear;
+    final rrect = RRect.fromRectAndRadius(hintRect, const Radius.circular(22));
+    canvas.drawRRect(rrect, cutoutPaint);
+    canvas.restore();
+
+    // Pulsing glow border around the cutout.
+    final glowPaint = Paint()
+      ..color = FlitColors.gold.withValues(alpha: 0.7)
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.0;
-    final borderPath = Path()
-      ..moveTo(0, size.height)
-      ..lineTo(size.width / 2, 0)
-      ..lineTo(size.width, size.height);
-    canvas.drawPath(borderPath, borderPaint);
+      ..strokeWidth = 2.5;
+    canvas.drawRRect(rrect, glowPaint);
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+  bool shouldRepaint(_HintSpotlightPainter oldDelegate) => false;
 }

--- a/lib/features/campaign/mission_dialog.dart
+++ b/lib/features/campaign/mission_dialog.dart
@@ -26,7 +26,7 @@ class MissionDialog {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Coach portrait + name row
+              // Coach portrait + name row + close button
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -48,26 +48,45 @@ class MissionDialog {
                         ),
                         const SizedBox(height: 2),
                         Text(
-                          '${mission.coach.title} — '
-                          '${mission.coach.nationality}',
+                          mission.coach.title,
                           style: const TextStyle(
                             color: FlitColors.textMuted,
                             fontSize: 11,
                           ),
                         ),
-                        const SizedBox(height: 4),
-                        Text(
-                          mission.coach.bio,
-                          style: const TextStyle(
-                            color: FlitColors.textSecondary,
-                            fontSize: 11,
-                            height: 1.3,
-                          ),
-                          maxLines: 3,
-                          overflow: TextOverflow.ellipsis,
-                        ),
                       ],
                     ),
+                  ),
+                  // Flag emoji (top-right) + close button
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      GestureDetector(
+                        onTap: () => Navigator.of(ctx).pop(),
+                        child: Container(
+                          width: 28,
+                          height: 28,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: FlitColors.backgroundMid,
+                            border: Border.all(
+                              color:
+                                  FlitColors.cardBorder.withValues(alpha: 0.5),
+                            ),
+                          ),
+                          child: const Icon(
+                            Icons.close,
+                            color: FlitColors.textSecondary,
+                            size: 16,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        mission.coach.flagEmoji,
+                        style: const TextStyle(fontSize: 24),
+                      ),
+                    ],
                   ),
                 ],
               ),
@@ -81,28 +100,6 @@ class MissionDialog {
                     fontSize: 14,
                     fontWeight: FontWeight.w900,
                     letterSpacing: 1.5,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-              const SizedBox(height: 10),
-              // Coach self-introduction
-              Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: FlitColors.backgroundDark.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(10),
-                  border: Border.all(
-                    color: FlitColors.cardBorder.withValues(alpha: 0.3),
-                  ),
-                ),
-                child: Text(
-                  '"${mission.coach.introduction}"',
-                  style: const TextStyle(
-                    color: FlitColors.textSecondary,
-                    fontSize: 12,
-                    fontStyle: FontStyle.italic,
-                    height: 1.4,
                   ),
                   textAlign: TextAlign.center,
                 ),
@@ -150,51 +147,113 @@ class MissionDialog {
                 value: '+${mission.coinReward}',
               ),
               const SizedBox(height: 16),
-              // Buttons: tick dismiss + start
-              Row(
-                children: [
-                  // Tick-in-circle dismiss button
-                  SizedBox(
-                    width: 48,
-                    height: 48,
-                    child: IconButton(
-                      onPressed: () => Navigator.of(ctx).pop(),
-                      style: IconButton.styleFrom(
-                        side: const BorderSide(color: FlitColors.cardBorder),
-                        shape: const CircleBorder(),
-                      ),
-                      icon: const Icon(
-                        Icons.check_circle_outline,
-                        color: FlitColors.textSecondary,
-                        size: 24,
-                      ),
+              // Start button (full width — close via X in top-right)
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(ctx).pop();
+                    onStart();
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: FlitColors.accent,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                  ),
+                  child: const Text(
+                    'START MISSION',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 1,
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: ElevatedButton(
-                      onPressed: () {
-                        Navigator.of(ctx).pop();
-                        onStart();
-                      },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: FlitColors.accent,
-                        foregroundColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(10),
-                        ),
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                      ),
-                      child: const Text(
-                        'START MISSION',
-                        style: TextStyle(
-                          fontWeight: FontWeight.w800,
-                          letterSpacing: 1,
-                        ),
-                      ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Show the coach farewell speech before the results dialog.
+  static void showFarewell(
+    BuildContext context, {
+    required CampaignMission mission,
+    required String farewellText,
+    required VoidCallback onContinue,
+  }) {
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => Dialog(
+        backgroundColor: FlitColors.cardBackground,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Coach portrait
+              _CoachPortrait(coach: mission.coach, size: 64),
+              const SizedBox(height: 12),
+              Text(
+                mission.coach.name,
+                style: const TextStyle(
+                  color: FlitColors.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 12),
+              // Farewell message
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF5F0E8),
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                    color: const Color(0xFFD4C9B8),
+                  ),
+                ),
+                child: Text(
+                  farewellText,
+                  style: const TextStyle(
+                    color: Color(0xFF2D2D2D),
+                    fontSize: 13,
+                    fontStyle: FontStyle.italic,
+                    height: 1.4,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(ctx).pop();
+                    onContinue();
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: FlitColors.accent,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                  ),
+                  child: const Text(
+                    'CONTINUE',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 1,
                     ),
                   ),
-                ],
+                ),
               ),
             ],
           ),

--- a/lib/features/campaign/tutorial_overlay.dart
+++ b/lib/features/campaign/tutorial_overlay.dart
@@ -289,10 +289,11 @@ class TutorialOverlayState extends State<TutorialOverlay>
               ),
             ),
 
-          // Coach avatar + speech bubble in top-right corner.
+          // Coach avatar below compass + speech bubble centred on screen.
           Positioned(
-            top: safePadding.top + 40,
+            top: safePadding.top + 110,
             right: 12,
+            left: 12,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.end,
               mainAxisSize: MainAxisSize.min,
@@ -300,14 +301,17 @@ class TutorialOverlayState extends State<TutorialOverlay>
                 // Coach avatar
                 _CoachAvatar(coach: coach),
                 const SizedBox(height: 4),
-                // Speech bubble
-                _CoachCard(
-                  coachName: coach.name,
-                  message: _message,
-                  showPulse: _isActionPhase,
-                  showContinueButton: _isTapPhase,
-                  continueLabel: _continueLabel,
-                  onTap: _isTapPhase ? _onTap : null,
+                // Speech bubble — centred
+                Align(
+                  alignment: Alignment.center,
+                  child: _CoachCard(
+                    coachName: coach.name,
+                    message: _message,
+                    showPulse: _isActionPhase,
+                    showContinueButton: _isTapPhase,
+                    continueLabel: _continueLabel,
+                    onTap: _isTapPhase ? _onTap : null,
+                  ),
                 ),
               ],
             ),
@@ -451,14 +455,14 @@ class _CoachCard extends StatelessWidget {
             width: maxWidth,
             padding: const EdgeInsets.fromLTRB(12, 10, 12, 8),
             decoration: BoxDecoration(
-              color: FlitColors.cardBackground.withValues(alpha: 0.97),
+              color: const Color(0xFFF5F0E8),
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: FlitColors.accent.withValues(alpha: 0.4),
+                color: const Color(0xFFD4C9B8),
               ),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.4),
+                  color: Colors.black.withValues(alpha: 0.2),
                   blurRadius: 16,
                   offset: const Offset(0, 4),
                 ),
@@ -472,7 +476,7 @@ class _CoachCard extends StatelessWidget {
                 Text(
                   coachName,
                   style: const TextStyle(
-                    color: FlitColors.accent,
+                    color: Color(0xFFC45E2C),
                     fontSize: 11,
                     fontWeight: FontWeight.w700,
                   ),
@@ -482,7 +486,7 @@ class _CoachCard extends StatelessWidget {
                 Text(
                   message,
                   style: const TextStyle(
-                    color: FlitColors.textPrimary,
+                    color: Color(0xFF2D2D2D),
                     fontSize: 13,
                     height: 1.35,
                   ),
@@ -534,7 +538,7 @@ class _BubbleTailPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
-      ..color = FlitColors.cardBackground.withValues(alpha: 0.97)
+      ..color = const Color(0xFFF5F0E8)
       ..style = PaintingStyle.fill;
 
     final path = Path()
@@ -545,7 +549,7 @@ class _BubbleTailPainter extends CustomPainter {
     canvas.drawPath(path, paint);
 
     final borderPaint = Paint()
-      ..color = FlitColors.accent.withValues(alpha: 0.4)
+      ..color = const Color(0xFFD4C9B8)
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.0;
     final borderPath = Path()
@@ -681,11 +685,11 @@ class _SpotlightPainter extends CustomPainter {
         );
 
       case TutorialTarget.speedControls:
-        // Bottom row center: speed pills.
+        // Bottom row center: speed pills — centred between hint and altitude.
         return Rect.fromLTRB(
-          size.width * 0.28 - pad,
+          size.width * 0.25 - pad,
           bottom - 48 - pad,
-          size.width * 0.62 + pad,
+          size.width * 0.65 + pad,
           bottom + pad,
         );
 

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -407,6 +407,8 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
 
     // Fire coach tip for first hint usage (campaign missions only).
     _coachOverlayKey.currentState?.showTip('firstHint');
+    // Notify coach overlay that a hint was used (explains what it does).
+    _coachOverlayKey.currentState?.onHintUsed(_hintTier + 1);
     // Reset the "lost" timer — using a hint shows engagement.
     _coachOverlayKey.currentState?.resetLostTimer();
 
@@ -1208,7 +1210,7 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
         );
     if (!mounted) return;
 
-    // Campaign mission completion — record progress and show campaign dialog.
+    // Campaign mission completion — show coach farewell, then results.
     if (widget.campaignMission != null) {
       final mission = widget.campaignMission!;
       final notifier = ref.read(accountProvider.notifier);
@@ -1222,13 +1224,25 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
         coinReward: mission.coinReward,
       );
       if (mounted) {
-        MissionDialog.showCompletion(
+        // Show coach farewell speech first — tapping dismiss shows results.
+        _coachOverlayKey.currentState?.cancelLostTimer();
+        final farewellText =
+            '${mission.coach.farewell}\n\n${mission.coach.nextCoachTeaser}';
+        MissionDialog.showFarewell(
           context,
           mission: mission,
-          result: campaignResult,
-          isFirstCompletion: isFirst,
+          farewellText: farewellText,
           onContinue: () {
-            if (mounted) Navigator.of(context).pop();
+            if (!mounted) return;
+            MissionDialog.showCompletion(
+              context,
+              mission: mission,
+              result: campaignResult,
+              isFirstCompletion: isFirst,
+              onContinue: () {
+                if (mounted) Navigator.of(context).pop();
+              },
+            );
           },
         );
       }
@@ -1911,9 +1925,11 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
 
             // Coach overlay for campaign missions
             if (widget.campaignMission != null && _gameReady)
-              CoachOverlay(
-                key: _coachOverlayKey,
-                mission: widget.campaignMission!,
+              Positioned.fill(
+                child: CoachOverlay(
+                  key: _coachOverlayKey,
+                  mission: widget.campaignMission!,
+                ),
               ),
 
             // Interactive tutorial overlay for Mission 1

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -194,7 +194,7 @@ class FlitGame extends FlameGame
   Vector2? _hintTarget;
 
   /// Current flight speed setting.
-  FlightSpeed _flightSpeed = FlightSpeed.medium;
+  FlightSpeed _flightSpeed = FlightSpeed.slow;
 
   /// Globe hit-test utility (screen-tap → lat/lng).
   final GlobeHitTest _hitTest = const GlobeHitTest();
@@ -1701,7 +1701,7 @@ class FlitGame extends FlameGame
     _currentClue = clue;
     _waymarker = null; // clear any previous waymarker
     _hintTarget = null; // clear any previous hint
-    _flightSpeed = FlightSpeed.medium; // reset speed
+    _flightSpeed = FlightSpeed.slow; // reset speed — always start slow
     _fuel = maxFuel; // full tank (includes licence bonus)
     // Start launch animation sequence.
     _launchPhase = LaunchPhase.positioning;

--- a/lib/game/map/descent_map_view.dart
+++ b/lib/game/map/descent_map_view.dart
@@ -58,6 +58,12 @@ class _DescentMapViewState extends State<DescentMapView> {
   bool _mapReady = false;
   double _widgetHeight = 800.0;
 
+  /// Throttle map updates — skip frames where position/zoom barely changed.
+  double _lastLat = double.nan;
+  double _lastLng = double.nan;
+  double _lastZoom = double.nan;
+  double _lastRotation = double.nan;
+
   /// Convert altitude transition (0.0–1.0) to flutter_map zoom level.
   /// Low altitude (0.0) → zoom 7 (regional overview)
   /// High altitude (1.0) → zoom 4 (continent-level)
@@ -106,9 +112,32 @@ class _DescentMapViewState extends State<DescentMapView> {
   @override
   void didUpdateWidget(DescentMapView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (_mapReady) {
-      _mapController.move(_effectiveCenter(), _zoom);
-      _mapController.rotate(_rotation);
+    if (!_mapReady) return;
+
+    final center = _effectiveCenter();
+    final zoom = _zoom;
+    final rotation = _rotation;
+
+    // Only push camera updates when values changed meaningfully.
+    // This avoids hammering flutter_map with redundant moves every 16ms.
+    final latDelta = (center.latitude - _lastLat).abs();
+    final lngDelta = (center.longitude - _lastLng).abs();
+    final zoomDelta = (zoom - _lastZoom).abs();
+    final rotDelta = (rotation - _lastRotation).abs();
+
+    final needsMove =
+        latDelta > 0.0001 || lngDelta > 0.0001 || zoomDelta > 0.01;
+    final needsRotate = rotDelta > 0.1;
+
+    if (needsMove) {
+      _mapController.move(center, zoom);
+      _lastLat = center.latitude;
+      _lastLng = center.longitude;
+      _lastZoom = zoom;
+    }
+    if (needsRotate) {
+      _mapController.rotate(rotation);
+      _lastRotation = rotation;
     }
   }
 
@@ -131,14 +160,19 @@ class _DescentMapViewState extends State<DescentMapView> {
               ),
               onMapReady: () {
                 _mapReady = true;
+                _lastLat = center.latitude;
+                _lastLng = center.longitude;
+                _lastZoom = _zoom;
+                _lastRotation = _rotation;
               },
             ),
             children: [
-              // Map tiles (style selected in settings)
+              // Map tiles (style selected in settings) — capped at zoom 12
+              // to reduce tile requests and improve performance at descent.
               TileLayer(
                 urlTemplate: widget.tileUrl,
                 userAgentPackageName: 'com.jamiembright.flit',
-                maxZoom: 18,
+                maxZoom: 12,
                 subdomains: const ['a', 'b', 'c'],
                 // On web, the browser cache handles tile storage.
               ),

--- a/lib/game/tutorial/campaign_mission.dart
+++ b/lib/game/tutorial/campaign_mission.dart
@@ -71,11 +71,15 @@ class CampaignMissionResult {
   final DateTime completedAt;
 
   /// Calculate stars from score (out of max possible ~10 000 per round x rounds).
+  ///
+  /// Thresholds are generous because tutorial missions involve exploring
+  /// controls for the first time — players shouldn't be penalised for
+  /// taking time to learn.
   static int calculateStars(int score, int rounds) {
     final maxScore = rounds * 10000;
     final ratio = score / maxScore;
-    if (ratio >= 0.8) return 3;
-    if (ratio >= 0.5) return 2;
+    if (ratio >= 0.5) return 3;
+    if (ratio >= 0.25) return 2;
     return 1;
   }
 

--- a/lib/game/tutorial/coach.dart
+++ b/lib/game/tutorial/coach.dart
@@ -12,6 +12,8 @@ class Coach {
     required this.bio,
     required this.introduction,
     required this.greeting,
+    required this.farewell,
+    required this.nextCoachTeaser,
     this.imageAsset,
   });
 
@@ -39,6 +41,16 @@ class Coach {
 
   /// Congratulations line spoken when the player completes the mission.
   final String greeting;
+
+  /// Personal anecdote the coach shares before the game ends (2-3 sentences).
+  /// Starts with a memory referencing their real achievements, then
+  /// congratulates the player.
+  final String farewell;
+
+  /// Teaser for the next coach (1-2 sentences) mentioning the next coach by
+  /// name and hinting at what makes them remarkable. For the last coach,
+  /// acknowledges that all training is complete.
+  final String nextCoachTeaser;
 
   /// Optional asset path to a cartoonised portrait.
   /// Falls back to a styled initial circle when null.
@@ -82,6 +94,15 @@ const Coach coachJRDTata = Coach(
       'know your borders and neighbours. Let me teach you to navigate.',
   greeting:
       'You navigate with the confidence of an airline founder. Well done.',
+  farewell:
+      'This reminds me of that first airmail run — just me, a tiny Puss Moth, '
+      'and the vast patchwork of borders stretching below from Karachi to '
+      'Bombay. You have shown the same steady hand I had that day. '
+      'Congratulations, pilot — you have earned the skies.',
+  nextCoachTeaser:
+      'Your next instructor is Lotfia El Nadi — the remarkable Egyptian woman '
+      'who secretly enrolled in flight school and became the first female pilot '
+      'in Africa and the Arab world. She has some extraordinary stories to share.',
   imageAsset: 'assets/images/coaches/Jrd tata.PNG',
 );
 
@@ -100,6 +121,15 @@ const Coach coachLotfia = Coach(
       'world to earn her wings. Every flag tells the story of a nation\'s '
       'spirit. Let me teach you to read them.',
   greeting: 'You read those flags like poetry. I\'m proud of you.',
+  farewell:
+      'This reminds me of the day I finally received my pilot\'s licence in '
+      'Cairo — every flag on that airfield seemed to wave just for me, and '
+      'I understood that each one carried a whole world of meaning. You have '
+      'learned to read those worlds today. Congratulations, my friend.',
+  nextCoachTeaser:
+      'Next you will meet Alberto Santos-Dumont, the brilliant Brazilian who '
+      'flew his airship around the Eiffel Tower and made history over the '
+      'fields of Paris — he will teach you everything about capital cities.',
   imageAsset: 'assets/images/coaches/Lotfia el nadi.PNG',
 );
 
@@ -118,6 +148,15 @@ const Coach coachSantosDumont = Coach(
       'Eiffel Tower in an airship and landed near capitals across Europe. '
       'Knowing where you are is just as important as knowing how to fly.',
   greeting: 'Bravo! You know your capitals like a true aviator of the world.',
+  farewell:
+      'This reminds me of floating over Paris in my airship, gazing down at '
+      'the grand boulevards leading to the heart of the city — every capital '
+      'has that same pulse of power and culture when seen from above. You '
+      'found that pulse today, and I applaud you wholeheartedly.',
+  nextCoachTeaser:
+      'Your next guide is Sabiha Gökçen — the world\'s first female combat '
+      'pilot, who flew 22 missions for Turkey and logged over 8,000 hours. '
+      'She will teach you to combine many signals into one clear picture.',
   imageAsset: 'assets/images/coaches/Alberto Santos-Dumont.PNG',
 );
 
@@ -136,6 +175,14 @@ const Coach coachSabiha = Coach(
       'instinct all at once. I\'ll teach you to combine every signal into '
       'one clear picture.',
   greeting: 'You combined those clues like a true combat pilot. Exceptional.',
+  farewell: 'This reminds me of a combat mission over the Aegean — instruments '
+      'flickering, weather closing in, and only instinct and training to '
+      'guide me through. You showed that same composure today, reading every '
+      'signal without flinching. I am genuinely impressed.',
+  nextCoachTeaser:
+      'Jean Batten of New Zealand awaits you next — she flew solo from '
+      'England to New Zealand, 14,000 miles in a single-engine aircraft, '
+      'and she will challenge you to master fuel management like no one else.',
   imageAsset: 'assets/images/coaches/Sabiha Gokcen.PNG',
 );
 
@@ -155,6 +202,15 @@ const Coach coachJeanBatten = Coach(
       'discipline.',
   greeting: 'Efficient and precise. You\'d have made it across the Tasman with '
       'fuel to spare.',
+  farewell: 'This reminds me of crossing the Tasman Sea alone — the fuel gauge '
+      'ticking down with nothing but dark water in every direction, trusting '
+      'the numbers I had planned so carefully on the ground. You showed that '
+      'same trust and precision today. Congratulations on a beautifully '
+      'managed flight.',
+  nextCoachTeaser:
+      'Antoine de Saint-Exupéry is waiting for you — French aviator, mail '
+      'pilot across the Sahara, and author of The Little Prince. He has a '
+      'poet\'s eye for finding what is essential.',
   imageAsset: 'assets/images/coaches/Jean batten.PNG',
 );
 
@@ -173,6 +229,15 @@ const Coach coachSaintExupery = Coach(
       'invisible to the eye — but sometimes you need a hint to find it.',
   greeting: 'You found your way with grace. As I once wrote: "It is only with '
       'the heart that one can see rightly."',
+  farewell:
+      'This reminds me of a night over the Sahara, my engine quiet, stars '
+      'blazing overhead — I had no map that mattered, only the clues the '
+      'desert whispered to those willing to listen. You listened today, and '
+      'you found your way. That is all any pilot can ask.',
+  nextCoachTeaser:
+      'Jorge Chávez of Peru will be your next instructor — the first man to '
+      'fly over the Alps, who calculated every number to the decimal and '
+      'turned data into courage.',
   imageAsset: 'assets/images/coaches/Antoine de Saint-Exupery.PNG',
 );
 
@@ -191,6 +256,15 @@ const Coach coachJorgeChavez = Coach(
       'altitude, wind speed, and fuel to the decimal. Numbers are the '
       'language of the sky. Let me teach you to read them.',
   greeting: 'Your data analysis would make any flight engineer proud.',
+  farewell: 'This reminds me of the moment I crested the Alps in my little '
+      'Blériot — every figure I had calculated for weeks suddenly became '
+      'real in the roar of the wind and the white peaks below. You turned '
+      'numbers into understanding today, just as I did. Congratulations, '
+      'and fly always with precision.',
+  nextCoachTeaser:
+      'Beryl Markham from Kenya is next — the first person to fly the '
+      'Atlantic solo from east to west, who learned to track wildlife from '
+      'the Nandi people and can read any landscape from altitude.',
   imageAsset: 'assets/images/coaches/Jorge Chavez.PNG',
 );
 
@@ -211,6 +285,14 @@ const Coach coachBerylMarkham = Coach(
       'distinctive as a fingerprint.',
   greeting:
       'You\'ve got the eye of a bush pilot. That silhouette didn\'t fool you.',
+  farewell: 'This reminds me of gliding low over the Kenyan savannah at dawn, '
+      'learning every ridge and river bend until I could find my way home '
+      'blindfolded — the land speaks if you know how to look. You have '
+      'learned to look today, and I could not be more pleased.',
+  nextCoachTeaser:
+      'Emilio Carranza, the Lindbergh of Mexico, is your next guide — he '
+      'flew nonstop from Mexico City to Washington on a goodwill mission '
+      'and will put every skill you have learned to the ultimate test.',
   imageAsset: 'assets/images/coaches/Beryl Markham.PNG',
 );
 
@@ -231,6 +313,15 @@ const Coach coachEmilioCarranza = Coach(
       'have learned.',
   greeting: 'You flew that like a captain on a goodwill mission. The world is '
       'yours to explore.',
+  farewell: 'This reminds me of that long nonstop flight from Mexico City to '
+      'Washington — no single skill was enough; navigation, endurance, '
+      'instinct, and knowledge of the world all had to work as one. You '
+      'wove them all together today with the grace of a true aviator. '
+      'I salute you.',
+  nextCoachTeaser:
+      'Al-Muqaddasi, the great medieval geographer from Jerusalem, is '
+      'your next mentor — a thousand years ago he walked every province '
+      'of the known world and wrote the first scientific regional geography.',
   imageAsset: 'assets/images/coaches/Emilio Carranza.PNG',
 );
 
@@ -254,6 +345,16 @@ const Coach coachMuqaddasi = Coach(
       'You have earned your wings, just as I earned my knowledge — through '
       'patience, curiosity, and a refusal to leave any corner of the world '
       'unexplored. Fly well, pilot.',
+  farewell:
+      'This reminds me of the years I spent walking the markets of Basra, '
+      'the mountains of Persia, and the ports of the Nile — every region '
+      'revealing its secrets only to those patient enough to truly look. '
+      'You have shown that patience and earned your licence. Go forth and '
+      'explore with the curiosity of a true geographer.',
+  nextCoachTeaser:
+      'Jesús Villamor of the Philippines is next — a WWII fighter ace who '
+      'led five biplanes against an entire Japanese invasion force, and who '
+      'will prepare you for the daily challenges ahead.',
   imageAsset: 'assets/images/coaches/Al-Muqaddasi.PNG',
 );
 
@@ -271,6 +372,15 @@ const Coach coachVillamor = Coach(
       'but never outfought. Daily challenges are like combat: preparation '
       'is everything. Let me sharpen your reflexes.',
   greeting: 'You handled that pressure like a true ace. Ready for anything.',
+  farewell: 'This reminds me of the morning of 10 December 1941 — six of us in '
+      'old P-26 Peashooters rising to meet a sky full of Japanese Zeros, '
+      'knowing that preparation and nerve were the only advantages we had. '
+      'You showed both of those qualities today. I am proud to have trained '
+      'you.',
+  nextCoachTeaser:
+      'Halim Perdanakusuma of Indonesia will be your graduation examiner '
+      '— a national hero who flew daring independence missions at just '
+      '25 years old. This is where everything you have learned comes together.',
   imageAsset: 'assets/images/coaches/Jesus Villamor.PNG',
 );
 
@@ -291,6 +401,15 @@ const Coach coachHalim = Coach(
   greeting:
       'You have earned your wings. Fly with the courage of those who fought '
       'for the freedom to explore.',
+  farewell: 'This reminds me of my last mission over Java — the knowledge that '
+      'every skill I had was being asked of me at once, and that the sky '
+      'itself was the final examiner. You passed that examination today '
+      'with honour. I am proud to call you a graduate.',
+  nextCoachTeaser:
+      'One final challenge awaits with Errol Barrow of Barbados — RAF '
+      'combat pilot, 45 missions over wartime Europe, and later Prime '
+      'Minister of his nation. He reserves his toughest test for those '
+      'who have come this far.',
   imageAsset: 'assets/images/coaches/Halim Perdanakusuma.PNG',
 );
 
@@ -310,6 +429,16 @@ const Coach coachErrolBarrow = Coach(
       'your final test — the ace challenge. Hold nothing back.',
   greeting: 'From combat pilot to prime minister, I have seen excellence — and '
       'you have it. Fly proud, ace.',
+  farewell: 'This reminds me of returning to Barbados after 45 missions over '
+      'Europe — knowing that every sortie, every decision made at altitude, '
+      'had shaped me into something more than a pilot. You have completed '
+      'the full journey today, from your first navigation lesson to this '
+      'final ace challenge. The sky is no longer a test — it is your home. '
+      'Congratulations.',
+  nextCoachTeaser:
+      'You have trained with all thirteen coaches and conquered every '
+      'challenge from navigation to ace combat. The full world is yours '
+      'to explore — take to the skies whenever you are ready.',
   imageAsset: 'assets/images/coaches/Errol Barrow.PNG',
 );
 

--- a/lib/game/ui/game_hud.dart
+++ b/lib/game/ui/game_hud.dart
@@ -721,27 +721,27 @@ class _HintButtonState extends State<_HintButton>
 
   @override
   Widget build(BuildContext context) {
-    final String icon;
+    final IconData iconData;
     final String label;
     switch (widget.tier) {
       case 0:
-        icon = '💡';
+        iconData = Icons.lightbulb_outline;
         label = 'NEW CLUE';
         break;
       case 1:
-        icon = '🌍';
+        iconData = Icons.public;
         label = 'REVEAL';
         break;
       case 2:
-        icon = '🧭';
+        iconData = Icons.explore;
         label = 'WAYLINE';
         break;
       case 3:
-        icon = '📍';
+        iconData = Icons.near_me;
         label = 'NAVIGATE';
         break;
       default:
-        icon = '✓';
+        iconData = Icons.check;
         label = 'DONE';
         break;
     }
@@ -765,7 +765,7 @@ class _HintButtonState extends State<_HintButton>
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(icon, style: const TextStyle(fontSize: 14)),
+                Icon(iconData, size: 16, color: FlitColors.gold),
                 const SizedBox(width: 6),
                 Text(
                   label,

--- a/lib/game/ui/ink_burst_overlay.dart
+++ b/lib/game/ui/ink_burst_overlay.dart
@@ -14,6 +14,7 @@ class _InkParticle {
     required this.color,
     required this.birthT,
     required this.deathT,
+    this.gravity = 0.0,
   });
 
   /// Direction of travel (radians).
@@ -33,12 +34,17 @@ class _InkParticle {
 
   /// Controller value at which this particle has fully faded out.
   final double deathT;
+
+  /// Downward acceleration in pixels — makes particles trickle down the screen.
+  final double gravity;
 }
 
 /// [CustomPainter] that draws a watercolor ink-burst particle effect.
 ///
 /// Each particle is rendered as a soft blurred under-wash plus a crisp core
 /// dot, matching the layered wash pattern from [WatercolorStyle.washFill].
+/// Particles are subject to gravity, causing them to arc upward then trickle
+/// down the screen like sparks from a firework.
 class _InkBurstPainter extends CustomPainter {
   _InkBurstPainter({
     required this.particles,
@@ -76,9 +82,9 @@ class _InkBurstPainter extends CustomPainter {
       // Ease-out: fast start, slow finish.
       final ease = 1.0 - pow(1.0 - tLocal, 2.5).toDouble();
 
-      // Position.
+      // Position — initial burst direction + gravity pulling downward.
       final dx = cos(p.angle) * p.speed * ease;
-      final dy = sin(p.angle) * p.speed * ease;
+      final dy = sin(p.angle) * p.speed * ease + p.gravity * tLocal * tLocal;
       final pos = origin + Offset(dx, dy);
 
       // Opacity: full until deathT, then fade to 0.
@@ -90,8 +96,8 @@ class _InkBurstPainter extends CustomPainter {
       }
       if (opacity <= 0) continue;
 
-      // Radius grows slightly as the particle travels.
-      final r = p.radius * (0.5 + 0.5 * ease);
+      // Radius shrinks as particle falls (simulates sparks cooling).
+      final r = p.radius * (0.5 + 0.5 * ease) * (0.6 + 0.4 * (1.0 - tLocal));
 
       // Under-wash: blurred circle at low opacity.
       washPaint
@@ -115,6 +121,9 @@ class _InkBurstPainter extends CustomPainter {
 ///
 /// Use a [GlobalKey] to obtain the state and call [InkBurstOverlayState.trigger]
 /// with the screen-space origin where the burst should appear.
+///
+/// Particles burst outward, then gravity pulls them downward so the effect
+/// trickles down the screen like sparks from a firework.
 class InkBurstOverlay extends StatefulWidget {
   const InkBurstOverlay({super.key});
 
@@ -124,8 +133,8 @@ class InkBurstOverlay extends StatefulWidget {
 
 class InkBurstOverlayState extends State<InkBurstOverlay>
     with TickerProviderStateMixin {
-  static const _particleCount = 28;
-  static const _duration = Duration(milliseconds: 900);
+  static const _particleCount = 36;
+  static const _duration = Duration(milliseconds: 1400);
 
   static const _palette = [
     FlitColors.gold,
@@ -167,13 +176,18 @@ class InkBurstOverlayState extends State<InkBurstOverlay>
           ? WatercolorStyle.lighten(baseColor, variation)
           : WatercolorStyle.darken(baseColor, -variation);
 
+      // Bias angles upward (between -150° and -30° from horizontal)
+      // so particles burst up, then gravity pulls them down.
+      final angle = -pi * 0.17 + (_rng.nextDouble() - 0.5) * pi * 1.2;
+
       return _InkParticle(
-        angle: _rng.nextDouble() * 2 * pi,
-        speed: 40 + _rng.nextDouble() * 140, // 40–180 px
-        radius: 3 + _rng.nextDouble() * 6, // 3–9 px
+        angle: angle,
+        speed: 50 + _rng.nextDouble() * 160, // 50–210 px
+        radius: 2.5 + _rng.nextDouble() * 5, // 2.5–7.5 px
         color: color,
-        birthT: _rng.nextDouble() * 0.35,
-        deathT: 0.6 + _rng.nextDouble() * 0.4,
+        birthT: _rng.nextDouble() * 0.25,
+        deathT: 0.55 + _rng.nextDouble() * 0.45,
+        gravity: 200 + _rng.nextDouble() * 300, // 200–500 px downward pull
       );
     });
   }


### PR DESCRIPTION
…mance

Mission briefing dialog:
- Remove coach bio (duplicative with opening statement)
- Replace nationality text with flag emoji in top-right
- Replace tick dismiss + start row with X close button + full-width start

In-game coach overlay:
- Light colour scheme for speech bubbles (cream background, dark text)
- Reposition coach avatar below compass to avoid overlapping timer/compass
- Centre speech bubble on screen for easier tap targets
- When player is stuck, force hint usage with spotlight overlay on hint button
- Remove dismiss button during hint-force mode (must tap hint to progress)
- Coach explains what each hint tier does after use
- Coach keeps coming back with hint suggestions (no cap)

Tutorial overlay:
- Match light colour scheme for speech bubbles
- Reposition coach below compass, centre speech bubble
- Widen speed control spotlight to better cover the controls

Game defaults:
- All game modes now start on SLOW speed (was MEDIUM)
- Lower 3-star threshold from 80% to 50% for tutorial missions

Coach farewell system:
- Add farewell and nextCoachTeaser fields to Coach model
- All 13 coaches have personal anecdotes and next-coach teasers
- Show farewell dialog before game-end summary in campaign

Performance:
- Descent map view: throttle camera updates, cap tile zoom at 12
- Replace emoji text in hint button with Material icons (no loading delay)

Clue celebration:
- Ink burst particles now have gravity, trickling down the screen
- More particles, longer duration, upward burst then fall

Campaign homepage:
- Add clue type icon legend at top of mission list
- Add tooltips to clue type icons on each mission card

https://claude.ai/code/session_01ERFrwcjyUS82eUg2W4KGrr