### PR TITLE
Fix coach briefing, flag placement, spotlight centering, and hint tap…

### DIFF
--- a/lib/features/campaign/coach_overlay.dart
+++ b/lib/features/campaign/coach_overlay.dart
@@ -240,20 +240,13 @@ class CoachOverlayState extends State<CoachOverlay>
       children: [
         // Hint button highlight overlay — semi-transparent scrim with a
         // spotlight cutout over the hint button, forcing the player to tap it.
+        // Uses a custom hit-test widget so taps inside the cutout pass through
+        // to the hint button underneath, while taps elsewhere are absorbed.
         if (_hintForceMode)
           Positioned.fill(
-            child: IgnorePointer(
-              ignoring: false,
-              child: GestureDetector(
-                behavior: HitTestBehavior.translucent,
-                onTap: () {}, // Absorb taps outside the hint button
-                child: CustomPaint(
-                  painter: _HintSpotlightPainter(
-                    screenSize: screenSize,
-                    safePadding: safePadding,
-                  ),
-                ),
-              ),
+            child: _HintSpotlightOverlay(
+              screenSize: screenSize,
+              safePadding: safePadding,
             ),
           ),
 
@@ -477,6 +470,103 @@ class _SpeechBubble extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Overlay that paints a dark scrim with a cutout over the hint button.
+/// Taps inside the cutout pass through to the hint button; taps outside
+/// are absorbed so the player can only interact with the hint.
+///
+/// Uses two layers: a [GestureDetector] that absorbs taps in the scrim area,
+/// and a [Positioned] hole that is ignored by hit-testing so taps fall through
+/// to the hint button underneath the entire overlay.
+class _HintSpotlightOverlay extends StatelessWidget {
+  const _HintSpotlightOverlay({
+    required this.screenSize,
+    required this.safePadding,
+  });
+
+  final Size screenSize;
+  final EdgeInsets safePadding;
+
+  Rect _hintRect(Size size) {
+    final bottom = size.height - safePadding.bottom - 16;
+    const pad = 12.0;
+    return Rect.fromLTRB(
+      safePadding.left + 4,
+      bottom - 44 - pad,
+      size.width * 0.32 + pad,
+      bottom + pad,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = Size(constraints.maxWidth, constraints.maxHeight);
+        final cutout = _hintRect(size);
+        return Stack(
+          children: [
+            // Painted scrim covering the full screen.
+            Positioned.fill(
+              child: CustomPaint(
+                painter: _HintSpotlightPainter(
+                  screenSize: screenSize,
+                  safePadding: safePadding,
+                ),
+              ),
+            ),
+            // Scrim region ABOVE the cutout — absorbs taps.
+            Positioned(
+              left: 0,
+              top: 0,
+              right: 0,
+              bottom: size.height - cutout.top,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {},
+              ),
+            ),
+            // Scrim region BELOW the cutout — absorbs taps.
+            Positioned(
+              left: 0,
+              top: cutout.bottom,
+              right: 0,
+              bottom: 0,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {},
+              ),
+            ),
+            // Scrim region LEFT of the cutout — absorbs taps.
+            Positioned(
+              left: 0,
+              top: cutout.top,
+              width: cutout.left,
+              height: cutout.height,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {},
+              ),
+            ),
+            // Scrim region RIGHT of the cutout — absorbs taps.
+            Positioned(
+              left: cutout.right,
+              top: cutout.top,
+              right: 0,
+              height: cutout.height,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {},
+              ),
+            ),
+            // The cutout area itself has NO gesture detector, so taps
+            // pass through to the hint button underneath.
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/campaign/mission_dialog.dart
+++ b/lib/features/campaign/mission_dialog.dart
@@ -33,18 +33,29 @@ class MissionDialog {
                   // Coach portrait (top-left)
                   _CoachPortrait(coach: mission.coach, size: 56),
                   const SizedBox(width: 12),
-                  // Name and title
+                  // Name, flag, and title
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          mission.coach.name,
-                          style: const TextStyle(
-                            color: FlitColors.textPrimary,
-                            fontSize: 16,
-                            fontWeight: FontWeight.w700,
-                          ),
+                        Row(
+                          children: [
+                            Text(
+                              mission.coach.flagEmoji,
+                              style: const TextStyle(fontSize: 18),
+                            ),
+                            const SizedBox(width: 6),
+                            Expanded(
+                              child: Text(
+                                mission.coach.name,
+                                style: const TextStyle(
+                                  color: FlitColors.textPrimary,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
                         const SizedBox(height: 2),
                         Text(
@@ -57,38 +68,37 @@ class MissionDialog {
                       ],
                     ),
                   ),
-                  // Flag emoji (top-right) + close button
-                  Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      GestureDetector(
-                        onTap: () => Navigator.of(ctx).pop(),
-                        child: Container(
-                          width: 28,
-                          height: 28,
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: FlitColors.backgroundMid,
-                            border: Border.all(
-                              color:
-                                  FlitColors.cardBorder.withValues(alpha: 0.5),
-                            ),
-                          ),
-                          child: const Icon(
-                            Icons.close,
-                            color: FlitColors.textSecondary,
-                            size: 16,
-                          ),
+                  // Close button (top-right)
+                  GestureDetector(
+                    onTap: () => Navigator.of(ctx).pop(),
+                    child: Container(
+                      width: 28,
+                      height: 28,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: FlitColors.backgroundMid,
+                        border: Border.all(
+                          color: FlitColors.cardBorder.withValues(alpha: 0.5),
                         ),
                       ),
-                      const SizedBox(height: 6),
-                      Text(
-                        mission.coach.flagEmoji,
-                        style: const TextStyle(fontSize: 24),
+                      child: const Icon(
+                        Icons.close,
+                        color: FlitColors.textSecondary,
+                        size: 16,
                       ),
-                    ],
+                    ),
                   ),
                 ],
+              ),
+              const SizedBox(height: 8),
+              // Coach bio
+              Text(
+                mission.coach.bio,
+                style: const TextStyle(
+                  color: FlitColors.textSecondary,
+                  fontSize: 12,
+                  height: 1.3,
+                ),
               ),
               const SizedBox(height: 14),
               // Mission title (centered)
@@ -200,13 +210,23 @@ class MissionDialog {
               // Coach portrait
               _CoachPortrait(coach: mission.coach, size: 64),
               const SizedBox(height: 12),
-              Text(
-                mission.coach.name,
-                style: const TextStyle(
-                  color: FlitColors.textPrimary,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w700,
-                ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    mission.coach.flagEmoji,
+                    style: const TextStyle(fontSize: 18),
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    mission.coach.name,
+                    style: const TextStyle(
+                      color: FlitColors.textPrimary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
               ),
               const SizedBox(height: 12),
               // Farewell message

--- a/lib/features/campaign/tutorial_overlay.dart
+++ b/lib/features/campaign/tutorial_overlay.dart
@@ -686,10 +686,12 @@ class _SpotlightPainter extends CustomPainter {
 
       case TutorialTarget.speedControls:
         // Bottom row center: speed pills — centred between hint and altitude.
+        // The HUD Row uses spaceEvenly with 3 items, so the speed control
+        // sits roughly in the center third of the screen.
         return Rect.fromLTRB(
-          size.width * 0.25 - pad,
+          size.width * 0.30 - pad,
           bottom - 48 - pad,
-          size.width * 0.65 + pad,
+          size.width * 0.70 + pad,
           bottom + pad,
         );
 


### PR DESCRIPTION
…-through

- Restore coach bio text in mission briefing dialog (was over-removed)
- Move flag emoji next to coach name (briefing + farewell dialogs)
- Remove separate flag from top-right column, keep only X close button
- Center speed control spotlight in tutorial overlay (0.30–0.70 range)
- Fix hint spotlight blocking taps: split overlay into 4 absorber regions around the cutout so taps inside the cutout pass through to the hint button

https://claude.ai/code/session_01ERFrwcjyUS82eUg2W4KGrr