### PR TITLE
perf: fix laggy descent mode map rendering

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -965,9 +965,17 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
         _timer?.cancel();
         _timer = Timer.periodic(const Duration(milliseconds: 16), (_) async {
           if (mounted && _session != null && !_session!.isCompleted) {
-            setState(() {
-              _elapsed = _session!.elapsed;
-            });
+            final newElapsed = _session!.elapsed;
+            // Only rebuild when displayed centisecond changes — avoids
+            // unconditional setState at 60 Hz (matches first timer logic).
+            if (newElapsed.inMilliseconds ~/ 100 !=
+                _elapsed.inMilliseconds ~/ 100) {
+              setState(() {
+                _elapsed = newElapsed;
+              });
+            } else {
+              _elapsed = newElapsed;
+            }
             if (_elapsed.inMilliseconds % 100 < 20) {
               _session!.recordPosition(_game.worldPosition);
             }
@@ -1778,12 +1786,14 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
             // the game canvas. Centered on the region, zoom fits the region.
             if (_gameReady && _session != null && _game.isFlatMapMode)
               Positioned.fill(
-                child: DescentMapView(
-                  centerLng: widget.region.center.x,
-                  centerLat: widget.region.center.y,
-                  heading: 0, // No rotation for flat map
-                  altitudeTransition: _flatMapZoom,
-                  tileUrl: GameSettings.instance.mapTileUrl,
+                child: RepaintBoundary(
+                  child: DescentMapView(
+                    centerLng: widget.region.center.x,
+                    centerLat: widget.region.center.y,
+                    heading: 0, // No rotation for flat map
+                    altitudeTransition: _flatMapZoom,
+                    tileUrl: GameSettings.instance.mapTileUrl,
+                  ),
                 ),
               )
             // Globe mode — OSM tile map shown during descent transition.
@@ -1794,18 +1804,21 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
                 _session != null &&
                 (_game.plane.continuousAltitude < 0.6 || _descentMapMounted))
               Positioned.fill(
-                child: Offstage(
-                  offstage: _game.plane.continuousAltitude >= 0.6,
+                child: Visibility(
+                  visible: _game.plane.continuousAltitude < 0.6,
+                  maintainState: true, // Keep alive to preserve tile cache
                   child: Opacity(
                     opacity: (1.0 - _game.plane.continuousAltitude / 0.6)
                         .clamp(0.0, 1.0),
-                    child: DescentMapView(
-                      centerLng: _game.worldPosition.x,
-                      centerLat: _game.worldPosition.y,
-                      heading: _game.cameraHeadingBearing,
-                      altitudeTransition: _game.plane.continuousAltitude,
-                      tileUrl: GameSettings.instance.mapTileUrl,
-                      trackPlane: true,
+                    child: RepaintBoundary(
+                      child: DescentMapView(
+                        centerLng: _game.worldPosition.x,
+                        centerLat: _game.worldPosition.y,
+                        heading: _game.cameraHeadingBearing,
+                        altitudeTransition: _game.plane.continuousAltitude,
+                        tileUrl: GameSettings.instance.mapTileUrl,
+                        trackPlane: true,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/game/map/descent_map_view.dart
+++ b/lib/game/map/descent_map_view.dart
@@ -125,9 +125,10 @@ class _DescentMapViewState extends State<DescentMapView> {
     final zoomDelta = (zoom - _lastZoom).abs();
     final rotDelta = (rotation - _lastRotation).abs();
 
-    final needsMove =
-        latDelta > 0.0001 || lngDelta > 0.0001 || zoomDelta > 0.01;
-    final needsRotate = rotDelta > 0.1;
+    // At zoom 7, 0.001° ≈ 111m — visually smooth at flight speed but
+    // reduces expensive mapController.move() calls by ~10x.
+    final needsMove = latDelta > 0.001 || lngDelta > 0.001 || zoomDelta > 0.05;
+    final needsRotate = rotDelta > 0.5;
 
     if (needsMove) {
       _mapController.move(center, zoom);


### PR DESCRIPTION
- Fix second round timer calling setState unconditionally at 60 Hz (was missing the throttle logic the first timer already had)
- Wrap DescentMapView in RepaintBoundary to isolate from parent repaints
- Replace Offstage+Opacity with Visibility (maintainState) so the map skips layout/paint entirely when hidden at high altitude
- Increase didUpdateWidget throttle thresholds (0.0001° → 0.001°, rotation 0.1° → 0.5°) to reduce expensive mapController.move() calls by ~10x while remaining visually smooth at flight speed

https://claude.ai/code/session_012GiuLDmoaNyQ1usLH58moN