### PR TITLE
Add deterministic start positions and headings to campaign missions

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -593,12 +593,20 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
       final mission = widget.campaignMission!;
       final baseSeed = mission.id.hashCode;
       final roundSeed = baseSeed + (_currentRound - 1) * 7919;
+      // Only override start position on round 1 — subsequent rounds continue
+      // seamlessly from the plane's current position via continueWithNewTarget.
+      final overrideStart = (_currentRound == 1 &&
+              mission.startLat != null &&
+              mission.startLng != null)
+          ? Vector2(mission.startLng!, mission.startLat!)
+          : null;
       return GameSession.seeded(
         roundSeed,
         allowedClueTypes: widget.enabledClueTypes,
         preferredClueType: widget.preferredClueType,
         maxDifficulty: mission.maxDifficulty,
         targetCountryCodes: mission.targetCountryCodes,
+        overrideStartPosition: overrideStart,
       );
     }
     if (widget.region == GameRegion.world) {
@@ -681,6 +689,7 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
         startPosition: _session!.startPosition,
         targetPosition: _session!.targetPosition,
         clue: _session!.clue.displayText,
+        heading: widget.campaignMission?.startHeading,
       );
 
       // Configure fuel system.

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -1675,6 +1675,7 @@ class FlitGame extends FlameGame
     required Vector2 startPosition,
     required Vector2 targetPosition,
     required String clue,
+    double? heading,
   }) {
     _log.info(
       'game',
@@ -1690,9 +1691,14 @@ class FlitGame extends FlameGame
     // startPosition is already (lng, lat) degrees — use directly
     _worldPosition = startPosition.clone();
 
-    // Random initial heading so the player doesn't start facing the target.
-    final rng = Random();
-    _heading = (rng.nextDouble() * 2 * pi) - pi;
+    // Use the provided heading or pick a random one so the player doesn't
+    // start facing the target by accident.
+    if (heading != null) {
+      _heading = heading;
+    } else {
+      final rng = Random();
+      _heading = (rng.nextDouble() * 2 * pi) - pi;
+    }
     _cameraHeading = _heading; // snap camera to heading on game start
     _cameraFirstUpdate = true;
     _plane.fadeIn(); // Start invisible during positioning phase

--- a/lib/game/session/game_session.dart
+++ b/lib/game/session/game_session.dart
@@ -285,6 +285,7 @@ class GameSession {
     Set<String>? allowedClueTypes,
     double? maxDifficulty,
     List<String>? targetCountryCodes,
+    Vector2? overrideStartPosition,
   }) {
     final random = Random(seed);
 
@@ -322,14 +323,15 @@ class GameSession {
       random: random,
     );
 
-    // Generate start position based on seed
+    // Generate start position based on seed, or use the override if provided.
     final startLng = (random.nextDouble() * 360) - 180;
     final startLat = (random.nextDouble() * 140) - 70;
+    final startPos = overrideStartPosition ?? Vector2(startLng, startLat);
 
     return GameSession(
       targetCountry: country,
       clue: clue,
-      startPosition: Vector2(startLng, startLat),
+      startPosition: startPos,
     );
   }
 }

--- a/lib/game/tutorial/campaign_mission.dart
+++ b/lib/game/tutorial/campaign_mission.dart
@@ -35,6 +35,9 @@ class CampaignMission {
     this.coinReward = 50,
     this.unlockMessage,
     this.tips = const [],
+    this.startLat,
+    this.startLng,
+    this.startHeading,
   });
 
   final String id;
@@ -52,6 +55,16 @@ class CampaignMission {
   final int coinReward;
   final String? unlockMessage;
   final List<CoachTip> tips;
+
+  /// Fixed starting latitude (degrees). When null, the session picks randomly.
+  final double? startLat;
+
+  /// Fixed starting longitude (degrees). When null, the session picks randomly.
+  final double? startLng;
+
+  /// Fixed starting heading (radians, 0 = east, π/2 = north). When null,
+  /// the game picks a random heading.
+  final double? startHeading;
 }
 
 /// Result of completing a campaign mission.

--- a/lib/game/tutorial/campaign_missions.dart
+++ b/lib/game/tutorial/campaign_missions.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import '../clues/clue_types.dart';
 import 'campaign_mission.dart';
 import 'coach.dart';
@@ -38,6 +40,10 @@ const List<CampaignMission> campaignMissions = [
     fuelEnabled: false,
     xpReward: 50,
     coinReward: 25,
+    // Start over the Mediterranean, facing east toward India.
+    startLat: 35.0,
+    startLng: 15.0,
+    startHeading: 0, // east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -91,6 +97,10 @@ const List<CampaignMission> campaignMissions = [
     fuelEnabled: false,
     xpReward: 100,
     coinReward: 75,
+    // Start over the North Atlantic, facing east — US then GB then Egypt.
+    startLat: 45.0,
+    startLng: -40.0,
+    startHeading: 0, // east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -158,6 +168,10 @@ const List<CampaignMission> campaignMissions = [
     fuelEnabled: false,
     xpReward: 100,
     coinReward: 75,
+    // Start over the South Atlantic, facing east — AU, then ZA, then BR.
+    startLat: 0.0,
+    startLng: -30.0,
+    startHeading: 0, // east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -223,6 +237,10 @@ const List<CampaignMission> campaignMissions = [
     fuelEnabled: false,
     xpReward: 125,
     coinReward: 100,
+    // Start over the North Atlantic, facing east — FR first.
+    startLat: 50.0,
+    startLng: -20.0,
+    startHeading: 0, // east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -288,6 +306,10 @@ const List<CampaignMission> campaignMissions = [
     fuelEnabled: true,
     xpReward: 125,
     coinReward: 100,
+    // Start over the North Atlantic heading north-east toward Iceland.
+    startLat: 52.0,
+    startLng: -30.0,
+    startHeading: -pi / 4, // north-east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -359,6 +381,10 @@ const List<CampaignMission> campaignMissions = [
     xpReward: 200,
     coinReward: 150,
     unlockMessage: 'Daily Briefing unlocked!',
+    // Start over the Atlantic west of the Sahara, facing east.
+    startLat: 25.0,
+    startLng: -25.0,
+    startHeading: 0, // east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -450,6 +476,10 @@ const List<CampaignMission> campaignMissions = [
     fuelEnabled: true,
     xpReward: 100,
     coinReward: 75,
+    // Start over the Caribbean, facing south toward Peru.
+    startLat: 20.0,
+    startLng: -70.0,
+    startHeading: pi / 2, // south
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -500,6 +530,10 @@ const List<CampaignMission> campaignMissions = [
     fuelEnabled: true,
     xpReward: 100,
     coinReward: 75,
+    // Start over Central Africa, facing east toward Kenya.
+    startLat: 5.0,
+    startLng: 20.0,
+    startHeading: 0, // east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -550,6 +584,10 @@ const List<CampaignMission> campaignMissions = [
     xpReward: 125,
     coinReward: 100,
     unlockMessage: 'Daily Challenge unlocked!',
+    // Start over the southern US, facing south toward Mexico.
+    startLat: 35.0,
+    startLng: -95.0,
+    startHeading: pi / 2, // south
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -601,6 +639,10 @@ const List<CampaignMission> campaignMissions = [
     fuelEnabled: true,
     xpReward: 125,
     coinReward: 100,
+    // Start over the eastern Mediterranean, facing south-east toward Arabia.
+    startLat: 38.0,
+    startLng: 25.0,
+    startHeading: pi / 4, // south-east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -652,6 +694,10 @@ const List<CampaignMission> campaignMissions = [
     xpReward: 150,
     coinReward: 100,
     unlockMessage: 'Dogfight unlocked!',
+    // Start over the Bay of Bengal, facing east toward the Philippines.
+    startLat: 15.0,
+    startLng: 90.0,
+    startHeading: 0, // east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -703,6 +749,10 @@ const List<CampaignMission> campaignMissions = [
     fuelEnabled: true,
     xpReward: 200,
     coinReward: 150,
+    // Start over the Indian Ocean, facing east toward Indonesia.
+    startLat: -5.0,
+    startLng: 80.0,
+    startHeading: 0, // east
     tips: [
       CoachTip(
         trigger: 'firstClue',
@@ -755,6 +805,10 @@ const List<CampaignMission> campaignMissions = [
     xpReward: 250,
     coinReward: 200,
     unlockMessage: 'All game modes unlocked! Fly safe, ace.',
+    // Start over the open Caribbean, facing east toward Barbados.
+    startLat: 15.0,
+    startLng: -70.0,
+    startHeading: 0, // east
     tips: [
       CoachTip(
         trigger: 'firstClue',


### PR DESCRIPTION
Cherry-picked from stale branch claude/add-geography-clues-si2KG. Each campaign mission now has optional startLat, startLng, and startHeading fields so round 1 begins at a sensible geographic position (e.g. over the Mediterranean facing east for the Europe mission) instead of a random location.

https://claude.ai/code/session_01K1L9xhmRF4AF9SCqHnMVs4