### PR TITLE
Fix Liechtenstein bounding box and capital dot placement

### DIFF
--- a/lib/game/quiz/border_smoothing.dart
+++ b/lib/game/quiz/border_smoothing.dart
@@ -61,7 +61,6 @@ const Set<String> alwaysTinyCodes = {
   'MC', // Monaco (2.0 km²)
   'SM', // San Marino (61 km²)
   'VA', // Vatican City (0.44 km²)
-  'LI', // Liechtenstein (160 km²)
 
   // City-states
   'SG', // Singapore (733 km²)

--- a/lib/game/quiz/uncharted_map_widget.dart
+++ b/lib/game/quiz/uncharted_map_widget.dart
@@ -647,15 +647,20 @@ class _UnchartedMapPainter extends CustomPainter {
     final fontSize = (10.0 / zoomScale).clamp(3.0, 14.0);
 
     if (capitalsMode && area.capital != null) {
-      // Capitals mode: red dot + "CapitalName (CC)"
+      // Capitals mode: red dot at actual capital city coordinates.
+      // Look up real lat/lon from CityData; fall back to polygon centroid.
+      final capitalCity = CountryData.getCapital(area.code);
+      final dotPos = capitalCity != null
+          ? transform.toCanvas(capitalCity.location.x, capitalCity.location.y)
+          : centroid;
       final dotRadius = (3.0 / zoomScale).clamp(1.0, 5.0);
       canvas.drawCircle(
-        centroid,
+        dotPos,
         dotRadius,
         Paint()..color = const Color(0xFFE74C3C),
       );
       canvas.drawCircle(
-        centroid,
+        dotPos,
         dotRadius,
         Paint()
           ..color = const Color(0xFFFFFFFF)
@@ -682,8 +687,8 @@ class _UnchartedMapPainter extends CustomPainter {
 
       // Offset text to the right of the dot.
       final textOffset = Offset(
-        centroid.dx + dotRadius + 3.0 / zoomScale,
-        centroid.dy - textPainter.height / 2,
+        dotPos.dx + dotRadius + 3.0 / zoomScale,
+        dotPos.dy - textPainter.height / 2,
       );
       textPainter.paint(canvas, textOffset);
     } else {


### PR DESCRIPTION
1. Remove Liechtenstein from alwaysTinyCodes - at 160 km² it's large enough to render as a proper polygon, not a tiny dot marker.

2. Fix capital city red dots to use actual lat/lon coordinates from CountryData.getCapital() instead of polygon centroid average. The centroid of polygon vertices placed capitals in wrong locations (e.g. Paris appeared in Spain due to overseas territories skewing the average). Falls back to centroid when no CityData entry exists.

https://claude.ai/code/session_016WaRy5JWxM65CFtZGqUZoT