### PR TITLE
Add proficiency percentage to score share text

### DIFF
--- a/lib/data/models/daily_result.dart
+++ b/lib/data/models/daily_result.dart
@@ -132,6 +132,27 @@ class DailyResult {
   /// Challenge theme title (e.g. "Flag Frenzy").
   final String theme;
 
+  /// Proficiency as a percentage of the maximum possible score.
+  ///
+  /// For each played round: max = (10,000 × difficultyMultiplier).
+  /// Unplayed rounds contribute 10,000 to the denominator (difficulty unknown).
+  int get proficiencyPercent {
+    int maxPossible = 0;
+    for (final round in rounds) {
+      if (round.countryCode.isNotEmpty) {
+        maxPossible +=
+            (10000 * difficultyMultiplier(round.countryCode)).round();
+      } else {
+        maxPossible += 10000;
+      }
+    }
+    // Unplayed rounds penalise proficiency (score 0, max 10,000 each).
+    final unplayed = totalRounds - rounds.length;
+    if (unplayed > 0) maxPossible += unplayed * 10000;
+    if (maxPossible == 0) return 0;
+    return ((totalScore / maxPossible) * 100).round().clamp(0, 100);
+  }
+
   /// Generate the Wordle-style shareable text.
   ///
   /// Example output:
@@ -140,17 +161,20 @@ class DailyResult {
   /// Flit daily challenge!
   /// 🟢🟡🟠🟢🔴
   /// Score: 34,655 pts
+  /// Proficiency: 94%
   /// Time: 4m30s
   /// ```
   String toShareText() {
     final emojiRow = _buildEmojiRow();
     final scoreFormatted = formatScore(totalScore);
     final timeFormatted = formatTime(totalTimeMs);
+    final pct = proficiencyPercent;
 
     return '     \u{1F6EB} \u{1F30D} \u{1F6EC}\n'
         'Flit daily challenge!\n'
         '$emojiRow\n'
         'Score: $scoreFormatted pts\n'
+        'Proficiency: $pct%\n'
         'Time: $timeFormatted';
   }
 

--- a/lib/data/services/leaderboard_service.dart
+++ b/lib/data/services/leaderboard_service.dart
@@ -245,7 +245,7 @@ class LeaderboardService {
       final data = await _client
           .from('scores')
           .select(
-            'score, time_ms, region, rounds_completed, round_emojis, created_at',
+            'score, time_ms, region, rounds_completed, round_emojis, round_details, created_at',
           )
           .eq('user_id', userId)
           .order('created_at', ascending: false)

--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -20,6 +20,7 @@ import '../avatar/avatar_widget.dart';
 import '../license/license_screen.dart';
 import '../../core/widgets/social_titles_card.dart';
 import '../../data/services/leaderboard_service.dart';
+import '../../game/data/country_difficulty.dart';
 
 /// Aviation rank title and icon for player level.
 ({String title, IconData icon}) _aviationRank(int level) {
@@ -1987,6 +1988,7 @@ class _GameHistoryEntry {
     required this.date,
     required this.roundsCompleted,
     this.roundEmojis,
+    this.maxPossibleScore,
   });
 
   final String region;
@@ -1996,15 +1998,28 @@ class _GameHistoryEntry {
   final int roundsCompleted;
   final String? roundEmojis;
 
+  /// Sum of (10,000 × difficultyMultiplier) for each round; null if unknown.
+  final int? maxPossibleScore;
+
+  /// Proficiency as a percentage (0–100), or null if max score is unknown.
+  int? get proficiencyPercent {
+    final max = maxPossibleScore;
+    if (max == null || max == 0) return null;
+    return ((score / max) * 100).round().clamp(0, 100);
+  }
+
   /// Generate shareable result text for socials.
   String toShareText() {
     final timeFormatted = _formatShareTime(duration);
     final scoreFormatted = _formatShareScore(score);
     final regionLabel = region[0].toUpperCase() + region.substring(1);
+    final pct = proficiencyPercent;
+    final proficiencyLine = pct != null ? 'Proficiency: $pct%\n' : '';
     return '     \u{1F6EB} \u{1F30D} \u{1F6EC}\n'
         'Flit — $regionLabel\n'
         '$clueEmojiRow\n'
         'Score: $scoreFormatted pts\n'
+        '$proficiencyLine'
         'Time: $timeFormatted\n'
         'Rounds: $roundsCompleted';
   }
@@ -2080,6 +2095,22 @@ class _GameHistoryScreenState extends ConsumerState<_GameHistoryScreen> {
             final createdAt = entry['created_at'];
             // Skip entries with missing required fields instead of crashing.
             if (timeMs == null || score == null || createdAt == null) continue;
+            final roundDetails = entry['round_details'] as List<dynamic>?;
+            int? maxPossible;
+            if (roundDetails != null && roundDetails.isNotEmpty) {
+              maxPossible = 0;
+              for (final rd in roundDetails) {
+                final code =
+                    (rd as Map<dynamic, dynamic>)['country_code'] as String? ??
+                        '';
+                if (code.isNotEmpty) {
+                  maxPossible = maxPossible! +
+                      (10000 * difficultyMultiplier(code)).round();
+                } else {
+                  maxPossible = maxPossible! + 10000;
+                }
+              }
+            }
             parsed.add(
               _GameHistoryEntry(
                 region: (entry['region'] as String?) ?? 'World',
@@ -2091,6 +2122,7 @@ class _GameHistoryScreenState extends ConsumerState<_GameHistoryScreen> {
                 date: DateTime.parse(createdAt as String),
                 roundsCompleted: (entry['rounds_completed'] as int?) ?? 0,
                 roundEmojis: entry['round_emojis'] as String?,
+                maxPossibleScore: maxPossible,
               ),
             );
           } catch (e) {

--- a/test/unit/data/models/daily_result_test.dart
+++ b/test/unit/data/models/daily_result_test.dart
@@ -2,6 +2,84 @@ import 'package:flit/data/models/daily_result.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('DailyResult proficiencyPercent', () {
+    test('returns 100 for perfect score with no country code', () {
+      const round = DailyRoundResult(
+        hintsUsed: 0,
+        completed: true,
+        timeMs: 5000, // ≤10s → no time penalty
+        score: 10000,
+      );
+      final result = DailyResult(
+        date: '2026-01-01',
+        rounds: [round],
+        totalScore: 10000,
+        totalTimeMs: 5000,
+        totalRounds: 1,
+        theme: 'Test',
+      );
+      expect(result.proficiencyPercent, 100);
+    });
+
+    test('returns 0 for empty rounds', () {
+      final result = DailyResult(
+        date: '2026-01-01',
+        rounds: [],
+        totalScore: 0,
+        totalTimeMs: 0,
+        totalRounds: 0,
+        theme: 'Test',
+      );
+      expect(result.proficiencyPercent, 0);
+    });
+
+    test('penalises unplayed rounds', () {
+      const round = DailyRoundResult(
+        hintsUsed: 0,
+        completed: true,
+        timeMs: 5000,
+        score: 10000,
+      );
+      // 1 round played (max 10000), 1 unplayed (max 10000) → max total 20000
+      final result = DailyResult(
+        date: '2026-01-01',
+        rounds: [round],
+        totalScore: 10000,
+        totalTimeMs: 5000,
+        totalRounds: 2,
+        theme: 'Test',
+      );
+      expect(result.proficiencyPercent, 50);
+    });
+
+    test('toShareText includes Proficiency line', () {
+      const round = DailyRoundResult(
+        hintsUsed: 0,
+        completed: true,
+        timeMs: 5000,
+        score: 10000,
+      );
+      final result = DailyResult(
+        date: '2026-01-01',
+        rounds: [round],
+        totalScore: 10000,
+        totalTimeMs: 5000,
+        totalRounds: 1,
+        theme: 'Test',
+      );
+      final text = result.toShareText();
+      expect(text, contains('Proficiency: 100%'));
+      expect(text, contains('Score: 10,000 pts'));
+      expect(text, contains('Time: 5s'));
+      // Proficiency line appears between score and time
+      final scoreIdx = text.indexOf('Score:');
+      final profIdx = text.indexOf('Proficiency:');
+      final timeIdx = text.indexOf('Time:');
+      expect(profIdx, greaterThan(scoreIdx));
+      expect(timeIdx, greaterThan(profIdx));
+    });
+  });
+
   group('DailyRoundResult emoji mapping', () {
     test('uses 0=green, 1-2=yellow, 3-4=orange, 5+=red', () {
       const zeroHints = DailyRoundResult(


### PR DESCRIPTION
Introduces a proficiency score (actual / max possible) wherever game results are shared. Max possible per round is 10,000 × the country's difficulty multiplier; unplayed rounds use 10,000.

- DailyResult: adds proficiencyPercent getter and includes "Proficiency: X%" between Score and Time in toShareText()
- _GameHistoryEntry: derives maxPossibleScore from round_details country codes (computed client-side, no schema change required) and conditionally includes proficiency in toShareText()
- LeaderboardService.fetchGameHistory: adds round_details to the select query so client-side proficiency can be computed
- 4 new unit tests covering the proficiency calculation and share text ordering

https://claude.ai/code/session_01EeisTD1Mds1YsUYkeDbA86