### PR TITLE
Cache-bust favicon/app-icon URLs so the new icon actually shows

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -12,17 +12,20 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Flit">
-  <link rel="apple-touch-icon" href="icons/Icon-apple-touch-180.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="icons/Icon-apple-touch-180.png">
-  <link rel="apple-touch-icon" sizes="192x192" href="icons/Icon-192.png">
-  <link rel="apple-touch-icon" sizes="512x512" href="icons/Icon-512.png">
+  <!-- Icon URLs carry a ?v= version token so browsers/iOS re-fetch the new
+       artwork instead of serving a long-cached old favicon. Bump on redesign. -->
+  <link rel="apple-touch-icon" href="icons/Icon-apple-touch-180.png?v=2">
+  <link rel="apple-touch-icon" sizes="180x180" href="icons/Icon-apple-touch-180.png?v=2">
+  <link rel="apple-touch-icon" sizes="192x192" href="icons/Icon-192.png?v=2">
+  <link rel="apple-touch-icon" sizes="512x512" href="icons/Icon-512.png?v=2">
 
   <!-- PWA manifest -->
   <link rel="manifest" href="manifest.json">
 
   <!-- Favicons -->
-  <link rel="icon" type="image/png" sizes="32x32" href="favicon.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="icons/Icon-192.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon.png?v=2">
+  <link rel="icon" type="image/png" sizes="192x192" href="icons/Icon-192.png?v=2">
+  <link rel="shortcut icon" href="favicon.png?v=2">
 
   <!-- Viewport for mobile -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -9,23 +9,23 @@
   "theme_color": "#1A2A32",
   "icons": [
     {
-      "src": "icons/Icon-192.png",
+      "src": "icons/Icon-192.png?v=2",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "icons/Icon-512.png",
+      "src": "icons/Icon-512.png?v=2",
       "sizes": "512x512",
       "type": "image/png"
     },
     {
-      "src": "icons/Icon-maskable-192.png",
+      "src": "icons/Icon-maskable-192.png?v=2",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "icons/Icon-maskable-512.png",
+      "src": "icons/Icon-maskable-512.png?v=2",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"


### PR DESCRIPTION
## Summary

The new dark-globe icon PNGs are already live in `main`, but browsers and iOS cache favicons **by URL** and very aggressively — so the old icon kept appearing in the browser tab even after the redesign deployed, because the `<link>`/manifest URLs were unchanged.

This adds a `?v=2` cache-busting version token to **every** icon reference so each surface re-fetches the new artwork:

- `web/index.html` — favicon (`rel="icon"`), all `apple-touch-icon` links, plus a new explicit `rel="shortcut icon"` for older browsers
- `web/manifest.json` — all PWA icon `src` entries (192, 512, maskable 192/512)

## Notes

- Bump the token (`?v=3`, …) on any future icon redesign to force the refresh again.
- **To see it immediately:** browser — hard-refresh; iOS homescreen — remove the saved shortcut and re-add via Safari → Share → Add to Home Screen.
- The actual icon images were already updated/derived from the supplied artwork in the previous change; this PR only fixes cache invalidation so they actually show.

## Remaining old-globe artifacts (not shipped here)
Two **unused** source files still depict the old globe but are not referenced or bundled anywhere (verified: not in `pubspec.yaml` assets, not referenced in code/HTML):
- `web/icons/icon-source.svg` (old teal biplane vector)
- `assets/images/logo.svg` (old globe + "FLIT" wordmark)

They don't render anywhere, so I left them rather than delete files I didn't author. Happy to remove or refresh them on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5)_