### PR TITLE
Reconcile daily streak across devices instead of overwriting on load

### DIFF
--- a/lib/data/providers/account_provider.dart
+++ b/lib/data/providers/account_provider.dart
@@ -374,9 +374,12 @@ class AccountNotifier extends StateNotifier<AccountState> {
     // Coins are consumable (server-authoritative), so they are NOT protected.
     // Admin overrides bypass this protection entirely.
     final local = state.currentPlayer;
-    final player = (!adminOverride &&
-            local.id.isNotEmpty &&
-            local.id == serverPlayer.id)
+    // Same authenticated user as the in-memory state (not a fresh login or an
+    // admin override) — safe to merge in-memory/local progress with the server
+    // copy instead of letting the snapshot overwrite it.
+    final sameUser =
+        !adminOverride && local.id.isNotEmpty && local.id == serverPlayer.id;
+    final player = sameUser
         ? serverPlayer.copyWith(
             gamesPlayed: math.max(local.gamesPlayed, serverPlayer.gamesPlayed),
             countriesFound: math.max(
@@ -422,6 +425,16 @@ class AccountNotifier extends StateNotifier<AccountState> {
           )
         : serverPlayer;
 
+    // Reconcile the daily-challenge streak the same way the player stats above
+    // are protected: a stale server snapshot must not clobber streak progress
+    // this session made while briefly unauthenticated (sync writes are dropped
+    // until [_supabaseLoaded]). Take the union — the most recent completion
+    // wins the current run; all-time fields are monotonic.
+    final serverDailyStreak = snapshot.toDailyStreak();
+    final reconciledDailyStreak = sameUser
+        ? _reconcileDailyStreak(state.dailyStreak, serverDailyStreak)
+        : serverDailyStreak;
+
     state = AccountState(
       currentPlayer: player,
       avatar: snapshot.toAvatarConfig(),
@@ -434,7 +447,7 @@ class AccountNotifier extends StateNotifier<AccountState> {
       equippedTitleId: snapshot.equippedTitleId,
       lastFreeRerollDate: snapshot.lastFreeRerollDate,
       lastDailyChallengeDate: snapshot.lastDailyChallengeDate,
-      dailyStreak: snapshot.toDailyStreak(),
+      dailyStreak: reconciledDailyStreak,
       lastDailyResult: snapshot.toLastDailyResult(),
       freeFlightCoinsToday: snapshot.freeFlightCoinsToday,
       freeFlightCoinDate: snapshot.freeFlightCoinDate,
@@ -446,6 +459,15 @@ class AccountNotifier extends StateNotifier<AccountState> {
     // Mark Supabase data as loaded — enables writes. Must happen AFTER
     // state is set so the first write contains real data, not defaults.
     _supabaseLoaded = true;
+
+    // If reconciliation kept progress the server snapshot lacked (e.g. a daily
+    // completed during a brief unauthenticated window on this device), push the
+    // merged streak back so every device converges on the union instead of
+    // diverging permanently.
+    if (sameUser &&
+        _dailyStreakChanged(reconciledDailyStreak, serverDailyStreak)) {
+      _syncAccountState();
+    }
 
     // Only hydrate GameSettings on initial load. On subsequent refreshes,
     // skip this to avoid overwriting local settings with stale server data
@@ -475,6 +497,62 @@ class AccountNotifier extends StateNotifier<AccountState> {
       );
     }
   }
+
+  /// Merge two daily-streak snapshots without losing progress.
+  ///
+  /// All-time fields ([DailyStreak.longestStreak], [DailyStreak.totalCompleted])
+  /// are monotonic — keep the max. The current run ([DailyStreak.currentStreak]
+  /// + [DailyStreak.lastCompletionDate]) is tied to the most recent completion,
+  /// so the side with the later date wins; on a tie keep the larger streak.
+  static DailyStreak _reconcileDailyStreak(
+    DailyStreak local,
+    DailyStreak server,
+  ) {
+    final longest = math.max(local.longestStreak, server.longestStreak);
+    final total = math.max(local.totalCompleted, server.totalCompleted);
+
+    final cmp = _compareCompletionDates(
+      local.lastCompletionDate,
+      server.lastCompletionDate,
+    );
+    final int currentStreak;
+    final String? lastDate;
+    if (cmp > 0) {
+      currentStreak = local.currentStreak;
+      lastDate = local.lastCompletionDate;
+    } else if (cmp < 0) {
+      currentStreak = server.currentStreak;
+      lastDate = server.lastCompletionDate;
+    } else {
+      currentStreak = math.max(local.currentStreak, server.currentStreak);
+      lastDate = local.lastCompletionDate ?? server.lastCompletionDate;
+    }
+
+    return DailyStreak(
+      currentStreak: currentStreak,
+      longestStreak: longest,
+      lastCompletionDate: lastDate,
+      totalCompleted: total,
+    );
+  }
+
+  /// Compare two `YYYY-MM-DD` completion dates. Returns >0 when [a] is more
+  /// recent, <0 when older, 0 when equal. A null date (never completed) is
+  /// treated as the oldest possible value.
+  static int _compareCompletionDates(String? a, String? b) {
+    if (a == b) return 0;
+    if (a == null) return -1;
+    if (b == null) return 1;
+    return a.compareTo(b);
+  }
+
+  /// Whether [merged] differs from the [server] snapshot in any field — i.e.
+  /// reconciliation preserved local progress that should be pushed back.
+  static bool _dailyStreakChanged(DailyStreak merged, DailyStreak server) =>
+      merged.currentStreak != server.currentStreak ||
+      merged.longestStreak != server.longestStreak ||
+      merged.lastCompletionDate != server.lastCompletionDate ||
+      merged.totalCompleted != server.totalCompleted;
 
   static int? _maxNullable(int? a, int? b) {
     if (a == null) return b;


### PR DESCRIPTION
## Problem

Daily-challenge streaks could diverge between platforms — e.g. the **web browser** session and the **installed iOS homescreen PWA** showing different streaks (the home banner's "N day streak / Best: N / N dailies played" = `DailyStreak.currentStreak` / `longestStreak` / `totalCompleted`).

## Root cause

Two compounding issues in `lib/data/providers/account_provider.dart`:

1. **No merge on load.** `_applySnapshot` took `dailyStreak` straight from the server snapshot, overwriting in-memory/local progress — even though the player's monotonic stats right above it (`gamesPlayed`, `bestStreak`, …) already `math.max`-merge local vs server. So a stale snapshot clobbered a streak this session had advanced.
2. **Dropped writes while unauthenticated.** `_syncProfile`/`_syncAccountState` intentionally no-op until `_supabaseLoaded` (this guard prevents a known license-reset bug where default data is persisted before the real load). On iOS Safari PWA cold start the auth token is often still refreshing, so a daily completed in that window never reached Supabase — and was then overwritten on the eventual load.

## Fix

- **Reconcile the daily streak on load** (`_reconcileDailyStreak`): the side with the more recent `lastCompletionDate` wins the current run; `longestStreak`/`totalCompleted` take the max. The merge is **monotonic — it never loses progress**.
- **Push the union back** when reconciliation preserved progress the server lacked, so every device converges instead of diverging permanently.
- The `_supabaseLoaded` write guard is **left intact** (no regression of the license-reset fix).

Mirrors the existing player-stat merge pattern, so it's consistent with how the rest of account state is protected.

## Validation
- `flutter analyze lib/data/providers/account_provider.dart lib/data/models/daily_streak.dart` → **No issues found.**
- Pure reconciliation logic; no schema or API changes.

## Note
If the divergence is instead because you're **signed into different accounts** (or not signed in) on the two platforms, no server reconciliation can merge them — they're separate accounts. This fix covers the same-account case. Let me know if you'd like a "sign in to sync" affordance for the not-signed-in case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5)_