### PR TITLE
Seasonal events: distinct themed vehicles (all 6) + admin preview

### DIFF
--- a/lib/data/models/seasonal_theme.dart
+++ b/lib/data/models/seasonal_theme.dart
@@ -179,6 +179,25 @@ class SeasonalTheme {
     return null;
   }
 
+  // ── Plane colour-scheme resolver ────────────────────────────────────
+
+  /// Returns the active seasonal event's vehicle colour scheme when an event
+  /// is active, otherwise returns [fallback] unchanged.
+  ///
+  /// Drop-in replacement for `plane?.colorScheme` at every game-launch site so
+  /// that all modes consistently pick up seasonal colours with zero duplication.
+  ///
+  /// NOTE: This overrides the *colour scheme* only. The seasonal vehicle
+  /// *shape* (e.g. an actual sleigh/broom silhouette) is not yet applied here —
+  /// only the palette is swapped. Shape overrides are a future TODO.
+  static Map<String, int>? resolvePlaneColorScheme({
+    required Map<String, int>? fallback,
+    DateTime? now,
+  }) {
+    final theme = now != null ? forDate(now) : current();
+    return theme?.vehicleColorScheme ?? fallback;
+  }
+
   // ── Serialisation ───────────────────────────────────────────────────
 
   Map<String, dynamic> toJson() => {

--- a/lib/data/models/seasonal_theme.dart
+++ b/lib/data/models/seasonal_theme.dart
@@ -232,13 +232,17 @@ class SeasonalTheme {
       case SeasonalEvent.summer:
         return 'plane_hang_glider';
       case SeasonalEvent.christmas:
+        return 'plane_santa_sleigh';
       case SeasonalEvent.halloween:
+        return 'plane_witch_broom';
       case SeasonalEvent.easter:
+        return 'plane_easter_carriage';
       case SeasonalEvent.valentines:
+        return 'plane_cupid_arrow';
       case SeasonalEvent.stPatricks:
+        return 'plane_clover_copter';
       case SeasonalEvent.none:
-        // No bespoke shape yet — keep the player's equipped silhouette while
-        // still applying the seasonal palette via resolvePlaneColorScheme.
+        // No seasonal event active — keep the player's equipped silhouette.
         return null;
     }
   }

--- a/lib/data/models/seasonal_theme.dart
+++ b/lib/data/models/seasonal_theme.dart
@@ -187,15 +187,60 @@ class SeasonalTheme {
   /// Drop-in replacement for `plane?.colorScheme` at every game-launch site so
   /// that all modes consistently pick up seasonal colours with zero duplication.
   ///
-  /// NOTE: This overrides the *colour scheme* only. The seasonal vehicle
-  /// *shape* (e.g. an actual sleigh/broom silhouette) is not yet applied here —
-  /// only the palette is swapped. Shape overrides are a future TODO.
+  /// This overrides the *colour scheme* (palette) only. The seasonal vehicle
+  /// *shape* is overridden separately via [resolvePlaneShapeId]; both resolvers
+  /// are applied side-by-side at every launch site.
   static Map<String, int>? resolvePlaneColorScheme({
     required Map<String, int>? fallback,
     DateTime? now,
   }) {
     final theme = now != null ? forDate(now) : current();
     return theme?.vehicleColorScheme ?? fallback;
+  }
+
+  // ── Plane shape (silhouette) resolver ───────────────────────────────
+
+  /// Returns the plane-shape id to draw for the active seasonal event, or
+  /// [fallback] (the player's equipped plane id) when no event maps to a
+  /// distinct shape.
+  ///
+  /// Drop-in replacement for the `equippedPlaneId` argument at every
+  /// game-launch site. The returned id flows unchanged through
+  /// `PlayScreen → FlitGame → PlaneComponent → PlaneRenderer.renderPlane`,
+  /// whose `switch (planeId)` already maps ids to distinct drawing routines —
+  /// so a seasonal shape needs no new plumbing, only a new `case` in the
+  /// renderer. Centralising the mapping here means zero per-mode duplication.
+  ///
+  /// Only the summer "Beach Glider" event currently maps to a bespoke shape
+  /// (`'plane_hang_glider'`). All other events fall back to the player's
+  /// equipped shape (their themed silhouettes are a future addition); they
+  /// still receive the seasonal *palette* via [resolvePlaneColorScheme].
+  static String resolvePlaneShapeId({
+    required String fallback,
+    DateTime? now,
+  }) {
+    final theme = now != null ? forDate(now) : current();
+    if (theme == null) return fallback;
+    return _shapeIdForEvent(theme.event) ?? fallback;
+  }
+
+  /// Maps a [SeasonalEvent] to a [PlaneRenderer] plane-shape id, or `null`
+  /// when the event has no bespoke silhouette yet (falls back to the equipped
+  /// plane). Add new `case`s here as themed shapes are authored.
+  static String? _shapeIdForEvent(SeasonalEvent event) {
+    switch (event) {
+      case SeasonalEvent.summer:
+        return 'plane_hang_glider';
+      case SeasonalEvent.christmas:
+      case SeasonalEvent.halloween:
+      case SeasonalEvent.easter:
+      case SeasonalEvent.valentines:
+      case SeasonalEvent.stPatricks:
+      case SeasonalEvent.none:
+        // No bespoke shape yet — keep the player's equipped silhouette while
+        // still applying the seasonal palette via resolvePlaneColorScheme.
+        return null;
+    }
   }
 
   // ── Serialisation ───────────────────────────────────────────────────

--- a/lib/data/models/seasonal_theme.dart
+++ b/lib/data/models/seasonal_theme.dart
@@ -179,6 +179,35 @@ class SeasonalTheme {
     return null;
   }
 
+  // ── Per-instance accessors ──────────────────────────────────────────
+
+  /// The [PlaneRenderer] plane-shape id for this theme's vehicle silhouette,
+  /// or `null` when the event has no bespoke shape yet.
+  ///
+  /// Convenience accessor so the admin UI (and any other display code) can
+  /// retrieve the shape id without duplicating the [_shapeIdForEvent] mapping.
+  String? get planeShapeId => _shapeIdForEvent(event);
+
+  /// Human-readable date window, e.g. `"Jun 21 – Jul 4"`.
+  String get dateWindowLabel {
+    const months = [
+      '',
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return '${months[startMonth]} $startDay – ${months[endMonth]} $endDay';
+  }
+
   // ── Plane colour-scheme resolver ────────────────────────────────────
 
   /// Returns the active seasonal event's vehicle colour scheme when an event

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -11,6 +11,8 @@ import '../../game/data/country_difficulty.dart';
 import '../../game/map/country_data.dart';
 import '../../data/models/avatar_config.dart';
 import '../../data/models/cosmetic.dart';
+import '../../data/models/seasonal_theme.dart';
+import '../../game/rendering/plane_renderer.dart';
 import '../../data/models/economy_config.dart';
 import '../../data/models/pilot_license.dart';
 import '../../data/providers/account_provider.dart';
@@ -2560,6 +2562,117 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                 _refreshAdminData();
               },
             ),
+            const SizedBox(height: 24),
+          ],
+
+          // ── Seasonal Vehicles (moderator + owner) ──
+          if (_can(state, AdminPermission.viewDesignPreviews)) ...[
+            const _SectionHeader(title: 'Seasonal Vehicles'),
+            const SizedBox(height: 8),
+            ...SeasonalTheme.allThemes.map((theme) {
+              final shapeId = theme.planeShapeId ?? 'plane_biplane';
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: FlitColors.cardBackground,
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: FlitColors.cardBorder),
+                  ),
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Vehicle preview canvas
+                      Container(
+                        width: 108,
+                        height: 108,
+                        decoration: BoxDecoration(
+                          color: FlitColors.backgroundDark,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: CustomPaint(
+                          painter: _SeasonalVehiclePainter(
+                            planeId: shapeId,
+                            colorScheme: theme.vehicleColorScheme,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      // Text info
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              theme.vehicleName,
+                              style: const TextStyle(
+                                color: FlitColors.textPrimary,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              theme.vehicleDescription,
+                              style: const TextStyle(
+                                color: FlitColors.textSecondary,
+                                fontSize: 12,
+                              ),
+                            ),
+                            const SizedBox(height: 6),
+                            Row(
+                              children: [
+                                const Icon(
+                                  Icons.event,
+                                  size: 12,
+                                  color: FlitColors.textMuted,
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  theme.event.name,
+                                  style: const TextStyle(
+                                    color: FlitColors.textMuted,
+                                    fontSize: 11,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 2),
+                            Row(
+                              children: [
+                                const Icon(
+                                  Icons.date_range,
+                                  size: 12,
+                                  color: FlitColors.textMuted,
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  theme.dateWindowLabel,
+                                  style: const TextStyle(
+                                    color: FlitColors.textMuted,
+                                    fontSize: 11,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              'Shape: $shapeId',
+                              style: const TextStyle(
+                                color: FlitColors.textMuted,
+                                fontSize: 10,
+                                fontFamily: 'monospace',
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }),
             const SizedBox(height: 24),
           ],
 
@@ -8747,4 +8860,44 @@ class _DifficultyRow extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Paints a single seasonal vehicle silhouette centred in the available space.
+///
+/// Uses the same [PlaneRenderer.renderPlane] path as the in-game plane and the
+/// shop/debug preview screens, so admins see exactly what players will see.
+/// Canvas is translated to centre, scaled proportionally, and rendered with
+/// non-banking defaults (bankCos: 1.0, bankSin: 0.0) matching the shop card.
+class _SeasonalVehiclePainter extends CustomPainter {
+  const _SeasonalVehiclePainter({
+    required this.planeId,
+    this.colorScheme,
+  });
+
+  final String planeId;
+  final Map<String, int>? colorScheme;
+
+  // Wing-span constant shared by paint() and shouldRepaint(); kept here so
+  // the admin preview matches the shop card's 26-unit span exactly.
+  static const double _wingSpan = 26.0;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final scale = size.shortestSide / (_wingSpan * 2.5);
+    canvas.translate(size.width / 2, size.height / 2);
+    canvas.scale(scale, scale * 0.7); // 0.7 perspective foreshortening
+    PlaneRenderer.renderPlane(
+      canvas: canvas,
+      bankCos: 1.0,
+      bankSin: 0.0,
+      wingSpan: _wingSpan,
+      planeId: planeId,
+      colorScheme: colorScheme,
+      propAngle: 0.0,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_SeasonalVehiclePainter oldDelegate) =>
+      oldDelegate.planeId != planeId || oldDelegate.colorScheme != colorScheme;
 }

--- a/lib/features/daily/daily_challenge_screen.dart
+++ b/lib/features/daily/daily_challenge_screen.dart
@@ -163,7 +163,7 @@ class _DailyChallengeScreenState extends ConsumerState<DailyChallengeScreen> {
             fallback: plane?.colorScheme,
           ),
           planeWingSpan: plane?.wingSpan,
-          equippedPlaneId: planeId,
+          equippedPlaneId: SeasonalTheme.resolvePlaneShapeId(fallback: planeId),
           companionType: companion,
           fuelBoostMultiplier: fuelBoost,
           clueChance: license.clueChance,

--- a/lib/features/daily/daily_challenge_screen.dart
+++ b/lib/features/daily/daily_challenge_screen.dart
@@ -159,7 +159,9 @@ class _DailyChallengeScreenState extends ConsumerState<DailyChallengeScreen> {
           region: GameRegion.world,
           totalRounds: 5,
           coinReward: reward,
-          planeColorScheme: plane?.colorScheme,
+          planeColorScheme: SeasonalTheme.resolvePlaneColorScheme(
+            fallback: plane?.colorScheme,
+          ),
           planeWingSpan: plane?.wingSpan,
           equippedPlaneId: planeId,
           companionType: companion,

--- a/lib/features/friends/friends_screen.dart
+++ b/lib/features/friends/friends_screen.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../data/models/challenge.dart';
 import '../../data/models/cosmetic.dart';
+import '../../data/models/seasonal_theme.dart';
 import '../../data/models/friend.dart';
 import '../../data/providers/account_provider.dart';
 import '../../data/services/challenge_service.dart';
@@ -492,7 +493,9 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
           challengeId: challengeId,
           challengeSeeds: seeds,
           totalRounds: Challenge.totalRounds,
-          planeColorScheme: plane?.colorScheme,
+          planeColorScheme: SeasonalTheme.resolvePlaneColorScheme(
+            fallback: plane?.colorScheme,
+          ),
           planeWingSpan: plane?.wingSpan,
           equippedPlaneId: planeId,
           companionType: companion,

--- a/lib/features/friends/friends_screen.dart
+++ b/lib/features/friends/friends_screen.dart
@@ -497,7 +497,7 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
             fallback: plane?.colorScheme,
           ),
           planeWingSpan: plane?.wingSpan,
-          equippedPlaneId: planeId,
+          equippedPlaneId: SeasonalTheme.resolvePlaneShapeId(fallback: planeId),
           companionType: companion,
           fuelBoostMultiplier: fuelBoost,
           clueChance: license.clueChance,

--- a/lib/features/matchmaking/find_challenger_screen.dart
+++ b/lib/features/matchmaking/find_challenger_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../data/models/challenge.dart';
 import '../../data/models/cosmetic.dart';
+import '../../data/models/seasonal_theme.dart';
 import '../../data/providers/account_provider.dart';
 import '../../data/services/challenge_service.dart';
 import '../../data/services/matchmaking_service.dart';
@@ -263,7 +264,9 @@ class _FindChallengerScreenState extends ConsumerState<FindChallengerScreen>
           challengeId: _matchResult!.challengeId,
           challengeSeeds: seeds,
           totalRounds: Challenge.totalRounds,
-          planeColorScheme: plane?.colorScheme,
+          planeColorScheme: SeasonalTheme.resolvePlaneColorScheme(
+            fallback: plane?.colorScheme,
+          ),
           planeWingSpan: plane?.wingSpan,
           equippedPlaneId: planeId,
           companionType: companion,

--- a/lib/features/matchmaking/find_challenger_screen.dart
+++ b/lib/features/matchmaking/find_challenger_screen.dart
@@ -268,7 +268,7 @@ class _FindChallengerScreenState extends ConsumerState<FindChallengerScreen>
             fallback: plane?.colorScheme,
           ),
           planeWingSpan: plane?.wingSpan,
-          equippedPlaneId: planeId,
+          equippedPlaneId: SeasonalTheme.resolvePlaneShapeId(fallback: planeId),
           companionType: companion,
           fuelBoostMultiplier: fuelBoost,
           clueChance: license.clueChance,

--- a/lib/features/play/free_flight_setup_screen.dart
+++ b/lib/features/play/free_flight_setup_screen.dart
@@ -138,7 +138,7 @@ class _FreeFlightSetupScreenState extends ConsumerState<FreeFlightSetupScreen> {
             fallback: plane?.colorScheme,
           ),
           planeWingSpan: plane?.wingSpan,
-          equippedPlaneId: planeId,
+          equippedPlaneId: SeasonalTheme.resolvePlaneShapeId(fallback: planeId),
           companionType: companion,
           fuelBoostMultiplier: fuelBoost,
           clueChance: license.clueChance,

--- a/lib/features/play/free_flight_setup_screen.dart
+++ b/lib/features/play/free_flight_setup_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/services/game_settings.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../data/models/cosmetic.dart';
+import '../../data/models/seasonal_theme.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/clues/clue_types.dart';
 import '../../game/map/region.dart';
@@ -133,7 +134,9 @@ class _FreeFlightSetupScreenState extends ConsumerState<FreeFlightSetupScreen> {
           region: widget.region,
           totalRounds: _selectedRounds == 0 ? 99999 : _selectedRounds,
           isEndless: _selectedRounds == 0,
-          planeColorScheme: plane?.colorScheme,
+          planeColorScheme: SeasonalTheme.resolvePlaneColorScheme(
+            fallback: plane?.colorScheme,
+          ),
           planeWingSpan: plane?.wingSpan,
           equippedPlaneId: planeId,
           companionType: companion,

--- a/lib/features/play/practice_screen.dart
+++ b/lib/features/play/practice_screen.dart
@@ -235,7 +235,7 @@ class _PracticeScreenState extends ConsumerState<PracticeScreen> {
             fallback: plane?.colorScheme,
           ),
           planeWingSpan: plane?.wingSpan,
-          equippedPlaneId: planeId,
+          equippedPlaneId: SeasonalTheme.resolvePlaneShapeId(fallback: planeId),
           companionType: companion,
           fuelBoostMultiplier: fuelBoost,
           clueChance: license.clueChance,

--- a/lib/features/play/practice_screen.dart
+++ b/lib/features/play/practice_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
 import '../../data/models/cosmetic.dart';
+import '../../data/models/seasonal_theme.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/clues/clue_types.dart';
 import '../../game/map/region.dart';
@@ -230,7 +231,9 @@ class _PracticeScreenState extends ConsumerState<PracticeScreen> {
         builder: (_) => PlayScreen(
           region: GameRegion.world,
           totalRounds: 10,
-          planeColorScheme: plane?.colorScheme,
+          planeColorScheme: SeasonalTheme.resolvePlaneColorScheme(
+            fallback: plane?.colorScheme,
+          ),
           planeWingSpan: plane?.wingSpan,
           equippedPlaneId: planeId,
           companionType: companion,

--- a/lib/game/rendering/plane_renderer.dart
+++ b/lib/game/rendering/plane_renderer.dart
@@ -290,6 +290,18 @@ class PlaneRenderer {
           planeId,
         );
         break;
+      case 'plane_hang_glider':
+        // Seasonal summer "Beach Glider" silhouette. Not a catalog cosmetic —
+        // injected only via SeasonalTheme.resolvePlaneShapeId during the event.
+        _renderHangGlider(
+          canvas,
+          bankCos,
+          bankSin,
+          wingSpan,
+          colorScheme,
+          planeId,
+        );
+        break;
       default:
         _renderBiPlane(
           canvas,
@@ -2659,5 +2671,241 @@ class PlaneRenderer {
     );
 
     canvas.restore(); // End body roll transform
+  }
+
+  // ─── Hang Glider (seasonal summer "Beach Glider") ───────────────────
+
+  /// Draws a hang-glider silhouette: a swept delta fabric wing (canopy) with a
+  /// central keel spine and a small pilot slung beneath on an A-frame control
+  /// bar. Top-down/behind view, nose pointing up (−Y), matching the watercolour
+  /// conventions of the other plane shapes.
+  ///
+  /// Colours: primary = sail/canopy fabric, secondary = keel + sail accent
+  /// stripes + control bar, detail = pilot/harness. The seasonal Beach Glider
+  /// palette (cyan / yellow / white) is wired in via the passed [colorScheme].
+  static void _renderHangGlider(
+    Canvas canvas,
+    double bankCos,
+    double bankSin,
+    double wingSpan,
+    Map<String, int>? colorScheme,
+    String planeId,
+  ) {
+    final rng = _sketchRng(planeId);
+    final primary = _primary(colorScheme, 0xFF00CED1); // sail fabric (cyan)
+    final secondary = _secondary(colorScheme, 0xFFFFD700); // keel / accents
+    final detail = _detail(colorScheme, 0xFFFFFFFF); // pilot / harness
+
+    final shade = bankSin;
+    final bodyShift = bankSin * 1.5;
+    // The delta wing is broad — give it a generous span like the flying-wing
+    // shapes so the triangular canopy reads clearly at small sizes.
+    final dynamicWingSpan = wingSpan * bankCos.abs() * 1.25;
+    final wingDip = -bankSin * 3.0;
+
+    // Inner (turning) half darkens, outer half stays lit — same banking
+    // treatment used by the jet / shuttle deltas.
+    final leftSailColor =
+        shade > 0 ? primary : Color.lerp(primary, Colors.black, 0.22)!;
+    final rightSailColor =
+        shade < 0 ? primary : Color.lerp(primary, Colors.black, 0.22)!;
+
+    // Apex of the delta (nose / leading point) sits forward of centre.
+    const noseY = -16.0;
+    // Trailing edge sweeps back to the rear corners.
+    const trailY = 12.0;
+
+    final leftSpan =
+        dynamicWingSpan * (1.0 - bankSin.abs() * 0.15) + bankSin * 1.5;
+    final rightSpan =
+        dynamicWingSpan * (1.0 - bankSin.abs() * 0.15) - bankSin * 1.5;
+
+    // --- Left sail half (delta triangle: nose → left tip → keel tail) ---
+    final leftSail = Path()
+      ..moveTo(bodyShift, noseY) // nose apex
+      ..lineTo(-leftSpan, trailY - 4 + wingDip) // swept-back left tip
+      ..quadraticBezierTo(
+        -leftSpan * 0.45,
+        trailY + 1 + wingDip * 0.5,
+        bodyShift,
+        trailY, // keel tail (centre trailing point)
+      )
+      ..close();
+    _wash(canvas, leftSail, leftSailColor, seed: planeId);
+    _crossHatch(
+      canvas,
+      Rect.fromLTRB(-leftSpan, noseY, bodyShift, trailY + wingDip),
+      leftSailColor,
+      spacing: 5.5,
+      opacity: 0.09,
+    );
+    _pencilOutline(leftSail, canvas, leftSailColor, strokeWidth: 1.0);
+
+    // --- Right sail half ---
+    final rightSail = Path()
+      ..moveTo(bodyShift, noseY)
+      ..lineTo(rightSpan, trailY - 4 - wingDip)
+      ..quadraticBezierTo(
+        rightSpan * 0.45,
+        trailY + 1 - wingDip * 0.5,
+        bodyShift,
+        trailY,
+      )
+      ..close();
+    _wash(canvas, rightSail, rightSailColor, seed: planeId);
+    _crossHatch(
+      canvas,
+      Rect.fromLTRB(bodyShift, noseY, rightSpan, trailY - wingDip),
+      rightSailColor,
+      spacing: 5.5,
+      opacity: 0.09,
+    );
+    _pencilOutline(rightSail, canvas, rightSailColor, strokeWidth: 1.0);
+
+    // Sail accent stripes (one per half) running nose → tip, secondary colour.
+    final stripePaint = Paint()
+      ..color = secondary.withOpacity(0.85)
+      ..strokeWidth = 1.6
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(
+      Offset(bodyShift, noseY),
+      Offset(-leftSpan * 0.62, trailY - 5 + wingDip * 0.6),
+      stripePaint,
+    );
+    canvas.drawLine(
+      Offset(bodyShift, noseY),
+      Offset(rightSpan * 0.62, trailY - 5 - wingDip * 0.6),
+      stripePaint,
+    );
+
+    // Sail highlight on the lit half (soft watercolour glint near the nose).
+    final highlightPaint = Paint()
+      ..color = FlitColors.planeHighlight.withOpacity(0.30);
+    if (shade <= 0) {
+      canvas.drawPath(
+        Path()
+          ..moveTo(bodyShift, noseY + 1)
+          ..lineTo(-leftSpan * 0.5, trailY - 6 + wingDip * 0.5)
+          ..lineTo(-leftSpan * 0.3, trailY - 5 + wingDip * 0.5)
+          ..lineTo(bodyShift, noseY + 4)
+          ..close(),
+        highlightPaint,
+      );
+    } else {
+      canvas.drawPath(
+        Path()
+          ..moveTo(bodyShift, noseY + 1)
+          ..lineTo(rightSpan * 0.5, trailY - 6 - wingDip * 0.5)
+          ..lineTo(rightSpan * 0.3, trailY - 5 - wingDip * 0.5)
+          ..lineTo(bodyShift, noseY + 4)
+          ..close(),
+        highlightPaint,
+      );
+    }
+
+    // --- Body group (keel spine + control bar + slung pilot) ---
+    // Wrapped in the same roll transform as the other shapes so the underslung
+    // assembly foreshortens correctly when banking.
+    canvas.save();
+    final rollScale = 0.55 + bankCos.abs() * 0.45;
+    canvas.translate(bodyShift, 0);
+    canvas.scale(rollScale, 1.0);
+    canvas.translate(-bodyShift, 0);
+
+    // Keel spine — the central tube/batten from nose to tail.
+    final keelPath = Path()
+      ..moveTo(bodyShift, noseY)
+      ..lineTo(bodyShift + 1.3, trailY)
+      ..lineTo(bodyShift - 1.3, trailY)
+      ..close();
+    _wash(canvas, keelPath, secondary, seed: planeId);
+    final keelSketchPaint = Paint()
+      ..color = _darken(secondary, 0.35).withOpacity(0.5)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.0
+      ..strokeCap = StrokeCap.round;
+    _sketchPath(keelPath, canvas, keelSketchPaint, rng, wobble: 0.3);
+
+    // Cross-bar (the spanwise batten across the wing, behind the pilot).
+    canvas.drawLine(
+      Offset(bodyShift - dynamicWingSpan * 0.5, -1),
+      Offset(bodyShift + dynamicWingSpan * 0.5, -1),
+      Paint()
+        ..color = _darken(secondary, 0.15).withOpacity(0.55)
+        ..strokeWidth = 0.9,
+    );
+
+    // A-frame control bar — triangle of struts hanging below the keel that the
+    // pilot holds. Drawn as thin lines for a wireframe look.
+    const hangApexY = -2.0; // hang point on the keel
+    const barY = 9.0; // base bar (where hands grip)
+    const barHalf = 4.5;
+    final framePaint = Paint()
+      ..color = _darken(secondary, 0.2)
+      ..strokeWidth = 1.1
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(
+      Offset(bodyShift, hangApexY),
+      Offset(bodyShift - barHalf, barY),
+      framePaint,
+    );
+    canvas.drawLine(
+      Offset(bodyShift, hangApexY),
+      Offset(bodyShift + barHalf, barY),
+      framePaint,
+    );
+    // Base bar (control bar the pilot grips).
+    canvas.drawLine(
+      Offset(bodyShift - barHalf, barY),
+      Offset(bodyShift + barHalf, barY),
+      framePaint,
+    );
+
+    // --- Pilot slung beneath, prone (head forward, body trailing aft) ---
+    // Suspension strap from the hang point down to the harness.
+    canvas.drawLine(
+      Offset(bodyShift, hangApexY),
+      Offset(bodyShift, 4),
+      Paint()
+        ..color = _darken(detail, 0.4)
+        ..strokeWidth = 1.0,
+    );
+
+    // Harness / pilot torso — a slim capsule lying along the keel.
+    final pilotPath = Path()
+      ..addRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromCenter(center: Offset(bodyShift, 3), width: 5, height: 13),
+          const Radius.circular(2.5),
+        ),
+      );
+    _wash(canvas, pilotPath, detail, seed: planeId);
+    _pencilOutline(pilotPath, canvas, detail, strokeWidth: 0.9);
+
+    // Pilot head (small circle near the nose/front of the harness).
+    canvas.drawCircle(
+      Offset(bodyShift, -3),
+      2.2,
+      Paint()..color = _darken(detail, 0.12),
+    );
+    canvas.drawCircle(
+      Offset(bodyShift - 0.5, -3.5),
+      0.9,
+      Paint()..color = _lighten(detail, 0.6),
+    );
+
+    // Hands gripping the control bar (two small dots at the base bar).
+    final handPaint = Paint()..color = _darken(detail, 0.25);
+    canvas.drawCircle(Offset(bodyShift - 2.4, barY), 1.0, handPaint);
+    canvas.drawCircle(Offset(bodyShift + 2.4, barY), 1.0, handPaint);
+
+    canvas.restore(); // End body roll transform
+
+    // Nose-tip nav highlight (tiny bright point at the leading apex).
+    canvas.drawCircle(
+      Offset(bodyShift, noseY),
+      1.4,
+      Paint()..color = secondary,
+    );
   }
 }

--- a/lib/game/rendering/plane_renderer.dart
+++ b/lib/game/rendering/plane_renderer.dart
@@ -302,6 +302,31 @@ class PlaneRenderer {
           planeId,
         );
         break;
+      case 'plane_santa_sleigh':
+        // Seasonal Christmas silhouette — injected via resolvePlaneShapeId.
+        _renderSantaSleigh(
+            canvas, bankCos, bankSin, wingSpan, colorScheme, planeId);
+        break;
+      case 'plane_witch_broom':
+        // Seasonal Halloween silhouette — injected via resolvePlaneShapeId.
+        _renderWitchBroom(
+            canvas, bankCos, bankSin, wingSpan, colorScheme, planeId);
+        break;
+      case 'plane_easter_carriage':
+        // Seasonal Easter silhouette — injected via resolvePlaneShapeId.
+        _renderEasterCarriage(
+            canvas, bankCos, bankSin, wingSpan, colorScheme, planeId);
+        break;
+      case 'plane_cupid_arrow':
+        // Seasonal Valentines silhouette — injected via resolvePlaneShapeId.
+        _renderCupidArrow(
+            canvas, bankCos, bankSin, wingSpan, colorScheme, planeId);
+        break;
+      case 'plane_clover_copter':
+        // Seasonal St Patrick's Day silhouette — injected via resolvePlaneShapeId.
+        _renderCloverCopter(
+            canvas, bankCos, bankSin, wingSpan, colorScheme, planeId);
+        break;
       default:
         _renderBiPlane(
           canvas,
@@ -2907,5 +2932,702 @@ class PlaneRenderer {
       1.4,
       Paint()..color = secondary,
     );
+  }
+
+  // ─── Santa's Sleigh (seasonal Christmas) ────────────────────────────
+
+  /// Draws Santa's sleigh: a curved-runner body (viewed from the side/above)
+  /// with a bulging gift sack at the rear, two curved runners extending left
+  /// and right (as "wings" to imply forward motion), and a reins line
+  /// projecting forward.
+  ///
+  /// Colours: primary = sleigh body (red), secondary = runners/gilt trim (gold),
+  /// detail = snow/gift accents (white).
+  static void _renderSantaSleigh(
+    Canvas canvas,
+    double bankCos,
+    double bankSin,
+    double wingSpan,
+    Map<String, int>? colorScheme,
+    String planeId,
+  ) {
+    final primary = _primary(colorScheme, 0xFFCC0000); // deep red
+    final secondary = _secondary(colorScheme, 0xFFFFD700); // gold
+    final detail = _detail(colorScheme, 0xFFFFFFFF); // white/snow
+
+    final bodyShift = bankSin * 1.5;
+    final dynamicWingSpan = wingSpan * bankCos.abs() * 1.1;
+    final wingDip = -bankSin * 3.5;
+
+    final leftColor =
+        bankSin > 0 ? secondary : Color.lerp(secondary, Colors.black, 0.2)!;
+    final rightColor =
+        bankSin < 0 ? secondary : Color.lerp(secondary, Colors.black, 0.2)!;
+
+    // --- Runners (curved blades extending L + R like wings) ---
+    // Left runner: curves from rear-left around to front-left.
+    final leftRunner = Path()
+      ..moveTo(bodyShift - 2, -8) // front tip
+      ..cubicTo(
+        bodyShift - dynamicWingSpan * 0.5,
+        -10 + wingDip,
+        -dynamicWingSpan + bodyShift,
+        -4 + wingDip,
+        -dynamicWingSpan + bodyShift,
+        4 + wingDip, // outer tip (mid-height)
+      )
+      ..lineTo(-dynamicWingSpan + bodyShift + 2, 5 + wingDip)
+      ..cubicTo(
+        -dynamicWingSpan * 0.6 + bodyShift,
+        6 + wingDip * 0.5,
+        bodyShift - 2,
+        2,
+        bodyShift - 2,
+        -8, // back to start
+      );
+    _wash(canvas, leftRunner, leftColor, seed: planeId);
+    _pencilOutline(leftRunner, canvas, leftColor, strokeWidth: 0.9);
+
+    // Right runner (mirror).
+    final rightRunner = Path()
+      ..moveTo(bodyShift + 2, -8)
+      ..cubicTo(
+        bodyShift + dynamicWingSpan * 0.5,
+        -10 - wingDip,
+        dynamicWingSpan + bodyShift,
+        -4 - wingDip,
+        dynamicWingSpan + bodyShift,
+        4 - wingDip,
+      )
+      ..lineTo(dynamicWingSpan + bodyShift - 2, 5 - wingDip)
+      ..cubicTo(
+        dynamicWingSpan * 0.6 + bodyShift,
+        6 - wingDip * 0.5,
+        bodyShift + 2,
+        2,
+        bodyShift + 2,
+        -8,
+      );
+    _wash(canvas, rightRunner, rightColor, seed: planeId);
+    _pencilOutline(rightRunner, canvas, rightColor, strokeWidth: 0.9);
+
+    // --- Body group (roll-foreshortens with bankCos) ---
+    canvas.save();
+    final rollScale = 0.55 + bankCos.abs() * 0.45;
+    canvas.translate(bodyShift, 0);
+    canvas.scale(rollScale, 1.0);
+    canvas.translate(-bodyShift, 0);
+
+    // Sleigh body — tapers to a curved prow at the front (top).
+    final bodyPath = Path()
+      ..moveTo(bodyShift, -14) // prow tip
+      ..quadraticBezierTo(bodyShift + 5, -10, bodyShift + 5, -2) // right side
+      ..lineTo(bodyShift + 4, 10) // right rear
+      ..quadraticBezierTo(bodyShift, 12, bodyShift - 4, 10) // rear curve
+      ..lineTo(bodyShift - 5, -2) // left rear side
+      ..quadraticBezierTo(bodyShift - 5, -10, bodyShift, -14)
+      ..close();
+    _wash(canvas, bodyPath, primary, seed: planeId);
+    _pencilOutline(bodyPath, canvas, primary, strokeWidth: 1.0);
+    _crossHatch(
+      canvas,
+      Rect.fromLTRB(bodyShift - 5, -14, bodyShift + 5, 10),
+      primary,
+      spacing: 5.0,
+      opacity: 0.08,
+    );
+
+    // Gold trim lines along the sleigh sides.
+    final trimPaint = Paint()
+      ..color = secondary.withOpacity(0.85)
+      ..strokeWidth = 1.2
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(
+        Offset(bodyShift - 4, -10), Offset(bodyShift - 3.5, 8), trimPaint);
+    canvas.drawLine(
+        Offset(bodyShift + 4, -10), Offset(bodyShift + 3.5, 8), trimPaint);
+
+    // Gift sack (bulging oval at the rear / tail).
+    final sackPath = Path()
+      ..addOval(
+        Rect.fromCenter(center: Offset(bodyShift, 12), width: 10, height: 8),
+      );
+    _wash(canvas, sackPath, detail, seed: planeId);
+    _pencilOutline(sackPath, canvas, detail, strokeWidth: 0.9);
+    // Tie-off knot on the sack.
+    canvas.drawCircle(
+      Offset(bodyShift, 7.5),
+      1.4,
+      Paint()..color = secondary,
+    );
+
+    // Reins — thin line projecting forward from the prow.
+    final reinPaint = Paint()
+      ..color = _darken(detail, 0.3).withOpacity(0.7)
+      ..strokeWidth = 0.9
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(
+      Offset(bodyShift - 1.5, -14),
+      Offset(bodyShift - 3, -22),
+      reinPaint,
+    );
+    canvas.drawLine(
+      Offset(bodyShift + 1.5, -14),
+      Offset(bodyShift + 3, -22),
+      reinPaint,
+    );
+
+    // Gold prow highlight (bright point at nose).
+    canvas.drawCircle(
+      Offset(bodyShift, -14),
+      1.6,
+      Paint()..color = secondary,
+    );
+
+    canvas.restore();
+  }
+
+  // ─── Witch's Broom (seasonal Halloween) ─────────────────────────────
+
+  /// Draws a witch's broom flying horizontally (nose = top, bristles at
+  /// bottom/rear). A long handle, a fan of bristles spread at the rear, and
+  /// a tiny seated witch silhouette + trailing smoke wisp.
+  ///
+  /// Colours: primary = handle/broom shaft (near-black), secondary = bristles
+  /// (orange), detail = witch/wisp (purple).
+  static void _renderWitchBroom(
+    Canvas canvas,
+    double bankCos,
+    double bankSin,
+    double wingSpan,
+    Map<String, int>? colorScheme,
+    String planeId,
+  ) {
+    final primary = _primary(colorScheme, 0xFF1A0A2E); // near-black purple
+    final secondary = _secondary(colorScheme, 0xFFFF6600); // orange bristles
+    final detail = _detail(colorScheme, 0xFF6B21A8); // purple witch/wisp
+
+    final bodyShift = bankSin * 1.5;
+    final dynamicWingSpan = wingSpan * bankCos.abs() * 1.0;
+    final wingDip = -bankSin * 2.5;
+
+    // --- Bristle fan (spread behind the broom like wings) ---
+    // Fan rendered as a series of individual bristle lines spreading left/right.
+    const bristleRootY = 8.0; // where shaft ends / bristles begin
+    const bristleCount = 7;
+    for (var i = 0; i < bristleCount; i++) {
+      final t = i / (bristleCount - 1); // 0..1
+      final side = (t - 0.5) * 2.0; // -1..1 (left to right)
+      final xTip = side * (dynamicWingSpan * 0.9) + bodyShift;
+      final yTip = bristleRootY + 8.0 + side.abs() * 2.0 + wingDip * side * 0.5;
+      // Darken outer bristles on the descending (banking) side.
+      final bristleColor =
+          (side * bankSin > 0.1) ? _darken(secondary, 0.25) : secondary;
+      canvas.drawLine(
+        Offset(bodyShift, bristleRootY),
+        Offset(xTip, yTip),
+        Paint()
+          ..color = bristleColor
+          ..strokeWidth = 1.2
+          ..strokeCap = StrokeCap.round,
+      );
+    }
+    // Bristle binding band (band of secondary colour at the root of the fan).
+    canvas.drawLine(
+      Offset(bodyShift - 3, bristleRootY - 0.5),
+      Offset(bodyShift + 3, bristleRootY - 0.5),
+      Paint()
+        ..color = _darken(secondary, 0.15)
+        ..strokeWidth = 3.0
+        ..strokeCap = StrokeCap.round,
+    );
+
+    // --- Body group ---
+    canvas.save();
+    final rollScale = 0.55 + bankCos.abs() * 0.45;
+    canvas.translate(bodyShift, 0);
+    canvas.scale(rollScale, 1.0);
+    canvas.translate(-bodyShift, 0);
+
+    // Broom handle (long slim shaft, nose = top, tapers to a point).
+    final handlePath = Path()
+      ..moveTo(bodyShift, -20) // tip of handle
+      ..lineTo(bodyShift + 1.5, -15)
+      ..lineTo(bodyShift + 2.0, bristleRootY)
+      ..lineTo(bodyShift - 2.0, bristleRootY)
+      ..lineTo(bodyShift - 1.5, -15)
+      ..close();
+    _wash(canvas, handlePath, primary, seed: planeId);
+    _pencilOutline(handlePath, canvas, primary, strokeWidth: 1.0);
+    // Wood-grain lines along the handle.
+    final grainPaint = Paint()
+      ..color = _lighten(primary, 0.25).withOpacity(0.4)
+      ..strokeWidth = 0.5;
+    for (var y = -16.0; y < bristleRootY; y += 4.0) {
+      canvas.drawLine(Offset(bodyShift - 1.5, y),
+          Offset(bodyShift + 1.5, y + 1.0), grainPaint);
+    }
+
+    // Seated witch silhouette — small oval body + conical hat above handle.
+    // Body (sits astride the broom at mid-handle).
+    canvas.drawOval(
+      Rect.fromCenter(center: Offset(bodyShift, -4), width: 6, height: 9),
+      Paint()..color = detail,
+    );
+    // Hat brim.
+    canvas.drawOval(
+      Rect.fromCenter(center: Offset(bodyShift, -9.5), width: 8, height: 2),
+      Paint()..color = primary,
+    );
+    // Hat cone.
+    final hatPath = Path()
+      ..moveTo(bodyShift, -18)
+      ..lineTo(bodyShift - 3.5, -9.5)
+      ..lineTo(bodyShift + 3.5, -9.5)
+      ..close();
+    _wash(canvas, hatPath, primary, seed: planeId);
+
+    // Trailing wisp / smoke (curvy line behind the bristles in detail colour).
+    final wispPaint = Paint()
+      ..color = detail.withOpacity(0.55)
+      ..strokeWidth = 1.5
+      ..strokeCap = StrokeCap.round
+      ..style = PaintingStyle.stroke;
+    final wispPath = Path()
+      ..moveTo(bodyShift, bristleRootY + 10)
+      ..cubicTo(
+        bodyShift + 4,
+        bristleRootY + 13,
+        bodyShift - 4,
+        bristleRootY + 16,
+        bodyShift + 2,
+        bristleRootY + 19,
+      );
+    canvas.drawPath(wispPath, wispPaint);
+
+    canvas.restore();
+  }
+
+  // ─── Easter Egg Express Carriage (seasonal Easter) ───────────────────
+
+  /// Draws a rounded egg-shaped carriage with small wheels, decorated with
+  /// painted-egg band accents. Viewed from the side/above; "nose" is top (−Y).
+  ///
+  /// Colours: primary = egg shell (pastel pink), secondary = carriage frame /
+  /// wheels (pastel blue), detail = painted-egg accent stripes (pastel yellow).
+  static void _renderEasterCarriage(
+    Canvas canvas,
+    double bankCos,
+    double bankSin,
+    double wingSpan,
+    Map<String, int>? colorScheme,
+    String planeId,
+  ) {
+    final primary = _primary(colorScheme, 0xFFFFB6C1); // pastel pink
+    final secondary = _secondary(colorScheme, 0xFFADD8E6); // pastel blue
+    final detail = _detail(colorScheme, 0xFFFFFF99); // pastel yellow
+
+    final bodyShift = bankSin * 1.5;
+    final dynamicWingSpan = wingSpan * bankCos.abs() * 0.9;
+    final wingDip = -bankSin * 3.0;
+
+    final leftColor =
+        bankSin > 0 ? secondary : Color.lerp(secondary, Colors.black, 0.2)!;
+    final rightColor =
+        bankSin < 0 ? secondary : Color.lerp(secondary, Colors.black, 0.2)!;
+
+    // --- Side wheels (drawn as arcs extending L/R like "wing stubs") ---
+    // Left wheel.
+    final leftWheel = Path()
+      ..addOval(
+        Rect.fromCenter(
+          center: Offset(-dynamicWingSpan * 0.6 + bodyShift, 6 + wingDip),
+          width: dynamicWingSpan * 0.55,
+          height: 5,
+        ),
+      );
+    _wash(canvas, leftWheel, leftColor, seed: planeId);
+    _pencilOutline(leftWheel, canvas, leftColor, strokeWidth: 0.9);
+
+    // Right wheel.
+    final rightWheel = Path()
+      ..addOval(
+        Rect.fromCenter(
+          center: Offset(dynamicWingSpan * 0.6 + bodyShift, 6 - wingDip),
+          width: dynamicWingSpan * 0.55,
+          height: 5,
+        ),
+      );
+    _wash(canvas, rightWheel, rightColor, seed: planeId);
+    _pencilOutline(rightWheel, canvas, rightColor, strokeWidth: 0.9);
+
+    // --- Body group ---
+    canvas.save();
+    final rollScale = 0.55 + bankCos.abs() * 0.45;
+    canvas.translate(bodyShift, 0);
+    canvas.scale(rollScale, 1.0);
+    canvas.translate(-bodyShift, 0);
+
+    // Egg-shaped carriage body (tall oval, pointed top, rounded base).
+    final bodyPath = Path()
+      ..moveTo(bodyShift, -18) // pointed top / "nose"
+      ..cubicTo(
+        bodyShift + 7,
+        -14,
+        bodyShift + 8,
+        -2,
+        bodyShift + 7,
+        10,
+      ) // right curve
+      ..quadraticBezierTo(bodyShift, 16, bodyShift - 7, 10) // base curve
+      ..cubicTo(
+        bodyShift - 8,
+        -2,
+        bodyShift - 7,
+        -14,
+        bodyShift,
+        -18,
+      )
+      ..close();
+    _wash(canvas, bodyPath, primary, seed: planeId);
+    _pencilOutline(bodyPath, canvas, primary, strokeWidth: 1.1);
+
+    // Decorative horizontal bands (painted-egg style).
+    final bandPaint = Paint()
+      ..color = detail.withOpacity(0.80)
+      ..strokeWidth = 2.2
+      ..strokeCap = StrokeCap.round;
+    for (final y in [-8.0, -1.0, 6.0]) {
+      // Clip bands to stay inside the egg outline — approximate with short lines.
+      final halfW = (y < -12 || y > 13) ? 3.0 : (y.abs() < 4 ? 7.5 : 6.0);
+      canvas.drawLine(
+        Offset(bodyShift - halfW, y),
+        Offset(bodyShift + halfW, y),
+        bandPaint,
+      );
+    }
+
+    // Secondary-colour frame ring at the equator (widest point).
+    canvas.drawOval(
+      Rect.fromCenter(
+        center: Offset(bodyShift, -1),
+        width: 16,
+        height: 4,
+      ),
+      Paint()
+        ..color = secondary.withOpacity(0.45)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.0,
+    );
+
+    // Small circular window (porthole).
+    canvas.drawCircle(
+      Offset(bodyShift, -7),
+      3.0,
+      Paint()..color = secondary.withOpacity(0.6),
+    );
+    canvas.drawCircle(
+      Offset(bodyShift, -7),
+      3.0,
+      Paint()
+        ..color = _darken(secondary, 0.2)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 0.7,
+    );
+
+    canvas.restore();
+  }
+
+  // ─── Cupid's Arrow (seasonal Valentines) ────────────────────────────
+
+  /// Draws a large horizontal arrow travelling upward (−Y = nose), with a
+  /// heart-shaped arrowhead at the front and feathered fletching at the rear.
+  /// A trail of small petals/hearts streams behind.
+  ///
+  /// Colours: primary = arrow shaft (pink), secondary = heart tip (crimson),
+  /// detail = feathers / petal trail (white).
+  static void _renderCupidArrow(
+    Canvas canvas,
+    double bankCos,
+    double bankSin,
+    double wingSpan,
+    Map<String, int>? colorScheme,
+    String planeId,
+  ) {
+    final primary = _primary(colorScheme, 0xFFFF69B4); // hot pink
+    final secondary = _secondary(colorScheme, 0xFFDC143C); // crimson
+    final detail = _detail(colorScheme, 0xFFFFFFFF); // white feathers
+
+    final bodyShift = bankSin * 1.5;
+    final dynamicWingSpan = wingSpan * bankCos.abs() * 1.05;
+    final wingDip = -bankSin * 3.0;
+
+    final leftColor =
+        bankSin > 0 ? primary : Color.lerp(primary, Colors.black, 0.2)!;
+    final rightColor =
+        bankSin < 0 ? primary : Color.lerp(primary, Colors.black, 0.2)!;
+
+    // --- Fletching fins (left + right, like wings near the rear) ---
+    // Left fletching — a teardrop feather shape.
+    final leftFletch = Path()
+      ..moveTo(bodyShift, 10) // root at shaft
+      ..quadraticBezierTo(
+        bodyShift - dynamicWingSpan * 0.5,
+        6 + wingDip,
+        -dynamicWingSpan * 0.85 + bodyShift,
+        12 + wingDip,
+      )
+      ..quadraticBezierTo(
+        bodyShift - dynamicWingSpan * 0.4,
+        16 + wingDip * 0.5,
+        bodyShift,
+        18,
+      )
+      ..close();
+    _wash(canvas, leftFletch, leftColor, seed: planeId);
+    _pencilOutline(leftFletch, canvas, leftColor, strokeWidth: 0.9);
+
+    // Right fletching.
+    final rightFletch = Path()
+      ..moveTo(bodyShift, 10)
+      ..quadraticBezierTo(
+        bodyShift + dynamicWingSpan * 0.5,
+        6 - wingDip,
+        dynamicWingSpan * 0.85 + bodyShift,
+        12 - wingDip,
+      )
+      ..quadraticBezierTo(
+        bodyShift + dynamicWingSpan * 0.4,
+        16 - wingDip * 0.5,
+        bodyShift,
+        18,
+      )
+      ..close();
+    _wash(canvas, rightFletch, rightColor, seed: planeId);
+    _pencilOutline(rightFletch, canvas, rightColor, strokeWidth: 0.9);
+
+    // --- Body group ---
+    canvas.save();
+    final rollScale = 0.55 + bankCos.abs() * 0.45;
+    canvas.translate(bodyShift, 0);
+    canvas.scale(rollScale, 1.0);
+    canvas.translate(-bodyShift, 0);
+
+    // Arrow shaft (slim rectangle along the centreline).
+    final shaftPath = Path()
+      ..addRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromCenter(center: Offset(bodyShift, 2), width: 4, height: 34),
+          const Radius.circular(2),
+        ),
+      );
+    _wash(canvas, shaftPath, primary, seed: planeId);
+    _pencilOutline(shaftPath, canvas, primary, strokeWidth: 0.8);
+
+    // Heart-shaped arrowhead at the front/top.
+    // Drawn as two overlapping circles + a triangle point below.
+    final heartLeft = Path()
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift - 2.8, -16), width: 5.6, height: 5.6));
+    final heartRight = Path()
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift + 2.8, -16), width: 5.6, height: 5.6));
+    final heartPoint = Path()
+      ..moveTo(bodyShift - 5, -14.5)
+      ..lineTo(bodyShift, -10)
+      ..lineTo(bodyShift + 5, -14.5)
+      ..close();
+    for (final p in [heartLeft, heartRight, heartPoint]) {
+      _wash(canvas, p, secondary, seed: planeId);
+    }
+    _pencilOutline(
+      Path()
+        ..addPath(heartLeft, Offset.zero)
+        ..addPath(heartRight, Offset.zero)
+        ..addPath(heartPoint, Offset.zero),
+      canvas,
+      secondary,
+      strokeWidth: 1.0,
+    );
+
+    // Feather quill lines on the fletching (detail white stripes).
+    final quillPaint = Paint()
+      ..color = detail.withOpacity(0.65)
+      ..strokeWidth = 0.7
+      ..strokeCap = StrokeCap.round;
+    for (var i = 0; i < 4; i++) {
+      final t = i / 3.0;
+      final x = bodyShift - 2.5 + t * 2.5;
+      canvas.drawLine(
+          Offset(x, 10 + t * 4), Offset(x - 2.5, 16 + t * 2), quillPaint);
+      canvas.drawLine(
+          Offset(x, 10 + t * 4), Offset(x + 2.5, 16 + t * 2), quillPaint);
+    }
+
+    // Petal trail (small dots/hearts streaming behind the arrow).
+    final petalPaint = Paint()..color = secondary.withOpacity(0.45);
+    for (final dy in [22.0, 26.0, 30.0]) {
+      canvas.drawCircle(
+          Offset(bodyShift + (dy - 26) * 0.4, dy), 1.2, petalPaint);
+    }
+
+    canvas.restore();
+  }
+
+  // ─── Lucky Clover Copter (seasonal St Patrick's Day) ─────────────────
+
+  /// Draws a helicopter whose rotor reads as a 4-leaf clover (four heart-leaf
+  /// blades arranged in a + pattern). A small rounded cockpit sits below the
+  /// rotor hub. Viewed from above, nose pointing up (−Y).
+  ///
+  /// Colours: primary = clover blades (green), secondary = cockpit (gold),
+  /// detail = highlights / stem (white).
+  static void _renderCloverCopter(
+    Canvas canvas,
+    double bankCos,
+    double bankSin,
+    double wingSpan,
+    Map<String, int>? colorScheme,
+    String planeId,
+  ) {
+    final primary = _primary(colorScheme, 0xFF228B22); // forest green
+    final secondary = _secondary(colorScheme, 0xFFFFD700); // gold
+    final detail = _detail(colorScheme, 0xFFFFFFFF); // white
+
+    final bodyShift = bankSin * 1.5;
+    final dynamicWingSpan = wingSpan * bankCos.abs() * 1.1;
+    final wingDip = -bankSin * 3.5;
+
+    // --- 4-Leaf clover rotor (four heart-leaf blades around the hub) ---
+    // Each blade is a pair of overlapping circles forming a heart-leaf,
+    // arranged top/bottom/left/right. Banking compresses L/R span.
+    // Top blade (forward, −Y).
+    final topBlade = Path()
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift - 2.5, -dynamicWingSpan * 0.35),
+          width: 7,
+          height: 8))
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift + 2.5, -dynamicWingSpan * 0.35),
+          width: 7,
+          height: 8));
+    final leftBladeDx = -dynamicWingSpan * 0.6;
+    final leftBlade = Path()
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift + leftBladeDx, wingDip * 0.5 - 2.5),
+          width: 8,
+          height: 7))
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift + leftBladeDx, wingDip * 0.5 + 2.5),
+          width: 8,
+          height: 7));
+    final rightBladeDx = dynamicWingSpan * 0.6;
+    final rightBlade = Path()
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift + rightBladeDx, -wingDip * 0.5 - 2.5),
+          width: 8,
+          height: 7))
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift + rightBladeDx, -wingDip * 0.5 + 2.5),
+          width: 8,
+          height: 7));
+    final bottomBlade = Path()
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift - 2.5, dynamicWingSpan * 0.35),
+          width: 7,
+          height: 8))
+      ..addOval(Rect.fromCenter(
+          center: Offset(bodyShift + 2.5, dynamicWingSpan * 0.35),
+          width: 7,
+          height: 8));
+
+    final leftBladeColor =
+        bankSin > 0 ? primary : Color.lerp(primary, Colors.black, 0.2)!;
+    final rightBladeColor =
+        bankSin < 0 ? primary : Color.lerp(primary, Colors.black, 0.2)!;
+
+    _wash(canvas, topBlade, primary, seed: planeId);
+    _pencilOutline(topBlade, canvas, primary, strokeWidth: 0.9);
+    _wash(canvas, leftBlade, leftBladeColor, seed: planeId);
+    _pencilOutline(leftBlade, canvas, leftBladeColor, strokeWidth: 0.9);
+    _wash(canvas, rightBlade, rightBladeColor, seed: planeId);
+    _pencilOutline(rightBlade, canvas, rightBladeColor, strokeWidth: 0.9);
+    _wash(canvas, bottomBlade, primary, seed: planeId);
+    _pencilOutline(bottomBlade, canvas, primary, strokeWidth: 0.9);
+
+    // Clover stem connecting blades to hub (small lines).
+    final stemPaint = Paint()
+      ..color = _darken(primary, 0.25)
+      ..strokeWidth = 1.2
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(Offset(bodyShift, 0),
+        Offset(bodyShift, -dynamicWingSpan * 0.22), stemPaint);
+    canvas.drawLine(Offset(bodyShift, 0),
+        Offset(bodyShift + leftBladeDx * 0.45, wingDip * 0.25), stemPaint);
+    canvas.drawLine(Offset(bodyShift, 0),
+        Offset(bodyShift + rightBladeDx * 0.45, -wingDip * 0.25), stemPaint);
+    canvas.drawLine(Offset(bodyShift, 0),
+        Offset(bodyShift, dynamicWingSpan * 0.22), stemPaint);
+
+    // --- Body group (cockpit) ---
+    canvas.save();
+    final rollScale = 0.55 + bankCos.abs() * 0.45;
+    canvas.translate(bodyShift, 0);
+    canvas.scale(rollScale, 1.0);
+    canvas.translate(-bodyShift, 0);
+
+    // Cockpit body — a small rounded capsule / bubble.
+    final cockpitPath = Path()
+      ..addRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromCenter(center: Offset(bodyShift, 0), width: 7, height: 12),
+          const Radius.circular(4),
+        ),
+      );
+    _wash(canvas, cockpitPath, secondary, seed: planeId);
+    _pencilOutline(cockpitPath, canvas, secondary, strokeWidth: 1.0);
+
+    // Rotor hub (gold disc at centre).
+    canvas.drawCircle(
+      Offset(bodyShift, 0),
+      2.5,
+      Paint()..color = secondary,
+    );
+    canvas.drawCircle(
+      Offset(bodyShift, 0),
+      1.2,
+      Paint()..color = detail,
+    );
+
+    // Cockpit bubble window.
+    canvas.drawOval(
+      Rect.fromCenter(center: Offset(bodyShift, -2), width: 4.5, height: 5),
+      Paint()..color = const Color(0xFF87CEEB).withOpacity(0.7),
+    );
+    canvas.drawOval(
+      Rect.fromCenter(center: Offset(bodyShift, -2), width: 4.5, height: 5),
+      Paint()
+        ..color = _darken(secondary, 0.25)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 0.6,
+    );
+
+    // Tail boom (slim line at the back, pointing downward/rear).
+    final tailPath = Path()
+      ..moveTo(bodyShift, 6)
+      ..lineTo(bodyShift + 1, 15)
+      ..lineTo(bodyShift - 1, 15)
+      ..close();
+    _wash(canvas, tailPath, secondary, seed: planeId);
+    _pencilOutline(tailPath, canvas, secondary, strokeWidth: 0.8);
+
+    // Small tail rotor disc.
+    canvas.drawCircle(
+      Offset(bodyShift, 15),
+      2.0,
+      Paint()..color = _darken(primary, 0.1),
+    );
+
+    canvas.restore();
   }
 }


### PR DESCRIPTION
## What this does

The seasonal event system was fully defined (`SeasonalTheme.allThemes`) but did nothing in gameplay — only a banner read it. This wires each event's **themed vehicle (distinct shape + colour)** into the plane across **all** modes, and adds an **admin preview** so the silhouettes can be eyeballed.

### 1. Colour + shape override (all modes)
Two shared resolvers on `SeasonalTheme` (no per-mode duplication), applied at all 5 game-launch sites (`daily_challenge`, `free_flight_setup`, `practice`, `friends`, `find_challenger`):
- `resolvePlaneColorScheme({fallback})` → event palette when active, else the cosmetic colours.
- `resolvePlaneShapeId({fallback})` → the event's plane-shape id, else the equipped plane id. The id flows unchanged through `PlayScreen → FlitGame → PlaneComponent → PlaneRenderer.renderPlane`'s existing `switch(planeId)`.

No event active → both return the fallback, behaviour identical.

### 2. All 6 themed vehicles drawn
New `_render…` routines in `plane_renderer.dart`, each consuming the theme palette and following the existing Canvas/banking conventions. `_shapeIdForEvent` maps every event:

| Event | Vehicle | Shape id |
|-------|---------|----------|
| summer | Beach Glider (hang-glider) | `plane_hang_glider` |
| christmas | Santa's Sleigh | `plane_santa_sleigh` |
| halloween | Witch's Broom | `plane_witch_broom` |
| easter | Easter Egg Express | `plane_easter_carriage` |
| valentines | Cupid's Arrow | `plane_cupid_arrow` |
| stPatricks | Lucky Clover Copter | `plane_clover_copter` |

(Verified: every id matches between `_shapeIdForEvent` and the `renderPlane` switch cases.)

### 3. Admin preview
- New public `SeasonalTheme.planeShapeId` + `dateWindowLabel` accessors.
- New **"Seasonal Vehicles"** section in `admin_screen.dart` (after *Design Preview*, gated by the existing `viewDesignPreviews` permission): a card per theme rendering a live `PlaneRenderer` preview + name, description, event, date window, and shape id. Decoupled local `_SeasonalVehiclePainter` (no admin→shop coupling).

## Validation
- `flutter analyze` on the full branch: **0 errors**, no new warnings.

## ⚠️ Visual caveat
The 6 silhouettes were written **without a render preview**, so proportions/banding may need tuning. **Open Admin → Seasonal Vehicles to see them all at once** and tell me which to refine.

> Touches `admin_screen.dart` + the 5 launch screens, so it'll need a rebase relative to #426 (menu) / #427 (license) depending on merge order — I'll handle that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5