### PR TITLE
Constrain menus to a max content width on large screens

### DIFF
--- a/lib/core/theme/flit_theme.dart
+++ b/lib/core/theme/flit_theme.dart
@@ -2,6 +2,12 @@ import 'package:flutter/material.dart';
 
 import 'flit_colors.dart';
 
+/// Maximum width for menu/screen content on wide displays (e.g. desktop
+/// browser). On narrow screens this is never hit, so phone layout is unchanged.
+/// The full-bleed background always fills the screen — only the interactive
+/// content column is constrained by this value.
+const double kMaxContentWidth = 560;
+
 /// Theme configuration for Flit.
 /// Pop art lo-fi realism with vintage atlas warmth.
 abstract final class FlitTheme {

--- a/lib/core/widgets/menu_content_wrapper.dart
+++ b/lib/core/widgets/menu_content_wrapper.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+import '../theme/flit_theme.dart';
+
+/// Centers and constrains menu/screen content to [kMaxContentWidth] on wide
+/// displays so that column-of-buttons style screens keep a phone-like feel on
+/// desktop browsers without regressing the narrow-screen (phone) layout.
+///
+/// Use this to wrap the **content** inside a Scaffold body, NOT the full
+/// Scaffold itself — the background/globe must always fill the screen.
+///
+/// On phones, [kMaxContentWidth] is never hit, so layout is unchanged.
+class MenuContentWrapper extends StatelessWidget {
+  const MenuContentWrapper({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: kMaxContentWidth),
+          child: child,
+        ),
+      );
+}

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/config/admin_config.dart';
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../core/utils/game_log.dart';
 import '../../game/clues/clue_types.dart';
 import '../../game/data/country_difficulty.dart';
@@ -2171,418 +2172,299 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
         title: Text('$roleName Panel'),
         centerTitle: true,
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          // ── Current account info ──
-          const _SectionHeader(title: 'Current Account'),
-          _AccountCard(player: player),
-          const SizedBox(height: 24),
+      body: MenuContentWrapper(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // ── Current account info ──
+            const _SectionHeader(title: 'Current Account'),
+            _AccountCard(player: player),
+            const SizedBox(height: 24),
 
-          // ── Analytics (moderator + owner) ──
-          if (_can(state, AdminPermission.viewAnalytics)) ...[
-            const _SectionHeader(title: 'Analytics'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.analytics,
-              iconColor: FlitColors.oceanHighlight,
-              label: 'Usage Stats',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const AdminStatsScreen(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            if (_can(state, AdminPermission.viewCoinLedger)) ...[
+            // ── Analytics (moderator + owner) ──
+            if (_can(state, AdminPermission.viewAnalytics)) ...[
+              const _SectionHeader(title: 'Analytics'),
               const SizedBox(height: 8),
               _AdminActionCard(
-                icon: Icons.receipt_long,
-                iconColor: FlitColors.gold,
-                label: 'Coin Ledger Explorer',
-                onTap: () => _showCoinLedgerDialog(context),
-              ),
-            ],
-            const SizedBox(height: 24),
-          ],
-
-          // ── User Lookup (moderator + owner) ──
-          if (_can(state, AdminPermission.viewUserData)) ...[
-            const _SectionHeader(title: 'User Lookup'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.person_search,
-              iconColor: FlitColors.oceanHighlight,
-              label: 'Look Up Player',
-              onTap: () => _showUserLookupDialog(context),
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── Quick self-actions (owner only) ──
-          if (_can(state, AdminPermission.selfServiceActions)) ...[
-            const _SectionHeader(title: 'Quick Actions (Self)'),
-            const SizedBox(height: 8),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                _ActionChip(
-                  label: '+100 Gold',
-                  onTap: () => notifier.addCoins(
-                    100,
-                    applyBoost: false,
-                    source: 'admin_grant',
-                  ),
-                ),
-                _ActionChip(
-                  label: '+1,000 Gold',
-                  onTap: () => notifier.addCoins(
-                    1000,
-                    applyBoost: false,
-                    source: 'admin_grant',
-                  ),
-                ),
-                _ActionChip(
-                  label: '+999,999 Gold',
-                  onTap: () => notifier.addCoins(
-                    999999,
-                    applyBoost: false,
-                    source: 'admin_grant',
-                  ),
-                ),
-                _ActionChip(label: '+50 XP', onTap: () => notifier.addXp(50)),
-                _ActionChip(label: '+500 XP', onTap: () => notifier.addXp(500)),
-                _ActionChip(
-                  label: '+1 Flight',
-                  onTap: () => notifier.incrementGamesPlayed(),
-                ),
-              ],
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── Gift to Player (owner only) ──
-          if (_can(state, AdminPermission.giftGold)) ...[
-            const _SectionHeader(title: 'Gift to Player'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.monetization_on,
-              iconColor: FlitColors.gold,
-              label: 'Gift Gold',
-              onTap: () => _showGiftGoldDialog(context),
-            ),
-            if (_can(state, AdminPermission.giftLevels)) ...[
-              const SizedBox(height: 8),
-              _AdminActionCard(
-                icon: Icons.arrow_upward,
-                iconColor: FlitColors.accent,
-                label: 'Gift Levels',
-                onTap: () => _showGiftLevelsDialog(context),
-              ),
-            ],
-            if (_can(state, AdminPermission.giftFlights)) ...[
-              const SizedBox(height: 8),
-              _AdminActionCard(
-                icon: Icons.flight,
+                icon: Icons.analytics,
                 iconColor: FlitColors.oceanHighlight,
-                label: 'Gift Flights',
-                onTap: () => _showGiftFlightsDialog(context),
-              ),
-            ],
-            if (_can(state, AdminPermission.setCoins)) ...[
-              const SizedBox(height: 8),
-              _AdminActionCard(
-                icon: Icons.monetization_on_outlined,
-                iconColor: FlitColors.gold,
-                label: 'Set Coins',
-                onTap: () => _showSetStatDialog(
-                  context,
-                  title: 'Set Coins',
-                  statColumn: 'coins',
-                  valueLabel: 'Coins total',
-                  icon: Icons.monetization_on,
-                  iconColor: FlitColors.gold,
-                ),
-              ),
-            ],
-            if (_can(state, AdminPermission.setLevel)) ...[
-              const SizedBox(height: 8),
-              _AdminActionCard(
-                icon: Icons.trending_up,
-                iconColor: FlitColors.accent,
-                label: 'Set Level',
-                onTap: () => _showSetStatDialog(
-                  context,
-                  title: 'Set Level',
-                  statColumn: 'level',
-                  valueLabel: 'Level',
-                  icon: Icons.trending_up,
-                  iconColor: FlitColors.accent,
-                ),
-              ),
-            ],
-            if (_can(state, AdminPermission.setFlights)) ...[
-              const SizedBox(height: 8),
-              _AdminActionCard(
-                icon: Icons.flight_takeoff,
-                iconColor: FlitColors.oceanHighlight,
-                label: 'Set Flights',
-                onTap: () => _showSetStatDialog(
-                  context,
-                  title: 'Set Flights',
-                  statColumn: 'games_played',
-                  valueLabel: 'Flights',
-                  icon: Icons.flight_takeoff,
-                  iconColor: FlitColors.oceanHighlight,
-                ),
-              ),
-            ],
-            if (_can(state, AdminPermission.giftCosmetic)) ...[
-              const SizedBox(height: 8),
-              _AdminActionCard(
-                icon: Icons.star,
-                iconColor: const Color(0xFF9B59B6),
-                label: 'Gift Cosmetic Item',
-                onTap: () => _showGiftCosmeticDialog(context),
-              ),
-            ],
-            if (_can(state, AdminPermission.setLicense)) ...[
-              const SizedBox(height: 8),
-              _AdminActionCard(
-                icon: Icons.badge,
-                iconColor: FlitColors.oceanHighlight,
-                label: 'Set Player License',
-                onTap: () => _showSetLicenseDialog(context),
-              ),
-            ],
-            if (_can(state, AdminPermission.setAvatar)) ...[
-              const SizedBox(height: 8),
-              _AdminActionCard(
-                icon: Icons.face,
-                iconColor: FlitColors.gold,
-                label: 'Set Player Avatar',
-                onTap: () => _showSetAvatarDialog(context),
-              ),
-            ],
-            const SizedBox(height: 24),
-          ],
-
-          // ── Moderation (moderator + owner) ──
-          if (_can(state, AdminPermission.changeUsername)) ...[
-            const _SectionHeader(title: 'Moderation'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.edit,
-              iconColor: FlitColors.warning,
-              label: 'Change Player Username',
-              onTap: () => _showChangeUsernameDialog(context),
-            ),
-            const SizedBox(height: 8),
-          ],
-          if (_can(state, AdminPermission.manageRoles)) ...[
-            _AdminActionCard(
-              icon: Icons.shield,
-              iconColor: FlitColors.accent,
-              label: 'Manage Moderators',
-              onTap: () => _showManageRoleDialog(context),
-            ),
-            const SizedBox(height: 8),
-          ],
-          if (_can(state, AdminPermission.unlockAll)) ...[
-            _AdminActionCard(
-              icon: Icons.lock_open,
-              iconColor: FlitColors.success,
-              label: 'Unlock All (Player)',
-              onTap: () => _showUnlockAllDialog(context),
-            ),
-            const SizedBox(height: 8),
-          ],
-          if (_can(state, AdminPermission.changeUsername) ||
-              _can(state, AdminPermission.manageRoles))
-            const SizedBox(height: 24),
-
-          // ── Ban Management (moderator + owner) ──
-          if (_can(state, AdminPermission.tempBanUser)) ...[
-            const _SectionHeader(title: 'Ban Management'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.gavel,
-              iconColor: FlitColors.error,
-              label: 'Ban Player',
-              onTap: () => _showBanUserDialog(context),
-            ),
-            const SizedBox(height: 8),
-          ],
-          if (_can(state, AdminPermission.unbanUser)) ...[
-            _AdminActionCard(
-              icon: Icons.lock_open,
-              iconColor: FlitColors.success,
-              label: 'Unban Player',
-              onTap: () => _showUnbanUserDialog(context),
-            ),
-            const SizedBox(height: 8),
-          ],
-          if (_can(state, AdminPermission.tempBanUser)) ...[
-            _AdminActionCard(
-              icon: Icons.people_outline,
-              iconColor: FlitColors.warning,
-              label: 'View Banned Players',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => _BannedPlayersScreen(
-                      onUnban: (username) {
-                        _showUnbanUserDialog(
-                          context,
-                          prefillUsername: username,
-                        );
-                      },
-                    ),
-                  ),
-                );
-              },
-            ),
-            const SizedBox(height: 8),
-          ],
-
-          // ── Report Queue (moderator + owner) ──
-          if (_can(state, AdminPermission.viewReports)) ...[
-            const _SectionHeader(title: 'Reports'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.flag,
-              iconColor: FlitColors.warning,
-              label: _pendingReportCount > 0
-                  ? 'Player Reports ($_pendingReportCount pending)'
-                  : 'Player Reports',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const _ReportQueuePlaceholder(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.map_outlined,
-              iconColor: FlitColors.warning,
-              label: _pendingClueReportCount > 0
-                  ? 'Clue Reports ($_pendingClueReportCount pending)'
-                  : 'Clue Reports',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const _ClueReportQueue(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── Difficulty Ratings (view: moderator + owner, edit: owner) ──
-          if (_can(state, AdminPermission.viewDifficulty)) ...[
-            const _SectionHeader(title: 'Difficulty Ratings'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.speed,
-              iconColor: const Color(0xFFFF9800),
-              label: _can(state, AdminPermission.editDifficulty)
-                  ? 'View / Edit Country Difficulty'
-                  : 'View Country Difficulty',
-              onTap: () => _showDifficultyEditorDialog(context),
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── Design Preview (moderator + owner) ──
-          if (_can(state, AdminPermission.viewDesignPreviews)) ...[
-            const _SectionHeader(title: 'Design Preview'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.flight,
-              iconColor: FlitColors.accent,
-              label: 'Plane Preview (all variants)',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const PlanePreviewScreen(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.face,
-              iconColor: FlitColors.oceanHighlight,
-              label: 'Avatar Preview (all styles)',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const AvatarPreviewScreen(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.flag,
-              iconColor: FlitColors.landMassHighlight,
-              label: 'Country Preview (flags & outlines)',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const CountryPreviewScreen(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.pets,
-              iconColor: FlitColors.gold,
-              label: 'Companion Preview (all creatures)',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const CompanionPreviewScreen(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── Economy Management (owner only) ──
-          if (_can(state, AdminPermission.editEarnings)) ...[
-            const _SectionHeader(title: 'Economy Management'),
-            const SizedBox(height: 8),
-            if (_economyConfigLoading)
-              const Center(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(vertical: 16),
-                  child: CircularProgressIndicator(),
-                ),
-              )
-            else ...[
-              _AdminActionCard(
-                icon: Icons.monetization_on,
-                iconColor: FlitColors.gold,
-                label: 'Gold Management',
+                label: 'Usage Stats',
                 onTap: () async {
                   await Navigator.of(context).push(
                     MaterialPageRoute<void>(
-                      builder: (_) => const GoldManagementScreen(),
+                      builder: (_) => const AdminStatsScreen(),
+                    ),
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              if (_can(state, AdminPermission.viewCoinLedger)) ...[
+                const SizedBox(height: 8),
+                _AdminActionCard(
+                  icon: Icons.receipt_long,
+                  iconColor: FlitColors.gold,
+                  label: 'Coin Ledger Explorer',
+                  onTap: () => _showCoinLedgerDialog(context),
+                ),
+              ],
+              const SizedBox(height: 24),
+            ],
+
+            // ── User Lookup (moderator + owner) ──
+            if (_can(state, AdminPermission.viewUserData)) ...[
+              const _SectionHeader(title: 'User Lookup'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.person_search,
+                iconColor: FlitColors.oceanHighlight,
+                label: 'Look Up Player',
+                onTap: () => _showUserLookupDialog(context),
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Quick self-actions (owner only) ──
+            if (_can(state, AdminPermission.selfServiceActions)) ...[
+              const _SectionHeader(title: 'Quick Actions (Self)'),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _ActionChip(
+                    label: '+100 Gold',
+                    onTap: () => notifier.addCoins(
+                      100,
+                      applyBoost: false,
+                      source: 'admin_grant',
+                    ),
+                  ),
+                  _ActionChip(
+                    label: '+1,000 Gold',
+                    onTap: () => notifier.addCoins(
+                      1000,
+                      applyBoost: false,
+                      source: 'admin_grant',
+                    ),
+                  ),
+                  _ActionChip(
+                    label: '+999,999 Gold',
+                    onTap: () => notifier.addCoins(
+                      999999,
+                      applyBoost: false,
+                      source: 'admin_grant',
+                    ),
+                  ),
+                  _ActionChip(label: '+50 XP', onTap: () => notifier.addXp(50)),
+                  _ActionChip(
+                      label: '+500 XP', onTap: () => notifier.addXp(500)),
+                  _ActionChip(
+                    label: '+1 Flight',
+                    onTap: () => notifier.incrementGamesPlayed(),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Gift to Player (owner only) ──
+            if (_can(state, AdminPermission.giftGold)) ...[
+              const _SectionHeader(title: 'Gift to Player'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.monetization_on,
+                iconColor: FlitColors.gold,
+                label: 'Gift Gold',
+                onTap: () => _showGiftGoldDialog(context),
+              ),
+              if (_can(state, AdminPermission.giftLevels)) ...[
+                const SizedBox(height: 8),
+                _AdminActionCard(
+                  icon: Icons.arrow_upward,
+                  iconColor: FlitColors.accent,
+                  label: 'Gift Levels',
+                  onTap: () => _showGiftLevelsDialog(context),
+                ),
+              ],
+              if (_can(state, AdminPermission.giftFlights)) ...[
+                const SizedBox(height: 8),
+                _AdminActionCard(
+                  icon: Icons.flight,
+                  iconColor: FlitColors.oceanHighlight,
+                  label: 'Gift Flights',
+                  onTap: () => _showGiftFlightsDialog(context),
+                ),
+              ],
+              if (_can(state, AdminPermission.setCoins)) ...[
+                const SizedBox(height: 8),
+                _AdminActionCard(
+                  icon: Icons.monetization_on_outlined,
+                  iconColor: FlitColors.gold,
+                  label: 'Set Coins',
+                  onTap: () => _showSetStatDialog(
+                    context,
+                    title: 'Set Coins',
+                    statColumn: 'coins',
+                    valueLabel: 'Coins total',
+                    icon: Icons.monetization_on,
+                    iconColor: FlitColors.gold,
+                  ),
+                ),
+              ],
+              if (_can(state, AdminPermission.setLevel)) ...[
+                const SizedBox(height: 8),
+                _AdminActionCard(
+                  icon: Icons.trending_up,
+                  iconColor: FlitColors.accent,
+                  label: 'Set Level',
+                  onTap: () => _showSetStatDialog(
+                    context,
+                    title: 'Set Level',
+                    statColumn: 'level',
+                    valueLabel: 'Level',
+                    icon: Icons.trending_up,
+                    iconColor: FlitColors.accent,
+                  ),
+                ),
+              ],
+              if (_can(state, AdminPermission.setFlights)) ...[
+                const SizedBox(height: 8),
+                _AdminActionCard(
+                  icon: Icons.flight_takeoff,
+                  iconColor: FlitColors.oceanHighlight,
+                  label: 'Set Flights',
+                  onTap: () => _showSetStatDialog(
+                    context,
+                    title: 'Set Flights',
+                    statColumn: 'games_played',
+                    valueLabel: 'Flights',
+                    icon: Icons.flight_takeoff,
+                    iconColor: FlitColors.oceanHighlight,
+                  ),
+                ),
+              ],
+              if (_can(state, AdminPermission.giftCosmetic)) ...[
+                const SizedBox(height: 8),
+                _AdminActionCard(
+                  icon: Icons.star,
+                  iconColor: const Color(0xFF9B59B6),
+                  label: 'Gift Cosmetic Item',
+                  onTap: () => _showGiftCosmeticDialog(context),
+                ),
+              ],
+              if (_can(state, AdminPermission.setLicense)) ...[
+                const SizedBox(height: 8),
+                _AdminActionCard(
+                  icon: Icons.badge,
+                  iconColor: FlitColors.oceanHighlight,
+                  label: 'Set Player License',
+                  onTap: () => _showSetLicenseDialog(context),
+                ),
+              ],
+              if (_can(state, AdminPermission.setAvatar)) ...[
+                const SizedBox(height: 8),
+                _AdminActionCard(
+                  icon: Icons.face,
+                  iconColor: FlitColors.gold,
+                  label: 'Set Player Avatar',
+                  onTap: () => _showSetAvatarDialog(context),
+                ),
+              ],
+              const SizedBox(height: 24),
+            ],
+
+            // ── Moderation (moderator + owner) ──
+            if (_can(state, AdminPermission.changeUsername)) ...[
+              const _SectionHeader(title: 'Moderation'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.edit,
+                iconColor: FlitColors.warning,
+                label: 'Change Player Username',
+                onTap: () => _showChangeUsernameDialog(context),
+              ),
+              const SizedBox(height: 8),
+            ],
+            if (_can(state, AdminPermission.manageRoles)) ...[
+              _AdminActionCard(
+                icon: Icons.shield,
+                iconColor: FlitColors.accent,
+                label: 'Manage Moderators',
+                onTap: () => _showManageRoleDialog(context),
+              ),
+              const SizedBox(height: 8),
+            ],
+            if (_can(state, AdminPermission.unlockAll)) ...[
+              _AdminActionCard(
+                icon: Icons.lock_open,
+                iconColor: FlitColors.success,
+                label: 'Unlock All (Player)',
+                onTap: () => _showUnlockAllDialog(context),
+              ),
+              const SizedBox(height: 8),
+            ],
+            if (_can(state, AdminPermission.changeUsername) ||
+                _can(state, AdminPermission.manageRoles))
+              const SizedBox(height: 24),
+
+            // ── Ban Management (moderator + owner) ──
+            if (_can(state, AdminPermission.tempBanUser)) ...[
+              const _SectionHeader(title: 'Ban Management'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.gavel,
+                iconColor: FlitColors.error,
+                label: 'Ban Player',
+                onTap: () => _showBanUserDialog(context),
+              ),
+              const SizedBox(height: 8),
+            ],
+            if (_can(state, AdminPermission.unbanUser)) ...[
+              _AdminActionCard(
+                icon: Icons.lock_open,
+                iconColor: FlitColors.success,
+                label: 'Unban Player',
+                onTap: () => _showUnbanUserDialog(context),
+              ),
+              const SizedBox(height: 8),
+            ],
+            if (_can(state, AdminPermission.tempBanUser)) ...[
+              _AdminActionCard(
+                icon: Icons.people_outline,
+                iconColor: FlitColors.warning,
+                label: 'View Banned Players',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => _BannedPlayersScreen(
+                        onUnban: (username) {
+                          _showUnbanUserDialog(
+                            context,
+                            prefillUsername: username,
+                          );
+                        },
+                      ),
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 8),
+            ],
+
+            // ── Report Queue (moderator + owner) ──
+            if (_can(state, AdminPermission.viewReports)) ...[
+              const _SectionHeader(title: 'Reports'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.flag,
+                iconColor: FlitColors.warning,
+                label: _pendingReportCount > 0
+                    ? 'Player Reports ($_pendingReportCount pending)'
+                    : 'Player Reports',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const _ReportQueuePlaceholder(),
                     ),
                   );
                   _refreshAdminData();
@@ -2590,292 +2472,414 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
               ),
               const SizedBox(height: 8),
               _AdminActionCard(
-                icon: Icons.attach_money,
-                iconColor: FlitColors.gold,
-                label: 'Set Earnings',
-                onTap: () => _showEarningsConfigDialog(context),
+                icon: Icons.map_outlined,
+                iconColor: FlitColors.warning,
+                label: _pendingClueReportCount > 0
+                    ? 'Clue Reports ($_pendingClueReportCount pending)'
+                    : 'Clue Reports',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const _ClueReportQueue(),
+                    ),
+                  );
+                  _refreshAdminData();
+                },
               ),
-              if (_can(state, AdminPermission.editPromotions)) ...[
-                const SizedBox(height: 8),
-                _AdminActionCard(
-                  icon: Icons.local_offer,
-                  iconColor: FlitColors.accent,
-                  label: 'Manage Promotions',
-                  onTap: () => _showPromotionsDialog(context),
-                ),
-              ],
-              if (_can(state, AdminPermission.editGoldPackages)) ...[
-                const SizedBox(height: 8),
-                _AdminActionCard(
-                  icon: Icons.inventory_2,
-                  iconColor: FlitColors.gold,
-                  label: 'Edit Gold Packages',
-                  onTap: () => _showGoldPackagesDialog(context),
-                ),
-              ],
-              if (_can(state, AdminPermission.editShopPrices)) ...[
-                const SizedBox(height: 8),
-                _AdminActionCard(
-                  icon: Icons.price_change,
-                  iconColor: FlitColors.oceanHighlight,
-                  label: 'Shop Price Overrides',
-                  onTap: () => _showShopPriceOverridesDialog(context),
-                ),
-              ],
+              const SizedBox(height: 24),
             ],
-            const SizedBox(height: 24),
-          ],
 
-          // ── Flight School Config (owner only) ──
-          if (_can(state, AdminPermission.editEarnings)) ...[
-            const _SectionHeader(title: 'Flight School'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.school,
-              iconColor: FlitColors.oceanHighlight,
-              label: 'Flight School Config',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const FlightSchoolAdminScreen(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 24),
-          ],
+            // ── Difficulty Ratings (view: moderator + owner, edit: owner) ──
+            if (_can(state, AdminPermission.viewDifficulty)) ...[
+              const _SectionHeader(title: 'Difficulty Ratings'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.speed,
+                iconColor: const Color(0xFFFF9800),
+                label: _can(state, AdminPermission.editDifficulty)
+                    ? 'View / Edit Country Difficulty'
+                    : 'View Country Difficulty',
+                onTap: () => _showDifficultyEditorDialog(context),
+              ),
+              const SizedBox(height: 24),
+            ],
 
-          // ── Country Aliases (moderator + owner) ──
-          if (_can(state, AdminPermission.editAliases)) ...[
-            const _SectionHeader(title: 'Country Aliases'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.spellcheck,
-              iconColor: FlitColors.success,
-              label: 'Country Aliases',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const AliasAdminScreen(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── App Config (owner only) ──
-          if (_can(state, AdminPermission.editAppConfig)) ...[
-            const _SectionHeader(title: 'App Config'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.system_update,
-              iconColor: FlitColors.accent,
-              label: 'Version Gate & Maintenance',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const _AppConfigPlaceholder(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── Announcements (moderator + owner) ──
-          if (_can(state, AdminPermission.viewAnnouncements)) ...[
-            const _SectionHeader(title: 'Announcements'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.campaign,
-              iconColor: FlitColors.gold,
-              label: 'Manage Announcements',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const _AnnouncementsPlaceholder(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── Feature Flags (owner: edit, moderator: view) ──
-          if (_can(state, AdminPermission.viewFeatureFlags)) ...[
-            const _SectionHeader(title: 'Feature Flags'),
-            const SizedBox(height: 8),
-            if (_featureFlagsLoading)
-              const Center(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(vertical: 16),
-                  child: CircularProgressIndicator(),
-                ),
-              )
-            else
-              ...(_featureFlags.entries.map(
-                (entry) => Padding(
-                  key: ValueKey('ff_${entry.key}'),
-                  padding: const EdgeInsets.only(bottom: 8),
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 16,
-                      vertical: 12,
+            // ── Design Preview (moderator + owner) ──
+            if (_can(state, AdminPermission.viewDesignPreviews)) ...[
+              const _SectionHeader(title: 'Design Preview'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.flight,
+                iconColor: FlitColors.accent,
+                label: 'Plane Preview (all variants)',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const PlanePreviewScreen(),
                     ),
-                    decoration: BoxDecoration(
-                      color: FlitColors.cardBackground,
-                      borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: FlitColors.cardBorder),
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.face,
+                iconColor: FlitColors.oceanHighlight,
+                label: 'Avatar Preview (all styles)',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const AvatarPreviewScreen(),
                     ),
-                    child: Row(
-                      children: [
-                        Icon(
-                          entry.value ? Icons.toggle_on : Icons.toggle_off,
-                          color: entry.value
-                              ? FlitColors.success
-                              : FlitColors.textMuted,
-                          size: 28,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Text(
-                            entry.key,
-                            style: const TextStyle(
-                              color: FlitColors.textPrimary,
-                              fontSize: 14,
-                            ),
-                          ),
-                        ),
-                        if (_can(state, AdminPermission.editFeatureFlags))
-                          Switch(
-                            value: entry.value,
-                            activeColor: FlitColors.success,
-                            onChanged: (val) async {
-                              // Optimistic local update — avoids a full
-                              // async reload that can reorder the list.
-                              final oldVal = entry.value;
-                              setState(() => _featureFlags[entry.key] = val);
-                              try {
-                                await FeatureFlagService.instance.setFlag(
-                                  flagKey: entry.key,
-                                  enabled: val,
-                                );
-                              } catch (_) {
-                                // Revert on failure.
-                                if (mounted) {
-                                  setState(
-                                    () => _featureFlags[entry.key] = oldVal,
-                                  );
-                                  _snack(
-                                    context,
-                                    'Failed to update flag',
-                                    isError: true,
-                                  );
-                                }
-                              }
-                            },
-                          )
-                        else
-                          Text(
-                            entry.value ? 'ON' : 'OFF',
-                            style: TextStyle(
-                              color: entry.value
-                                  ? FlitColors.success
-                                  : FlitColors.textMuted,
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                      ],
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.flag,
+                iconColor: FlitColors.landMassHighlight,
+                label: 'Country Preview (flags & outlines)',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const CountryPreviewScreen(),
                     ),
-                  ),
-                ),
-              )),
-            const SizedBox(height: 24),
-          ],
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.pets,
+                iconColor: FlitColors.gold,
+                label: 'Companion Preview (all creatures)',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const CompanionPreviewScreen(),
+                    ),
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 24),
+            ],
 
-          // ── Suspicious Activity (moderator + owner) ──
-          if (_can(state, AdminPermission.viewSuspiciousActivity)) ...[
-            const _SectionHeader(title: 'Anomaly Detection'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.warning_amber,
-              iconColor: FlitColors.error,
-              label: 'Suspicious Activity',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const _SuspiciousActivityPlaceholder(),
+            // ── Economy Management (owner only) ──
+            if (_can(state, AdminPermission.editEarnings)) ...[
+              const _SectionHeader(title: 'Economy Management'),
+              const SizedBox(height: 8),
+              if (_economyConfigLoading)
+                const Center(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(vertical: 16),
+                    child: CircularProgressIndicator(),
                   ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── Game Log (moderator + owner) ──
-          if (_can(state, AdminPermission.viewGameLog)) ...[
-            const _SectionHeader(title: 'Game Log'),
-            const SizedBox(height: 8),
-            _AdminActionCard(
-              icon: Icons.bug_report,
-              iconColor: FlitColors.warning,
-              label:
-                  'View Game Log (${GameLog.instance.entries.length} entries)',
-              onTap: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const _GameLogScreen(),
-                  ),
-                );
-                _refreshAdminData();
-              },
-            ),
-            const SizedBox(height: 24),
-          ],
-
-          // ── Info footer ──
-          Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: FlitColors.cardBackground,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: FlitColors.cardBorder),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '$roleName Panel',
-                  style: const TextStyle(
-                    color: FlitColors.accent,
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
+                )
+              else ...[
+                _AdminActionCard(
+                  icon: Icons.monetization_on,
+                  iconColor: FlitColors.gold,
+                  label: 'Gold Management',
+                  onTap: () async {
+                    await Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const GoldManagementScreen(),
+                      ),
+                    );
+                    _refreshAdminData();
+                  },
                 ),
                 const SizedBox(height: 8),
-                Text(
-                  player.isOwner
-                      ? 'Full owner access. Gift actions write directly to '
-                          'Supabase. Username changes enforce uniqueness.'
-                      : 'Moderator access. You can view player data, game '
-                          'designs, and rename offensive usernames. Economy '
-                          'and gifting tools are restricted to owners.',
-                  style: const TextStyle(
-                    color: FlitColors.textSecondary,
-                    fontSize: 14,
-                  ),
+                _AdminActionCard(
+                  icon: Icons.attach_money,
+                  iconColor: FlitColors.gold,
+                  label: 'Set Earnings',
+                  onTap: () => _showEarningsConfigDialog(context),
                 ),
+                if (_can(state, AdminPermission.editPromotions)) ...[
+                  const SizedBox(height: 8),
+                  _AdminActionCard(
+                    icon: Icons.local_offer,
+                    iconColor: FlitColors.accent,
+                    label: 'Manage Promotions',
+                    onTap: () => _showPromotionsDialog(context),
+                  ),
+                ],
+                if (_can(state, AdminPermission.editGoldPackages)) ...[
+                  const SizedBox(height: 8),
+                  _AdminActionCard(
+                    icon: Icons.inventory_2,
+                    iconColor: FlitColors.gold,
+                    label: 'Edit Gold Packages',
+                    onTap: () => _showGoldPackagesDialog(context),
+                  ),
+                ],
+                if (_can(state, AdminPermission.editShopPrices)) ...[
+                  const SizedBox(height: 8),
+                  _AdminActionCard(
+                    icon: Icons.price_change,
+                    iconColor: FlitColors.oceanHighlight,
+                    label: 'Shop Price Overrides',
+                    onTap: () => _showShopPriceOverridesDialog(context),
+                  ),
+                ],
               ],
+              const SizedBox(height: 24),
+            ],
+
+            // ── Flight School Config (owner only) ──
+            if (_can(state, AdminPermission.editEarnings)) ...[
+              const _SectionHeader(title: 'Flight School'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.school,
+                iconColor: FlitColors.oceanHighlight,
+                label: 'Flight School Config',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const FlightSchoolAdminScreen(),
+                    ),
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Country Aliases (moderator + owner) ──
+            if (_can(state, AdminPermission.editAliases)) ...[
+              const _SectionHeader(title: 'Country Aliases'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.spellcheck,
+                iconColor: FlitColors.success,
+                label: 'Country Aliases',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const AliasAdminScreen(),
+                    ),
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── App Config (owner only) ──
+            if (_can(state, AdminPermission.editAppConfig)) ...[
+              const _SectionHeader(title: 'App Config'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.system_update,
+                iconColor: FlitColors.accent,
+                label: 'Version Gate & Maintenance',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const _AppConfigPlaceholder(),
+                    ),
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Announcements (moderator + owner) ──
+            if (_can(state, AdminPermission.viewAnnouncements)) ...[
+              const _SectionHeader(title: 'Announcements'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.campaign,
+                iconColor: FlitColors.gold,
+                label: 'Manage Announcements',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const _AnnouncementsPlaceholder(),
+                    ),
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Feature Flags (owner: edit, moderator: view) ──
+            if (_can(state, AdminPermission.viewFeatureFlags)) ...[
+              const _SectionHeader(title: 'Feature Flags'),
+              const SizedBox(height: 8),
+              if (_featureFlagsLoading)
+                const Center(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(vertical: 16),
+                    child: CircularProgressIndicator(),
+                  ),
+                )
+              else
+                ...(_featureFlags.entries.map(
+                  (entry) => Padding(
+                    key: ValueKey('ff_${entry.key}'),
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
+                      decoration: BoxDecoration(
+                        color: FlitColors.cardBackground,
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(color: FlitColors.cardBorder),
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(
+                            entry.value ? Icons.toggle_on : Icons.toggle_off,
+                            color: entry.value
+                                ? FlitColors.success
+                                : FlitColors.textMuted,
+                            size: 28,
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Text(
+                              entry.key,
+                              style: const TextStyle(
+                                color: FlitColors.textPrimary,
+                                fontSize: 14,
+                              ),
+                            ),
+                          ),
+                          if (_can(state, AdminPermission.editFeatureFlags))
+                            Switch(
+                              value: entry.value,
+                              activeColor: FlitColors.success,
+                              onChanged: (val) async {
+                                // Optimistic local update — avoids a full
+                                // async reload that can reorder the list.
+                                final oldVal = entry.value;
+                                setState(() => _featureFlags[entry.key] = val);
+                                try {
+                                  await FeatureFlagService.instance.setFlag(
+                                    flagKey: entry.key,
+                                    enabled: val,
+                                  );
+                                } catch (_) {
+                                  // Revert on failure.
+                                  if (mounted) {
+                                    setState(
+                                      () => _featureFlags[entry.key] = oldVal,
+                                    );
+                                    _snack(
+                                      context,
+                                      'Failed to update flag',
+                                      isError: true,
+                                    );
+                                  }
+                                }
+                              },
+                            )
+                          else
+                            Text(
+                              entry.value ? 'ON' : 'OFF',
+                              style: TextStyle(
+                                color: entry.value
+                                    ? FlitColors.success
+                                    : FlitColors.textMuted,
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                )),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Suspicious Activity (moderator + owner) ──
+            if (_can(state, AdminPermission.viewSuspiciousActivity)) ...[
+              const _SectionHeader(title: 'Anomaly Detection'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.warning_amber,
+                iconColor: FlitColors.error,
+                label: 'Suspicious Activity',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const _SuspiciousActivityPlaceholder(),
+                    ),
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Game Log (moderator + owner) ──
+            if (_can(state, AdminPermission.viewGameLog)) ...[
+              const _SectionHeader(title: 'Game Log'),
+              const SizedBox(height: 8),
+              _AdminActionCard(
+                icon: Icons.bug_report,
+                iconColor: FlitColors.warning,
+                label:
+                    'View Game Log (${GameLog.instance.entries.length} entries)',
+                onTap: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const _GameLogScreen(),
+                    ),
+                  );
+                  _refreshAdminData();
+                },
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // ── Info footer ──
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: FlitColors.cardBackground,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: FlitColors.cardBorder),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '$roleName Panel',
+                    style: const TextStyle(
+                      color: FlitColors.accent,
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    player.isOwner
+                        ? 'Full owner access. Gift actions write directly to '
+                            'Supabase. Username changes enforce uniqueness.'
+                        : 'Moderator access. You can view player data, game '
+                            'designs, and rename offensive usernames. Economy '
+                            'and gifting tools are restricted to owners.',
+                    style: const TextStyle(
+                      color: FlitColors.textSecondary,
+                      fontSize: 14,
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/admin/admin_stats_screen.dart
+++ b/lib/features/admin/admin_stats_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 
 /// Admin usage statistics dashboard.
 ///
@@ -222,60 +223,62 @@ class _AdminStatsScreenState extends State<AdminStatsScreen> {
           ),
         ],
       ),
-      body: _loading
-          ? const Center(
-              child: CircularProgressIndicator(color: FlitColors.accent),
-            )
-          : _error != null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
+      body: MenuContentWrapper(
+        child: _loading
+            ? const Center(
+                child: CircularProgressIndicator(color: FlitColors.accent),
+              )
+            : _error != null
+                ? Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(
+                            Icons.error_outline,
+                            color: FlitColors.error,
+                            size: 48,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            _error!,
+                            style: const TextStyle(color: FlitColors.textMuted),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 16),
+                          ElevatedButton(
+                            onPressed: _loadStats,
+                            child: const Text('Retry'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                : RefreshIndicator(
+                    onRefresh: _loadStats,
+                    color: FlitColors.accent,
+                    child: ListView(
+                      padding: const EdgeInsets.all(16),
                       children: [
-                        const Icon(
-                          Icons.error_outline,
-                          color: FlitColors.error,
-                          size: 48,
-                        ),
-                        const SizedBox(height: 12),
-                        Text(
-                          _error!,
-                          style: const TextStyle(color: FlitColors.textMuted),
-                          textAlign: TextAlign.center,
-                        ),
+                        _buildPlayerStats(),
                         const SizedBox(height: 16),
-                        ElevatedButton(
-                          onPressed: _loadStats,
-                          child: const Text('Retry'),
-                        ),
+                        _buildGameActivity(),
+                        const SizedBox(height: 16),
+                        _buildSocialStats(),
+                        const SizedBox(height: 16),
+                        _buildEconomyHealth(),
+                        const SizedBox(height: 16),
+                        _buildTopRichest(),
+                        const SizedBox(height: 16),
+                        _buildTopPlayers(),
+                        const SizedBox(height: 16),
+                        _buildRecentGames(),
+                        const SizedBox(height: 24),
                       ],
                     ),
                   ),
-                )
-              : RefreshIndicator(
-                  onRefresh: _loadStats,
-                  color: FlitColors.accent,
-                  child: ListView(
-                    padding: const EdgeInsets.all(16),
-                    children: [
-                      _buildPlayerStats(),
-                      const SizedBox(height: 16),
-                      _buildGameActivity(),
-                      const SizedBox(height: 16),
-                      _buildSocialStats(),
-                      const SizedBox(height: 16),
-                      _buildEconomyHealth(),
-                      const SizedBox(height: 16),
-                      _buildTopRichest(),
-                      const SizedBox(height: 16),
-                      _buildTopPlayers(),
-                      const SizedBox(height: 16),
-                      _buildRecentGames(),
-                      const SizedBox(height: 24),
-                    ],
-                  ),
-                ),
+      ),
     );
   }
 

--- a/lib/features/admin/alias_admin_screen.dart
+++ b/lib/features/admin/alias_admin_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../game/data/country_aliases.dart';
 import '../../game/map/country_data.dart';
 import '../../game/map/region.dart';
@@ -212,83 +213,85 @@ class _AliasAdminScreenState extends State<AliasAdminScreen> {
           ),
         ],
       ),
-      body: Column(
-        children: [
-          // Search bar.
-          Padding(
-            padding: const EdgeInsets.all(12),
-            child: TextField(
-              controller: _searchController,
-              style: const TextStyle(color: FlitColors.textPrimary),
-              decoration: InputDecoration(
-                hintText: 'Search countries or aliases...',
-                hintStyle: TextStyle(
-                    color: FlitColors.textSecondary.withValues(alpha: 0.5)),
-                prefixIcon:
-                    const Icon(Icons.search, color: FlitColors.textSecondary),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: BorderSide(
-                      color: FlitColors.accent.withValues(alpha: 0.3)),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide:
-                      const BorderSide(color: FlitColors.accent, width: 2),
-                ),
-                filled: true,
-                fillColor: FlitColors.backgroundMid,
-                contentPadding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              ),
-              onChanged: (v) => setState(() => _searchQuery = v.trim()),
-            ),
-          ),
-          // Count.
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              children: [
-                Text(
-                  '${filtered.length} areas',
-                  style: const TextStyle(
-                      color: FlitColors.textSecondary, fontSize: 13),
-                ),
-                const Spacer(),
-                if (_showRemoved)
-                  Text(
-                    'Showing removed',
-                    style: TextStyle(
-                      color: FlitColors.error.withValues(alpha: 0.7),
-                      fontSize: 11,
-                      fontStyle: FontStyle.italic,
-                    ),
+      body: MenuContentWrapper(
+        child: Column(
+          children: [
+            // Search bar.
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: TextField(
+                controller: _searchController,
+                style: const TextStyle(color: FlitColors.textPrimary),
+                decoration: InputDecoration(
+                  hintText: 'Search countries or aliases...',
+                  hintStyle: TextStyle(
+                      color: FlitColors.textSecondary.withValues(alpha: 0.5)),
+                  prefixIcon:
+                      const Icon(Icons.search, color: FlitColors.textSecondary),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
                   ),
-              ],
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(
+                        color: FlitColors.accent.withValues(alpha: 0.3)),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide:
+                        const BorderSide(color: FlitColors.accent, width: 2),
+                  ),
+                  filled: true,
+                  fillColor: FlitColors.backgroundMid,
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                ),
+                onChanged: (v) => setState(() => _searchQuery = v.trim()),
+              ),
             ),
-          ),
-          const SizedBox(height: 4),
-          // List.
-          Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              itemCount: filtered.length,
-              itemBuilder: (context, index) {
-                final entry = filtered[index];
-                return _AliasCard(
-                  entry: entry,
-                  showRemoved: _showRemoved,
-                  onAdd: () => _showAddAliasDialog(entry),
-                  onRemove: (alias) => _removeAlias(entry, alias),
-                  onRestore: (alias) => _restoreBaselineAlias(entry, alias),
-                );
-              },
+            // Count.
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Text(
+                    '${filtered.length} areas',
+                    style: const TextStyle(
+                        color: FlitColors.textSecondary, fontSize: 13),
+                  ),
+                  const Spacer(),
+                  if (_showRemoved)
+                    Text(
+                      'Showing removed',
+                      style: TextStyle(
+                        color: FlitColors.error.withValues(alpha: 0.7),
+                        fontSize: 11,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                ],
+              ),
             ),
-          ),
-        ],
+            const SizedBox(height: 4),
+            // List.
+            Expanded(
+              child: ListView.builder(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                itemCount: filtered.length,
+                itemBuilder: (context, index) {
+                  final entry = filtered[index];
+                  return _AliasCard(
+                    entry: entry,
+                    showRemoved: _showRemoved,
+                    onAdd: () => _showAddAliasDialog(entry),
+                    onRemove: (alias) => _removeAlias(entry, alias),
+                    onRestore: (alias) => _restoreBaselineAlias(entry, alias),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/admin/flight_school_admin_screen.dart
+++ b/lib/features/admin/flight_school_admin_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../game/quiz/flight_school_level.dart';
 import '../../game/quiz/quiz_category.dart';
 import '../../game/quiz/quiz_difficulty.dart';
@@ -261,67 +262,69 @@ class _FlightSchoolAdminScreenState extends State<FlightSchoolAdminScreen> {
         title: const Text('Flight School Config'),
         centerTitle: true,
       ),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : _error != null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        const Icon(
-                          Icons.error_outline,
-                          color: FlitColors.error,
-                          size: 48,
-                        ),
-                        const SizedBox(height: 12),
-                        Text(
-                          _error!,
-                          style: const TextStyle(
-                            color: FlitColors.textSecondary,
-                            fontSize: 14,
+      body: MenuContentWrapper(
+        child: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : _error != null
+                ? Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(
+                            Icons.error_outline,
+                            color: FlitColors.error,
+                            size: 48,
                           ),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 16),
-                        ElevatedButton(
-                          onPressed: _loadConfig,
-                          child: const Text('Retry'),
-                        ),
-                      ],
-                    ),
-                  ),
-                )
-              : ListView(
-                  padding: const EdgeInsets.all(16),
-                  children: [
-                    // Level selector dropdown
-                    _buildLevelSelector(),
-                    const SizedBox(height: 20),
-
-                    // Level settings card
-                    _buildLevelSettingsCard(),
-                    const SizedBox(height: 20),
-
-                    // Category multipliers header
-                    const Padding(
-                      padding: EdgeInsets.only(bottom: 8),
-                      child: Text(
-                        'CATEGORY DIFFICULTY MULTIPLIERS',
-                        style: TextStyle(
-                          color: FlitColors.textMuted,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
-                          letterSpacing: 1,
-                        ),
+                          const SizedBox(height: 12),
+                          Text(
+                            _error!,
+                            style: const TextStyle(
+                              color: FlitColors.textSecondary,
+                              fontSize: 14,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 16),
+                          ElevatedButton(
+                            onPressed: _loadConfig,
+                            child: const Text('Retry'),
+                          ),
+                        ],
                       ),
                     ),
+                  )
+                : ListView(
+                    padding: const EdgeInsets.all(16),
+                    children: [
+                      // Level selector dropdown
+                      _buildLevelSelector(),
+                      const SizedBox(height: 20),
 
-                    // Category rows
-                    ...QuizCategory.values.map(_buildCategoryRow),
-                  ],
-                ),
+                      // Level settings card
+                      _buildLevelSettingsCard(),
+                      const SizedBox(height: 20),
+
+                      // Category multipliers header
+                      const Padding(
+                        padding: EdgeInsets.only(bottom: 8),
+                        child: Text(
+                          'CATEGORY DIFFICULTY MULTIPLIERS',
+                          style: TextStyle(
+                            color: FlitColors.textMuted,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: 1,
+                          ),
+                        ),
+                      ),
+
+                      // Category rows
+                      ...QuizCategory.values.map(_buildCategoryRow),
+                    ],
+                  ),
+      ),
     );
   }
 

--- a/lib/features/admin/gold_management_screen.dart
+++ b/lib/features/admin/gold_management_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/economy_config.dart';
 import '../../data/services/economy_config_service.dart';
 import '../../game/quiz/flight_school_level.dart';
@@ -360,17 +361,19 @@ class _GoldManagementScreenState extends State<GoldManagementScreen> {
         title: const Text('Gold Management'),
         centerTitle: true,
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          _buildPlayerGoldSection(),
-          const SizedBox(height: 16),
-          _buildFlightSchoolEconomySection(),
-          const SizedBox(height: 16),
-          _buildEconomyConfigSection(),
-          const SizedBox(height: 16),
-          _buildAuditLogSection(),
-        ],
+      body: MenuContentWrapper(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            _buildPlayerGoldSection(),
+            const SizedBox(height: 16),
+            _buildFlightSchoolEconomySection(),
+            const SizedBox(height: 16),
+            _buildEconomyConfigSection(),
+            const SizedBox(height: 16),
+            _buildAuditLogSection(),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/auth/banned_screen.dart
+++ b/lib/features/auth/banned_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 
 /// Full-screen "Account Suspended" display.
 ///
@@ -31,73 +32,77 @@ class BannedScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: FlitColors.backgroundDark,
       body: SafeArea(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(Icons.gavel, color: FlitColors.error, size: 64),
-                const SizedBox(height: 24),
-                const Text(
-                  'Account Suspended',
-                  style: TextStyle(
-                    color: FlitColors.textPrimary,
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                if (banReason != null && banReason!.isNotEmpty) ...[
-                  Container(
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: FlitColors.error.withOpacity(0.15),
-                      borderRadius: BorderRadius.circular(12),
-                      border: Border.all(
-                        color: FlitColors.error.withOpacity(0.3),
-                      ),
-                    ),
-                    child: Text(
-                      banReason!,
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        color: FlitColors.textPrimary,
-                        fontSize: 15,
-                      ),
+        child: MenuContentWrapper(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.gavel, color: FlitColors.error, size: 64),
+                  const SizedBox(height: 24),
+                  const Text(
+                    'Account Suspended',
+                    style: TextStyle(
+                      color: FlitColors.textPrimary,
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
                   const SizedBox(height: 16),
-                ],
-                Text(
-                  _expiryText,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: FlitColors.textSecondary,
-                    fontSize: 14,
-                  ),
-                ),
-                const SizedBox(height: 32),
-                OutlinedButton.icon(
-                  onPressed: () {
-                    final uri = Uri(
-                      scheme: 'mailto',
-                      path: 'support@flit.app',
-                      queryParameters: {'subject': 'Account Suspension Appeal'},
-                    );
-                    launchUrl(uri);
-                  },
-                  icon: const Icon(Icons.email_outlined, size: 18),
-                  label: const Text('Contact Support'),
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: FlitColors.textSecondary,
-                    side: const BorderSide(color: FlitColors.cardBorder),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
+                  if (banReason != null && banReason!.isNotEmpty) ...[
+                    Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: FlitColors.error.withOpacity(0.15),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: FlitColors.error.withOpacity(0.3),
+                        ),
+                      ),
+                      child: Text(
+                        banReason!,
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: FlitColors.textPrimary,
+                          fontSize: 15,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+                  Text(
+                    _expiryText,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: FlitColors.textSecondary,
+                      fontSize: 14,
                     ),
                   ),
-                ),
-              ],
+                  const SizedBox(height: 32),
+                  OutlinedButton.icon(
+                    onPressed: () {
+                      final uri = Uri(
+                        scheme: 'mailto',
+                        path: 'support@flit.app',
+                        queryParameters: {
+                          'subject': 'Account Suspension Appeal'
+                        },
+                      );
+                      launchUrl(uri);
+                    },
+                    icon: const Icon(Icons.email_outlined, size: 18),
+                    label: const Text('Contact Support'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: FlitColors.textSecondary,
+                      side: const BorderSide(color: FlitColors.cardBorder),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/features/auth/login_screen.dart
+++ b/lib/features/auth/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/app_remote_config.dart';
 import '../../data/models/player.dart';
 import '../../data/providers/account_provider.dart';
@@ -106,67 +107,73 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           fit: StackFit.expand,
           children: [
             const _AuthBackground(),
-            SafeArea(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(horizontal: 32),
-                child: Column(
-                  children: [
-                    SizedBox(height: MediaQuery.of(context).size.height * 0.12),
-                    const Text(
-                      'FLIT',
-                      style: TextStyle(
-                        color: FlitColors.textPrimary,
-                        fontSize: 64,
-                        fontWeight: FontWeight.w900,
-                        letterSpacing: 16,
+            MenuContentWrapper(
+              child: SafeArea(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(horizontal: 32),
+                  child: Column(
+                    children: [
+                      SizedBox(
+                        height: MediaQuery.of(context).size.height * 0.12,
                       ),
-                    ),
-                    const SizedBox(height: 4),
-                    const Text(
-                      'A GEOGRAPHICAL ADVENTURE',
-                      style: TextStyle(
-                        color: FlitColors.gold,
-                        fontSize: 11,
-                        fontWeight: FontWeight.w600,
-                        letterSpacing: 3,
-                      ),
-                    ),
-                    const SizedBox(height: 48),
-                    if (_mode == _AuthMode.welcome) _buildWelcome(),
-                    if (_mode == _AuthMode.signUp) _buildSignUp(),
-                    if (_mode == _AuthMode.signIn) _buildSignIn(),
-                    if (_mode == _AuthMode.confirmEmail) _buildConfirmEmail(),
-                    if (_mode == _AuthMode.forgotPassword)
-                      _buildForgotPassword(),
-                    if (_mode == _AuthMode.resetEmailSent)
-                      _buildResetEmailSent(),
-                    if (_error != null) ...[
-                      const SizedBox(height: 16),
-                      _ErrorBanner(message: _error!),
-                    ],
-                    if (_isLoading) ...[
-                      const SizedBox(height: 24),
-                      const CircularProgressIndicator(color: FlitColors.accent),
-                    ],
-                    const SizedBox(height: 40),
-                    const Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        _PrivacyLink(),
-                        SizedBox(width: 16),
-                        Text(
-                          '|',
-                          style: TextStyle(
-                            color: FlitColors.textMuted,
-                            fontSize: 11,
-                          ),
+                      const Text(
+                        'FLIT',
+                        style: TextStyle(
+                          color: FlitColors.textPrimary,
+                          fontSize: 64,
+                          fontWeight: FontWeight.w900,
+                          letterSpacing: 16,
                         ),
-                        SizedBox(width: 16),
-                        _TermsLink(),
+                      ),
+                      const SizedBox(height: 4),
+                      const Text(
+                        'A GEOGRAPHICAL ADVENTURE',
+                        style: TextStyle(
+                          color: FlitColors.gold,
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 3,
+                        ),
+                      ),
+                      const SizedBox(height: 48),
+                      if (_mode == _AuthMode.welcome) _buildWelcome(),
+                      if (_mode == _AuthMode.signUp) _buildSignUp(),
+                      if (_mode == _AuthMode.signIn) _buildSignIn(),
+                      if (_mode == _AuthMode.confirmEmail) _buildConfirmEmail(),
+                      if (_mode == _AuthMode.forgotPassword)
+                        _buildForgotPassword(),
+                      if (_mode == _AuthMode.resetEmailSent)
+                        _buildResetEmailSent(),
+                      if (_error != null) ...[
+                        const SizedBox(height: 16),
+                        _ErrorBanner(message: _error!),
                       ],
-                    ),
-                    const SizedBox(height: 16),
-                  ],
+                      if (_isLoading) ...[
+                        const SizedBox(height: 24),
+                        const CircularProgressIndicator(
+                          color: FlitColors.accent,
+                        ),
+                      ],
+                      const SizedBox(height: 40),
+                      const Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          _PrivacyLink(),
+                          SizedBox(width: 16),
+                          Text(
+                            '|',
+                            style: TextStyle(
+                              color: FlitColors.textMuted,
+                              fontSize: 11,
+                            ),
+                          ),
+                          SizedBox(width: 16),
+                          _TermsLink(),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/features/auth/maintenance_screen.dart
+++ b/lib/features/auth/maintenance_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/app_remote_config.dart';
 import '../../data/services/app_config_service.dart';
 import 'login_screen.dart';
@@ -44,60 +45,62 @@ class _MaintenanceScreenState extends State<MaintenanceScreen> {
     return Scaffold(
       backgroundColor: FlitColors.backgroundDark,
       body: SafeArea(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(
-                  Icons.construction,
-                  color: FlitColors.warning,
-                  size: 64,
-                ),
-                const SizedBox(height: 24),
-                const Text(
-                  'Under Maintenance',
-                  style: TextStyle(
-                    color: FlitColors.textPrimary,
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
+        child: MenuContentWrapper(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.construction,
+                    color: FlitColors.warning,
+                    size: 64,
                   ),
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  widget.message ??
-                      'Flit is temporarily down for maintenance. '
-                          'Please check back shortly.',
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: FlitColors.textSecondary,
-                    fontSize: 15,
-                  ),
-                ),
-                const SizedBox(height: 32),
-                ElevatedButton.icon(
-                  onPressed: _checking ? null : _retry,
-                  icon: _checking
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: FlitColors.textPrimary,
-                          ),
-                        )
-                      : const Icon(Icons.refresh, size: 18),
-                  label: Text(_checking ? 'Checking...' : 'Retry'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: FlitColors.warning,
-                    foregroundColor: FlitColors.textPrimary,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
+                  const SizedBox(height: 24),
+                  const Text(
+                    'Under Maintenance',
+                    style: TextStyle(
+                      color: FlitColors.textPrimary,
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
-                ),
-              ],
+                  const SizedBox(height: 16),
+                  Text(
+                    widget.message ??
+                        'Flit is temporarily down for maintenance. '
+                            'Please check back shortly.',
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: FlitColors.textSecondary,
+                      fontSize: 15,
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  ElevatedButton.icon(
+                    onPressed: _checking ? null : _retry,
+                    icon: _checking
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: FlitColors.textPrimary,
+                            ),
+                          )
+                        : const Icon(Icons.refresh, size: 18),
+                    label: Text(_checking ? 'Checking...' : 'Retry'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: FlitColors.warning,
+                      foregroundColor: FlitColors.textPrimary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/features/auth/update_required_screen.dart
+++ b/lib/features/auth/update_required_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../core/utils/platform_stub.dart'
     if (dart.library.io) '../../core/utils/platform_native.dart';
 
@@ -30,51 +31,53 @@ class UpdateRequiredScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: FlitColors.backgroundDark,
       body: SafeArea(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(
-                  Icons.system_update,
-                  color: FlitColors.accent,
-                  size: 64,
-                ),
-                const SizedBox(height: 24),
-                const Text(
-                  'Update Required',
-                  style: TextStyle(
-                    color: FlitColors.textPrimary,
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
+        child: MenuContentWrapper(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.system_update,
+                    color: FlitColors.accent,
+                    size: 64,
                   ),
-                ),
-                const SizedBox(height: 16),
-                const Text(
-                  'A new version of Flit is available. Please update to '
-                  'continue playing.',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: FlitColors.textSecondary,
-                    fontSize: 15,
-                  ),
-                ),
-                const SizedBox(height: 32),
-                if (!kIsWeb)
-                  ElevatedButton.icon(
-                    onPressed: _openStore,
-                    icon: const Icon(Icons.download, size: 18),
-                    label: const Text('Update Now'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: FlitColors.accent,
-                      foregroundColor: FlitColors.textPrimary,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
+                  const SizedBox(height: 24),
+                  const Text(
+                    'Update Required',
+                    style: TextStyle(
+                      color: FlitColors.textPrimary,
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
-              ],
+                  const SizedBox(height: 16),
+                  const Text(
+                    'A new version of Flit is available. Please update to '
+                    'continue playing.',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: FlitColors.textSecondary,
+                      fontSize: 15,
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  if (!kIsWeb)
+                    ElevatedButton.icon(
+                      onPressed: _openStore,
+                      icon: const Icon(Icons.download, size: 18),
+                      label: const Text('Update Now'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: FlitColors.accent,
+                        foregroundColor: FlitColors.textPrimary,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/features/avatar/avatar_editor_screen.dart
+++ b/lib/features/avatar/avatar_editor_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/avatar_config.dart';
 import '../../data/providers/account_provider.dart';
 import '../shop/shop_screen.dart';
@@ -1854,46 +1855,48 @@ class _AvatarEditorScreenState extends ConsumerState<AvatarEditorScreen> {
           ),
         ],
       ),
-      body: Column(
-        children: [
-          // -- Avatar preview --
-          _AvatarPreviewSection(config: _config),
+      body: MenuContentWrapper(
+        child: Column(
+          children: [
+            // -- Avatar preview --
+            _AvatarPreviewSection(config: _config),
 
-          // -- Category tabs --
-          _CategoryTabBar(
-            categories: _categories,
-            selectedIndex: _selectedCategory,
-            onSelected: (index) {
-              setState(() => _selectedCategory = index);
-            },
-          ),
-
-          // -- Parts grid --
-          Expanded(
-            child: _PartsGrid(
-              category: _categories[_selectedCategory],
-              currentConfig: _config,
-              selectedPartId: _selectedPartForCategory(
-                _categories[_selectedCategory].configKey,
-              ),
-              ownedParts: ownedParts,
-              coins: coins,
-              onPartTapped: (part) {
-                final key = _categories[_selectedCategory].configKey;
-                if (part.isCustomPicker) {
-                  _showCustomColorPickerDialog(key);
-                } else if (_canUsePart(part)) {
-                  _selectPart(key, part.id);
-                } else {
-                  _showPurchaseDialog(part, key);
-                }
+            // -- Category tabs --
+            _CategoryTabBar(
+              categories: _categories,
+              selectedIndex: _selectedCategory,
+              onSelected: (index) {
+                setState(() => _selectedCategory = index);
               },
             ),
-          ),
 
-          // -- Save button --
-          _SaveBar(coins: coins, onSave: _saveConfig),
-        ],
+            // -- Parts grid --
+            Expanded(
+              child: _PartsGrid(
+                category: _categories[_selectedCategory],
+                currentConfig: _config,
+                selectedPartId: _selectedPartForCategory(
+                  _categories[_selectedCategory].configKey,
+                ),
+                ownedParts: ownedParts,
+                coins: coins,
+                onPartTapped: (part) {
+                  final key = _categories[_selectedCategory].configKey;
+                  if (part.isCustomPicker) {
+                    _showCustomColorPickerDialog(key);
+                  } else if (_canUsePart(part)) {
+                    _selectPart(key, part.id);
+                  } else {
+                    _showPurchaseDialog(part, key);
+                  }
+                },
+              ),
+            ),
+
+            // -- Save button --
+            _SaveBar(coins: coins, onSave: _saveConfig),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/campaign/campaign_screen.dart
+++ b/lib/features/campaign/campaign_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/clues/clue_types.dart';
 import '../../game/tutorial/campaign_mission.dart';
@@ -84,52 +85,55 @@ class CampaignScreen extends ConsumerWidget {
             ),
         ],
       ),
-      body: Column(
-        children: [
-          // Clue type legend
-          const Padding(
-            padding: EdgeInsets.fromLTRB(20, 12, 20, 4),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                _LegendItem(icon: Icons.flag, label: 'Flag'),
-                SizedBox(width: 10),
-                _LegendItem(icon: Icons.crop_square, label: 'Outline'),
-                SizedBox(width: 10),
-                _LegendItem(icon: Icons.border_all, label: 'Borders'),
-                SizedBox(width: 10),
-                _LegendItem(icon: Icons.location_city, label: 'Capital'),
-                SizedBox(width: 10),
-                _LegendItem(icon: Icons.bar_chart, label: 'Stats'),
-              ],
+      body: MenuContentWrapper(
+        child: Column(
+          children: [
+            // Clue type legend
+            const Padding(
+              padding: EdgeInsets.fromLTRB(20, 12, 20, 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _LegendItem(icon: Icons.flag, label: 'Flag'),
+                  SizedBox(width: 10),
+                  _LegendItem(icon: Icons.crop_square, label: 'Outline'),
+                  SizedBox(width: 10),
+                  _LegendItem(icon: Icons.border_all, label: 'Borders'),
+                  SizedBox(width: 10),
+                  _LegendItem(icon: Icons.location_city, label: 'Capital'),
+                  SizedBox(width: 10),
+                  _LegendItem(icon: Icons.bar_chart, label: 'Stats'),
+                ],
+              ),
             ),
-          ),
-          Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-              itemCount: campaignMissions.length,
-              itemBuilder: (context, index) {
-                final mission = campaignMissions[index];
-                final result = progress[mission.id];
-                final isCompleted = result != null;
+            Expanded(
+              child: ListView.builder(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                itemCount: campaignMissions.length,
+                itemBuilder: (context, index) {
+                  final mission = campaignMissions[index];
+                  final result = progress[mission.id];
+                  final isCompleted = result != null;
 
-                // A mission is unlocked if it's the first, or the previous one is complete.
-                final isUnlocked = index == 0 ||
-                    progress.containsKey(campaignMissions[index - 1].id);
+                  // A mission is unlocked if it's the first, or the previous one is complete.
+                  final isUnlocked = index == 0 ||
+                      progress.containsKey(campaignMissions[index - 1].id);
 
-                return _MissionCard(
-                  mission: mission,
-                  result: result,
-                  isUnlocked: isUnlocked,
-                  isCompleted: isCompleted,
-                  onTap: isUnlocked
-                      ? () => _startMission(context, ref, mission)
-                      : null,
-                );
-              },
+                  return _MissionCard(
+                    mission: mission,
+                    result: result,
+                    isUnlocked: isUnlocked,
+                    isCompleted: isCompleted,
+                    onTap: isUnlocked
+                        ? () => _startMission(context, ref, mission)
+                        : null,
+                  );
+                },
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/challenge/challenge_result_screen.dart
+++ b/lib/features/challenge/challenge_result_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/challenge.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/providers/account_provider.dart';
@@ -112,64 +113,66 @@ class ChallengeResultScreen extends ConsumerWidget {
         centerTitle: true,
         automaticallyImplyLeading: false,
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            // Result header
-            _ResultHeader(
-              youWon: youWon,
-              isDraw: isDraw,
-              opponentName: opponentName,
-            ),
-            const SizedBox(height: 24),
-            // Pilot license cards side by side
-            _PilotCards(
-              yourInfo: yourInfo,
-              opponentInfo: opponentInfo,
-              youWon: youWon,
-              isDraw: isDraw,
-            ),
-            const SizedBox(height: 24),
-            // Score display — quiz uses total score, flight uses round wins
-            if (challenge.gameMode == ChallengeGameMode.quiz)
-              _QuizScoreDisplay(
-                challenge: challenge,
-                isChallenger: isChallenger,
-              )
-            else
-              _ScoreDisplay(yourWins: yourWins, theirWins: theirWins),
-            const SizedBox(height: 24),
-            // Per-round breakdown — quiz shows stats, flight shows clues
-            if (challenge.gameMode == ChallengeGameMode.quiz)
-              _QuizRoundBreakdown(
-                challenge: challenge,
-                isChallenger: isChallenger,
-                yourName: yourInfo.name,
-                opponentName: opponentInfo.name,
-              )
-            else
-              _RoundBreakdown(
-                rounds: challenge.rounds,
-                isChallenger: isChallenger,
-                yourName: yourInfo.name,
-                opponentName: opponentInfo.name,
+      body: MenuContentWrapper(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              // Result header
+              _ResultHeader(
+                youWon: youWon,
+                isDraw: isDraw,
+                opponentName: opponentName,
               ),
-            const SizedBox(height: 24),
-            // Coins earned
-            _RewardsDisplay(coins: yourCoins),
-            const SizedBox(height: 24),
-            // Actions
-            _ResultActions(
-              onRematch: onRematch ??
-                  () {
-                    _handleRematch(context, ref);
-                  },
-              onHome: () =>
-                  Navigator.of(context).popUntil((route) => route.isFirst),
-              onPlayAgain: onPlayAgain,
-            ),
-          ],
+              const SizedBox(height: 24),
+              // Pilot license cards side by side
+              _PilotCards(
+                yourInfo: yourInfo,
+                opponentInfo: opponentInfo,
+                youWon: youWon,
+                isDraw: isDraw,
+              ),
+              const SizedBox(height: 24),
+              // Score display — quiz uses total score, flight uses round wins
+              if (challenge.gameMode == ChallengeGameMode.quiz)
+                _QuizScoreDisplay(
+                  challenge: challenge,
+                  isChallenger: isChallenger,
+                )
+              else
+                _ScoreDisplay(yourWins: yourWins, theirWins: theirWins),
+              const SizedBox(height: 24),
+              // Per-round breakdown — quiz shows stats, flight shows clues
+              if (challenge.gameMode == ChallengeGameMode.quiz)
+                _QuizRoundBreakdown(
+                  challenge: challenge,
+                  isChallenger: isChallenger,
+                  yourName: yourInfo.name,
+                  opponentName: opponentInfo.name,
+                )
+              else
+                _RoundBreakdown(
+                  rounds: challenge.rounds,
+                  isChallenger: isChallenger,
+                  yourName: yourInfo.name,
+                  opponentName: opponentInfo.name,
+                ),
+              const SizedBox(height: 24),
+              // Coins earned
+              _RewardsDisplay(coins: yourCoins),
+              const SizedBox(height: 24),
+              // Actions
+              _ResultActions(
+                onRematch: onRematch ??
+                    () {
+                      _handleRematch(context, ref);
+                    },
+                onHome: () =>
+                    Navigator.of(context).popUntil((route) => route.isFirst),
+                onPlayAgain: onPlayAgain,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/daily/daily_challenge_screen.dart
+++ b/lib/features/daily/daily_challenge_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../game/data/country_difficulty.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/models/daily_challenge.dart';
@@ -92,50 +93,52 @@ class _DailyChallengeScreenState extends ConsumerState<DailyChallengeScreen> {
             ),
           ],
         ),
-        body: Column(
-          children: [
-            Expanded(
-              child: ListView(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                children: [
-                  const _StreakSection(),
-                  const SizedBox(height: 12),
-                  _ChallengeHeader(challenge: _challenge),
-                  const SizedBox(height: 12),
-                  if (_seasonalTheme != null) ...[
-                    _SeasonalBanner(theme: _seasonalTheme),
+        body: MenuContentWrapper(
+          child: Column(
+            children: [
+              Expanded(
+                child: ListView(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  children: [
+                    const _StreakSection(),
                     const SizedBox(height: 12),
-                  ],
-                  _RewardsSection(
-                    challenge: _challenge,
-                    playerCount: _dailyPlayerCount,
-                  ),
-                  const SizedBox(height: 12),
-                  const _MedalProgressSection(),
-                  const SizedBox(height: 16),
-                  _loadingLeaderboard
-                      ? const Padding(
-                          padding: EdgeInsets.all(20),
-                          child: Center(
-                            child: CircularProgressIndicator(
-                              color: FlitColors.accent,
+                    _ChallengeHeader(challenge: _challenge),
+                    const SizedBox(height: 12),
+                    if (_seasonalTheme != null) ...[
+                      _SeasonalBanner(theme: _seasonalTheme),
+                      const SizedBox(height: 12),
+                    ],
+                    _RewardsSection(
+                      challenge: _challenge,
+                      playerCount: _dailyPlayerCount,
+                    ),
+                    const SizedBox(height: 12),
+                    const _MedalProgressSection(),
+                    const SizedBox(height: 16),
+                    _loadingLeaderboard
+                        ? const Padding(
+                            padding: EdgeInsets.all(20),
+                            child: Center(
+                              child: CircularProgressIndicator(
+                                color: FlitColors.accent,
+                              ),
                             ),
-                          ),
-                        )
-                      : _LeaderboardSection(entries: _leaderboardEntries),
-                  const SizedBox(height: 16),
-                  _HallOfFameSection(entries: _hallOfFame),
-                  const SizedBox(height: 16),
-                  _InfoFooter(bonusCoinReward: _challenge.bonusCoinReward),
-                  const SizedBox(height: 16),
-                ],
+                          )
+                        : _LeaderboardSection(entries: _leaderboardEntries),
+                    const SizedBox(height: 16),
+                    _HallOfFameSection(entries: _hallOfFame),
+                    const SizedBox(height: 16),
+                    _InfoFooter(bonusCoinReward: _challenge.bonusCoinReward),
+                    const SizedBox(height: 16),
+                  ],
+                ),
               ),
-            ),
-            _hasDoneToday
-                ? const _CompletedBanner()
-                : _PlayButton(onPressed: _onPlay),
-          ],
+              _hasDoneToday
+                  ? const _CompletedBanner()
+                  : _PlayButton(onPressed: _onPlay),
+            ],
+          ),
         ),
       );
 

--- a/lib/features/explore/country_clues_screen.dart
+++ b/lib/features/explore/country_clues_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/services/clue_report_service.dart';
 import '../../game/clues/clue_types.dart';
 import '../../game/data/canada_clues.dart';
@@ -124,88 +125,90 @@ class _CountryCluesScreenState extends State<CountryCluesScreen> {
             ],
           ),
         ),
-        body: Column(
-          children: [
-            // Search bar (shared across tabs)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-              child: TextField(
-                controller: _searchCtl,
-                onChanged: (v) => setState(() => _search = v.trim()),
-                style: const TextStyle(
-                  color: FlitColors.textPrimary,
-                  fontSize: 14,
-                ),
-                decoration: InputDecoration(
-                  hintText: 'Search…',
-                  hintStyle: const TextStyle(color: FlitColors.textMuted),
-                  prefixIcon: const Icon(
-                    Icons.search,
-                    color: FlitColors.textMuted,
-                    size: 20,
+        body: MenuContentWrapper(
+          child: Column(
+            children: [
+              // Search bar (shared across tabs)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                child: TextField(
+                  controller: _searchCtl,
+                  onChanged: (v) => setState(() => _search = v.trim()),
+                  style: const TextStyle(
+                    color: FlitColors.textPrimary,
+                    fontSize: 14,
                   ),
-                  suffixIcon: _search.isNotEmpty
-                      ? IconButton(
-                          icon: const Icon(
-                            Icons.close,
-                            color: FlitColors.textMuted,
-                            size: 18,
-                          ),
-                          onPressed: () {
-                            _searchCtl.clear();
-                            setState(() => _search = '');
-                          },
-                        )
-                      : null,
-                  filled: true,
-                  fillColor: FlitColors.backgroundMid,
-                  contentPadding: const EdgeInsets.symmetric(
-                    vertical: 10,
-                    horizontal: 12,
-                  ),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(10),
-                    borderSide: BorderSide.none,
+                  decoration: InputDecoration(
+                    hintText: 'Search…',
+                    hintStyle: const TextStyle(color: FlitColors.textMuted),
+                    prefixIcon: const Icon(
+                      Icons.search,
+                      color: FlitColors.textMuted,
+                      size: 20,
+                    ),
+                    suffixIcon: _search.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(
+                              Icons.close,
+                              color: FlitColors.textMuted,
+                              size: 18,
+                            ),
+                            onPressed: () {
+                              _searchCtl.clear();
+                              setState(() => _search = '');
+                            },
+                          )
+                        : null,
+                    filled: true,
+                    fillColor: FlitColors.backgroundMid,
+                    contentPadding: const EdgeInsets.symmetric(
+                      vertical: 10,
+                      horizontal: 12,
+                    ),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(10),
+                      borderSide: BorderSide.none,
+                    ),
                   ),
                 ),
               ),
-            ),
 
-            // Tab content
-            Expanded(
-              child: TabBarView(
-                children: [
-                  // All World tab
-                  _CountriesTab(
-                    countries: _filteredCountries,
-                    unsupportedFlags: _unsupportedFlagCodes,
-                  ),
+              // Tab content
+              Expanded(
+                child: TabBarView(
+                  children: [
+                    // All World tab
+                    _CountriesTab(
+                      countries: _filteredCountries,
+                      unsupportedFlags: _unsupportedFlagCodes,
+                    ),
 
-                  // Regions tab (continental with filter)
-                  _FilteredRegionalTab(
-                    regions: _continentalRegions,
-                    selectedRegion: _selectedContinental,
-                    onRegionChanged: (r) =>
-                        setState(() => _selectedContinental = r),
-                    filteredAreas: _selectedContinental != null
-                        ? _filteredAreas(_selectedContinental!)
-                        : null,
-                  ),
+                    // Regions tab (continental with filter)
+                    _FilteredRegionalTab(
+                      regions: _continentalRegions,
+                      selectedRegion: _selectedContinental,
+                      onRegionChanged: (r) =>
+                          setState(() => _selectedContinental = r),
+                      filteredAreas: _selectedContinental != null
+                          ? _filteredAreas(_selectedContinental!)
+                          : null,
+                    ),
 
-                  // Sub-national tab (with filter)
-                  _FilteredRegionalTab(
-                    regions: _subNationalRegions,
-                    selectedRegion: _selectedSubNational,
-                    onRegionChanged: (r) =>
-                        setState(() => _selectedSubNational = r),
-                    filteredAreas: _selectedSubNational != null
-                        ? _filteredAreas(_selectedSubNational!)
-                        : null,
-                  ),
-                ],
+                    // Sub-national tab (with filter)
+                    _FilteredRegionalTab(
+                      regions: _subNationalRegions,
+                      selectedRegion: _selectedSubNational,
+                      onRegionChanged: (r) =>
+                          setState(() => _selectedSubNational = r),
+                      filteredAreas: _selectedSubNational != null
+                          ? _filteredAreas(_selectedSubNational!)
+                          : null,
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/friends/friends_screen.dart
+++ b/lib/features/friends/friends_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/challenge.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/models/friend.dart';
@@ -200,15 +201,17 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
             ),
           ],
         ),
-        body: _loading
-            ? const Center(
-                child: CircularProgressIndicator(color: FlitColors.accent),
-              )
-            : RefreshIndicator(
-                onRefresh: _loadData,
-                color: FlitColors.accent,
-                child: _buildBody(),
-              ),
+        body: MenuContentWrapper(
+          child: _loading
+              ? const Center(
+                  child: CircularProgressIndicator(color: FlitColors.accent),
+                )
+              : RefreshIndicator(
+                  onRefresh: _loadData,
+                  color: FlitColors.accent,
+                  child: _buildBody(),
+                ),
+        ),
       );
 
   Widget _buildBody() {

--- a/lib/features/guide/gameplay_guide_screen.dart
+++ b/lib/features/guide/gameplay_guide_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 
 /// Identifies a tab within the gameplay guide.
 ///
@@ -131,18 +132,20 @@ class _GameplayGuideScreenState extends State<GameplayGuideScreen>
           ],
         ),
       ),
-      body: TabBarView(
-        controller: _tabController,
-        children: const [
-          _OverviewTab(),
-          _DailyScrambleTab(),
-          _FreeFlightTab(),
-          _TrainingSortieTab(),
-          _DailyBriefingTab(),
-          _FlightSchoolTab(),
-          _UnchartedTab(),
-          _DogfightTab(),
-        ],
+      body: MenuContentWrapper(
+        child: TabBarView(
+          controller: _tabController,
+          children: const [
+            _OverviewTab(),
+            _DailyScrambleTab(),
+            _FreeFlightTab(),
+            _TrainingSortieTab(),
+            _DailyBriefingTab(),
+            _FlightSchoolTab(),
+            _UnchartedTab(),
+            _DogfightTab(),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -6,6 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/app_version.dart';
 import '../../data/providers/account_provider.dart';
 import '../../core/theme/flit_colors.dart';
+import '../../core/theme/flit_theme.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/challenge.dart';
 import '../../data/services/app_config_service.dart';
 import '../../data/services/challenge_service.dart';
@@ -167,30 +169,34 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
               child: const AnnouncementBanner(),
             ),
 
-            // Menu overlay
-            SafeArea(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 28),
-                child: Column(
-                  children: [
-                    const Spacer(flex: 3),
-                    // Title block with paper plane accent
-                    _buildTitle(),
-                    const Spacer(flex: 2),
-                    _buildMenuButtons(context),
-                    const Spacer(flex: 1),
-                    // Version number
-                    const Text(
-                      appVersion,
-                      style: TextStyle(
-                        color: FlitColors.textMuted,
-                        fontSize: 10,
-                        fontWeight: FontWeight.w400,
-                        letterSpacing: 1,
+            // Menu overlay — constrained to kMaxContentWidth and centered so it
+            // keeps a phone-like column on wide screens (desktop browser).
+            // The full-bleed background above still fills the screen.
+            MenuContentWrapper(
+              child: SafeArea(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 28),
+                  child: Column(
+                    children: [
+                      const Spacer(flex: 3),
+                      // Title block with paper plane accent
+                      _buildTitle(),
+                      const Spacer(flex: 2),
+                      _buildMenuButtons(context),
+                      const Spacer(flex: 1),
+                      // Version number
+                      const Text(
+                        appVersion,
+                        style: TextStyle(
+                          color: FlitColors.textMuted,
+                          fontSize: 10,
+                          fontWeight: FontWeight.w400,
+                          letterSpacing: 1,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 4),
-                  ],
+                      const SizedBox(height: 4),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -406,6 +412,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       isScrollControlled: true,
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.85,
+        maxWidth: kMaxContentWidth,
       ),
       builder: (ctx) => Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),

--- a/lib/features/leaderboard/leaderboard_screen.dart
+++ b/lib/features/leaderboard/leaderboard_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../core/theme/rarity_colors.dart';
 import '../../data/models/avatar_config.dart';
 import '../../data/models/leaderboard_entry.dart';
@@ -259,50 +260,54 @@ class _LeaderboardScreenState extends State<LeaderboardScreen>
             ],
           ),
         ),
-        body: Column(
-          children: [
-            // Sub-tab chips: Today | Last Month | All Time
-            _TimeframeChips(
-                selected: _timeframe, onChanged: _onTimeframeChanged),
-            // Sort chips: Score | Proficiency | Time
-            _SortChips(selected: _sort, onChanged: _onSortChanged),
-            const Divider(color: FlitColors.cardBorder, height: 1),
-            // Player rank banner (score-based; hidden when not sorting by score)
-            if (_playerRank != null && _sort == LeaderboardSort.score)
-              _PlayerRankBanner(entry: _playerRank!),
-            // Leaderboard list
-            Expanded(
-              child: _loading
-                  ? const Center(child: CircularProgressIndicator())
-                  : _errorMessage != null
-                      ? _ErrorState(message: _errorMessage!, onRetry: _loadData)
-                      : _entries.isEmpty
-                          ? const _EmptyState()
-                          : ListView.builder(
-                              padding: const EdgeInsets.symmetric(vertical: 8),
-                              itemCount: _sortedEntries.length,
-                              itemBuilder: (context, index) {
-                                final e = _sortedEntries[index];
-                                final isSelf = e.playerId == _userId;
-                                // Embargo: hide round details for other
-                                // players' daily-scramble scores from today
-                                // so clues/answers aren't spoiled.
-                                final embargoed = !isSelf &&
-                                    _currentMode ==
-                                        LeaderboardMode.dailyScramble &&
-                                    _isFromToday(e.timestamp);
-                                return _LeaderboardRow(
-                                  entry: e,
-                                  rank: index + 1,
-                                  isCurrentPlayer: isSelf,
-                                  isEmbargoed: embargoed,
-                                  sort: _sort,
-                                  proficiencyPct: _computeProficiencyPct(e),
-                                );
-                              },
-                            ),
-            ),
-          ],
+        body: MenuContentWrapper(
+          child: Column(
+            children: [
+              // Sub-tab chips: Today | Last Month | All Time
+              _TimeframeChips(
+                  selected: _timeframe, onChanged: _onTimeframeChanged),
+              // Sort chips: Score | Proficiency | Time
+              _SortChips(selected: _sort, onChanged: _onSortChanged),
+              const Divider(color: FlitColors.cardBorder, height: 1),
+              // Player rank banner (score-based; hidden when not sorting by score)
+              if (_playerRank != null && _sort == LeaderboardSort.score)
+                _PlayerRankBanner(entry: _playerRank!),
+              // Leaderboard list
+              Expanded(
+                child: _loading
+                    ? const Center(child: CircularProgressIndicator())
+                    : _errorMessage != null
+                        ? _ErrorState(
+                            message: _errorMessage!, onRetry: _loadData)
+                        : _entries.isEmpty
+                            ? const _EmptyState()
+                            : ListView.builder(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 8),
+                                itemCount: _sortedEntries.length,
+                                itemBuilder: (context, index) {
+                                  final e = _sortedEntries[index];
+                                  final isSelf = e.playerId == _userId;
+                                  // Embargo: hide round details for other
+                                  // players' daily-scramble scores from today
+                                  // so clues/answers aren't spoiled.
+                                  final embargoed = !isSelf &&
+                                      _currentMode ==
+                                          LeaderboardMode.dailyScramble &&
+                                      _isFromToday(e.timestamp);
+                                  return _LeaderboardRow(
+                                    entry: e,
+                                    rank: index + 1,
+                                    isCurrentPlayer: isSelf,
+                                    isEmbargoed: embargoed,
+                                    sort: _sort,
+                                    proficiencyPct: _computeProficiencyPct(e),
+                                  );
+                                },
+                              ),
+              ),
+            ],
+          ),
         ),
       );
 }

--- a/lib/features/license/license_screen.dart
+++ b/lib/features/license/license_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../core/theme/rarity_colors.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/models/pilot_license.dart';
@@ -220,21 +221,23 @@ class _LicenseScreenState extends ConsumerState<LicenseScreen>
           ),
         ],
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
-        child: Column(
-          children: [
-            _buildLicenseCard(),
-            const SizedBox(height: 24),
-            _buildLockSection(coins),
-            const SizedBox(height: 24),
-            _buildFreeRerollButton(),
-            const SizedBox(height: 12),
-            _buildDailyScrambleRerollButton(),
-            const SizedBox(height: 12),
-            _buildRerollButton(coins),
-            const SizedBox(height: 16),
-          ],
+      body: MenuContentWrapper(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+          child: Column(
+            children: [
+              _buildLicenseCard(),
+              const SizedBox(height: 24),
+              _buildLockSection(coins),
+              const SizedBox(height: 24),
+              _buildFreeRerollButton(),
+              const SizedBox(height: 12),
+              _buildDailyScrambleRerollButton(),
+              const SizedBox(height: 12),
+              _buildRerollButton(coins),
+              const SizedBox(height: 16),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/matchmaking/find_challenger_screen.dart
+++ b/lib/features/matchmaking/find_challenger_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/challenge.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/providers/account_provider.dart';
@@ -326,27 +327,30 @@ class _FindChallengerScreenState extends ConsumerState<FindChallengerScreen>
         ],
       ),
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20),
-          child: Column(
-            children: [
-              const SizedBox(height: 24),
-              // Player ELO card
-              _EloCard(elo: elo, level: player.level),
-              const SizedBox(height: 24),
-              // Main action area
-              Expanded(child: _buildStateContent()),
-              // Pool entries
-              if (_poolEntries.isNotEmpty && _state != _MatchState.matched) ...[
-                const Divider(color: FlitColors.cardBorder, height: 1),
-                _PoolEntriesSection(
-                  entries: _poolEntries,
-                  onCheckMatch: _checkForMatches,
-                  onCancelEntry: _cancelEntry,
-                ),
+        child: MenuContentWrapper(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Column(
+              children: [
+                const SizedBox(height: 24),
+                // Player ELO card
+                _EloCard(elo: elo, level: player.level),
+                const SizedBox(height: 24),
+                // Main action area
+                Expanded(child: _buildStateContent()),
+                // Pool entries
+                if (_poolEntries.isNotEmpty &&
+                    _state != _MatchState.matched) ...[
+                  const Divider(color: FlitColors.cardBorder, height: 1),
+                  _PoolEntriesSection(
+                    entries: _poolEntries,
+                    onCheckMatch: _checkForMatches,
+                    onCancelEntry: _cancelEntry,
+                  ),
+                ],
+                const SizedBox(height: 16),
               ],
-              const SizedBox(height: 16),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/features/play/free_flight_setup_screen.dart
+++ b/lib/features/play/free_flight_setup_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/services/game_settings.dart';
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/clues/clue_types.dart';
@@ -182,49 +183,51 @@ class _FreeFlightSetupScreenState extends ConsumerState<FreeFlightSetupScreen> {
         ],
       ),
       body: SafeArea(
-        child: Column(
-          children: [
-            // Difficulty selector bar
-            ListenableBuilder(
-              listenable: GameSettings.instance,
-              builder: (context, _) => _DifficultyBar(
-                difficulty: GameSettings.instance.difficulty,
-                onChanged: (d) => GameSettings.instance.difficulty = d,
-              ),
-            ),
-
-            Expanded(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 20,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Header
-                    _buildHeader(),
-                    const SizedBox(height: 20),
-
-                    // Round count
-                    _buildSectionLabel('ROUNDS', Icons.repeat),
-                    const SizedBox(height: 10),
-                    _buildRoundSelector(),
-                    const SizedBox(height: 20),
-
-                    // Clue types
-                    _buildSectionLabel('CLUE TYPES', Icons.tune),
-                    const SizedBox(height: 10),
-                    ..._buildClueToggleCards(),
-                    const SizedBox(height: 24),
-                  ],
+        child: MenuContentWrapper(
+          child: Column(
+            children: [
+              // Difficulty selector bar
+              ListenableBuilder(
+                listenable: GameSettings.instance,
+                builder: (context, _) => _DifficultyBar(
+                  difficulty: GameSettings.instance.difficulty,
+                  onChanged: (d) => GameSettings.instance.difficulty = d,
                 ),
               ),
-            ),
 
-            // Bottom bar
-            _buildBottomBar(),
-          ],
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 20,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Header
+                      _buildHeader(),
+                      const SizedBox(height: 20),
+
+                      // Round count
+                      _buildSectionLabel('ROUNDS', Icons.repeat),
+                      const SizedBox(height: 10),
+                      _buildRoundSelector(),
+                      const SizedBox(height: 20),
+
+                      // Clue types
+                      _buildSectionLabel('CLUE TYPES', Icons.tune),
+                      const SizedBox(height: 10),
+                      ..._buildClueToggleCards(),
+                      const SizedBox(height: 24),
+                    ],
+                  ),
+                ),
+              ),
+
+              // Bottom bar
+              _buildBottomBar(),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/play/practice_screen.dart
+++ b/lib/features/play/practice_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/clues/clue_types.dart';
@@ -317,49 +318,51 @@ class _PracticeScreenState extends ConsumerState<PracticeScreen> {
         ],
       ),
       body: SafeArea(
-        child: Column(
-          children: [
-            // Scrollable content
-            Expanded(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 20,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Header
-                    _buildHeader(),
-                    const SizedBox(height: 20),
+        child: MenuContentWrapper(
+          child: Column(
+            children: [
+              // Scrollable content
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 20,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Header
+                      _buildHeader(),
+                      const SizedBox(height: 20),
 
-                    // Coin cost display
-                    _buildCostDisplay(coins),
-                    const SizedBox(height: 20),
+                      // Coin cost display
+                      _buildCostDisplay(coins),
+                      const SizedBox(height: 20),
 
-                    // Section label: Clue Types
-                    _buildSectionLabel('CLUE TYPES', Icons.tune),
-                    const SizedBox(height: 10),
+                      // Section label: Clue Types
+                      _buildSectionLabel('CLUE TYPES', Icons.tune),
+                      const SizedBox(height: 10),
 
-                    // Clue type toggle cards
-                    ..._buildClueToggleCards(),
-                    const SizedBox(height: 24),
+                      // Clue type toggle cards
+                      ..._buildClueToggleCards(),
+                      const SizedBox(height: 24),
 
-                    // Section label: Clue Progress
-                    _buildSectionLabel('CLUE PROGRESS', Icons.trending_up),
-                    const SizedBox(height: 10),
+                      // Section label: Clue Progress
+                      _buildSectionLabel('CLUE PROGRESS', Icons.trending_up),
+                      const SizedBox(height: 10),
 
-                    // Clue progress cards
-                    ..._buildClueProgressCards(),
-                    const SizedBox(height: 24),
-                  ],
+                      // Clue progress cards
+                      ..._buildClueProgressCards(),
+                      const SizedBox(height: 24),
+                    ],
+                  ),
                 ),
               ),
-            ),
 
-            // Bottom action bar (always visible)
-            _buildBottomBar(coins, canStart),
-          ],
+              // Bottom action bar (always visible)
+              _buildBottomBar(coins, canStart),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/play/region_select_screen.dart
+++ b/lib/features/play/region_select_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/services/game_settings.dart';
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/map/region.dart';
 import 'free_flight_setup_screen.dart';
@@ -91,77 +92,79 @@ class RegionSelectScreen extends ConsumerWidget {
           ),
         ],
       ),
-      body: Column(
-        children: [
-          // Difficulty selector bar
-          ListenableBuilder(
-            listenable: GameSettings.instance,
-            builder: (context, _) => _DifficultyBar(
-              difficulty: GameSettings.instance.difficulty,
-              onChanged: (d) => GameSettings.instance.difficulty = d,
+      body: MenuContentWrapper(
+        child: Column(
+          children: [
+            // Difficulty selector bar
+            ListenableBuilder(
+              listenable: GameSettings.instance,
+              builder: (context, _) => _DifficultyBar(
+                difficulty: GameSettings.instance.difficulty,
+                onChanged: (d) => GameSettings.instance.difficulty = d,
+              ),
             ),
-          ),
-          // Region list
-          Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: GameRegion.values.length,
-              itemBuilder: (context, index) {
-                final region = GameRegion.values[index];
-                final isUnlockedByLevel = playerLevel >= region.requiredLevel;
-                final isUnlockedByPurchase =
-                    accountState.unlockedRegions.contains(region.name);
-                final isUnlocked = isUnlockedByLevel || isUnlockedByPurchase;
-                final cost = unlockCost(region);
-                final canAfford = coins >= cost && cost > 0;
+            // Region list
+            Expanded(
+              child: ListView.builder(
+                padding: const EdgeInsets.all(16),
+                itemCount: GameRegion.values.length,
+                itemBuilder: (context, index) {
+                  final region = GameRegion.values[index];
+                  final isUnlockedByLevel = playerLevel >= region.requiredLevel;
+                  final isUnlockedByPurchase =
+                      accountState.unlockedRegions.contains(region.name);
+                  final isUnlocked = isUnlockedByLevel || isUnlockedByPurchase;
+                  final cost = unlockCost(region);
+                  final canAfford = coins >= cost && cost > 0;
 
-                final isAdmin = accountState.isAdmin;
-                final isWorld = region == GameRegion.world;
+                  final isAdmin = accountState.isAdmin;
+                  final isWorld = region == GameRegion.world;
 
-                // For non-admin users, non-World regions are gated behind a
-                // "Coming Soon" dialog regardless of unlock / purchase state.
-                VoidCallback? tapHandler;
-                VoidCallback? buyHandler;
+                  // For non-admin users, non-World regions are gated behind a
+                  // "Coming Soon" dialog regardless of unlock / purchase state.
+                  VoidCallback? tapHandler;
+                  VoidCallback? buyHandler;
 
-                if (isAdmin) {
-                  // Admin: full existing behaviour.
-                  tapHandler = isUnlocked
-                      ? () => _launchPlay(context, ref, region)
-                      : null;
-                  buyHandler = (!isUnlocked && canAfford)
-                      ? () => _showUnlockDialog(context, ref, region, cost)
-                      : null;
-                } else if (isWorld) {
-                  // Regular user, World region: normal play flow (always unlocked).
-                  tapHandler = isUnlocked
-                      ? () => _launchPlay(context, ref, region)
-                      : null;
-                  // World is always unlocked so buyHandler stays null.
-                } else {
-                  // Regular user, non-World region: show "Coming Soon" for both
-                  // tap (when nominally unlocked) and buy button.
-                  tapHandler = isUnlocked
-                      ? () => _showComingSoonDialog(context, region)
-                      : null;
-                  buyHandler = (!isUnlocked && canAfford)
-                      ? () => _showComingSoonDialog(context, region)
-                      : null;
-                }
+                  if (isAdmin) {
+                    // Admin: full existing behaviour.
+                    tapHandler = isUnlocked
+                        ? () => _launchPlay(context, ref, region)
+                        : null;
+                    buyHandler = (!isUnlocked && canAfford)
+                        ? () => _showUnlockDialog(context, ref, region, cost)
+                        : null;
+                  } else if (isWorld) {
+                    // Regular user, World region: normal play flow (always unlocked).
+                    tapHandler = isUnlocked
+                        ? () => _launchPlay(context, ref, region)
+                        : null;
+                    // World is always unlocked so buyHandler stays null.
+                  } else {
+                    // Regular user, non-World region: show "Coming Soon" for both
+                    // tap (when nominally unlocked) and buy button.
+                    tapHandler = isUnlocked
+                        ? () => _showComingSoonDialog(context, region)
+                        : null;
+                    buyHandler = (!isUnlocked && canAfford)
+                        ? () => _showComingSoonDialog(context, region)
+                        : null;
+                  }
 
-                return _RegionCard(
-                  region: region,
-                  isUnlocked: isUnlocked,
-                  playerLevel: playerLevel,
-                  unlockCost: cost,
-                  canBuy: !isUnlocked && canAfford,
-                  isAdmin: isAdmin,
-                  onTap: tapHandler,
-                  onBuy: buyHandler,
-                );
-              },
-            ),
-          ), // Expanded
-        ], // Column
+                  return _RegionCard(
+                    region: region,
+                    isUnlocked: isUnlocked,
+                    playerLevel: playerLevel,
+                    unlockCost: cost,
+                    canBuy: !isUnlocked && canAfford,
+                    isAdmin: isAdmin,
+                    onTap: tapHandler,
+                    onBuy: buyHandler,
+                  );
+                },
+              ),
+            ), // Expanded
+          ], // Column
+        ),
       ),
     );
   }

--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -6,6 +6,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
 import '../../core/utils/web_download.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../core/widgets/settings_sheet.dart';
 import '../../core/widgets/sync_status_indicator.dart';
 import '../../core/utils/profanity_filter.dart';
@@ -684,73 +685,75 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           ),
         ],
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            // Avatar and name
-            _ProfileHeader(player: player, avatarConfig: avatarConfig),
-            const SizedBox(height: 24),
-            // Level progress
-            _LevelProgress(player: player),
-            const SizedBox(height: 24),
-            // Stats grid
-            _StatsGrid(
-              player: player,
-              bestDailyScore: _bestDailyScore,
-              bestDailyTime: _bestDailyTime,
-              bestTrainingScore: _bestTrainingScore,
-              bestTrainingTime: _bestTrainingTime,
-            ),
-            const SizedBox(height: 24),
-            // Quick links
-            Row(
-              children: [
-                Expanded(
-                  child: _QuickLinkButton(
-                    icon: Icons.face,
-                    label: 'Avatar',
-                    onTap: () => Navigator.of(context).push(
-                      MaterialPageRoute<void>(
-                        builder: (_) => const AvatarEditorScreen(),
+      body: MenuContentWrapper(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              // Avatar and name
+              _ProfileHeader(player: player, avatarConfig: avatarConfig),
+              const SizedBox(height: 24),
+              // Level progress
+              _LevelProgress(player: player),
+              const SizedBox(height: 24),
+              // Stats grid
+              _StatsGrid(
+                player: player,
+                bestDailyScore: _bestDailyScore,
+                bestDailyTime: _bestDailyTime,
+                bestTrainingScore: _bestTrainingScore,
+                bestTrainingTime: _bestTrainingTime,
+              ),
+              const SizedBox(height: 24),
+              // Quick links
+              Row(
+                children: [
+                  Expanded(
+                    child: _QuickLinkButton(
+                      icon: Icons.face,
+                      label: 'Avatar',
+                      onTap: () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => const AvatarEditorScreen(),
+                        ),
                       ),
                     ),
                   ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: _QuickLinkButton(
-                    icon: Icons.badge,
-                    label: 'License',
-                    onTap: () => Navigator.of(context).push(
-                      MaterialPageRoute<void>(
-                        builder: (_) => const LicenseScreen(),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: _QuickLinkButton(
+                      icon: Icons.badge,
+                      label: 'License',
+                      onTap: () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => const LicenseScreen(),
+                        ),
                       ),
                     ),
                   ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 24),
-            // Nationality
-            _NationalitySection(
-              nationality: account.license.nationality,
-              onTap: () => _showNationalityPicker(),
-            ),
-            const SizedBox(height: 24),
-            // Social titles
-            const SocialTitlesCard(),
-            const SizedBox(height: 24),
-            // Actions
-            _ProfileActions(
-              onEditProfile: _editProfile,
-              onChangePassword: _changePassword,
-              onGameHistory: _showGameHistory,
-              onExportData: _exportData,
-              onDeleteAccount: _deleteAccount,
-              onSignOut: _signOut,
-            ),
-          ],
+                ],
+              ),
+              const SizedBox(height: 24),
+              // Nationality
+              _NationalitySection(
+                nationality: account.license.nationality,
+                onTap: () => _showNationalityPicker(),
+              ),
+              const SizedBox(height: 24),
+              // Social titles
+              const SocialTitlesCard(),
+              const SizedBox(height: 24),
+              // Actions
+              _ProfileActions(
+                onEditProfile: _editProfile,
+                onChangePassword: _changePassword,
+                onGameHistory: _showGameHistory,
+                onExportData: _exportData,
+                onDeleteAccount: _deleteAccount,
+                onSignOut: _signOut,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/quiz/daily_briefing_screen.dart
+++ b/lib/features/quiz/daily_briefing_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../game/quiz/daily_briefing.dart';
 import '../guide/gameplay_guide_screen.dart';
 import '../../game/quiz/quiz_category.dart';
@@ -131,22 +132,24 @@ class _DailyBriefingScreenState extends State<DailyBriefingScreen>
           ),
         ],
       ),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : SingleChildScrollView(
-              padding: const EdgeInsets.all(20),
-              child: Column(
-                children: [
-                  _buildMissionHeader(),
-                  const SizedBox(height: 24),
-                  _buildBriefingCard(),
-                  const SizedBox(height: 24),
-                  _buildActionArea(),
-                  const SizedBox(height: 32),
-                  _buildInfoFooter(),
-                ],
+      body: MenuContentWrapper(
+        child: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : SingleChildScrollView(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  children: [
+                    _buildMissionHeader(),
+                    const SizedBox(height: 24),
+                    _buildBriefingCard(),
+                    const SizedBox(height: 24),
+                    _buildActionArea(),
+                    const SizedBox(height: 32),
+                    _buildInfoFooter(),
+                  ],
+                ),
               ),
-            ),
+      ),
     );
   }
 

--- a/lib/features/quiz/flight_school_screen.dart
+++ b/lib/features/quiz/flight_school_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/quiz/flight_school_level.dart';
 import '../guide/gameplay_guide_screen.dart';
@@ -104,39 +105,41 @@ class _FlightSchoolScreenState extends ConsumerState<FlightSchoolScreen> {
         ),
       ),
       body: SafeArea(
-        child: Column(
-          children: [
-            _buildHeader(),
-            Expanded(
-              child: ListView.builder(
-                padding: const EdgeInsets.all(16),
-                itemCount: flightSchoolLevels.length,
-                itemBuilder: (context, index) {
-                  final level = flightSchoolLevels[index];
-                  final isUnlocked = notifier.isFlightSchoolLevelUnlocked(
-                    level,
-                  );
-                  final progress =
-                      progressMap[level.id] ?? const FlightSchoolProgress();
-                  final canBuyEarly = !isUnlocked &&
-                      level.unlockCost > 0 &&
-                      playerCoins >= level.unlockCost;
+        child: MenuContentWrapper(
+          child: Column(
+            children: [
+              _buildHeader(),
+              Expanded(
+                child: ListView.builder(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: flightSchoolLevels.length,
+                  itemBuilder: (context, index) {
+                    final level = flightSchoolLevels[index];
+                    final isUnlocked = notifier.isFlightSchoolLevelUnlocked(
+                      level,
+                    );
+                    final progress =
+                        progressMap[level.id] ?? const FlightSchoolProgress();
+                    final canBuyEarly = !isUnlocked &&
+                        level.unlockCost > 0 &&
+                        playerCoins >= level.unlockCost;
 
-                  return _LevelCard(
-                    level: level,
-                    progress: progress,
-                    isUnlocked: isUnlocked,
-                    canBuyEarly: canBuyEarly,
-                    playerLevel: playerLevel,
-                    playerCoins: playerCoins,
-                    onTap: isUnlocked ? () => _navigateToSetup(level) : null,
-                    onBuy:
-                        canBuyEarly ? () => _buyLevel(level, notifier) : null,
-                  );
-                },
+                    return _LevelCard(
+                      level: level,
+                      progress: progress,
+                      isUnlocked: isUnlocked,
+                      canBuyEarly: canBuyEarly,
+                      playerLevel: playerLevel,
+                      playerCoins: playerCoins,
+                      onTap: isUnlocked ? () => _navigateToSetup(level) : null,
+                      onBuy:
+                          canBuyEarly ? () => _buyLevel(level, notifier) : null,
+                    );
+                  },
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/quiz/h2h_challenge_screen.dart
+++ b/lib/features/quiz/h2h_challenge_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/h2h_challenge.dart';
 import '../../data/providers/account_provider.dart';
 import '../../data/services/challenge_service.dart';
@@ -64,9 +65,11 @@ class _H2HChallengeScreenState extends ConsumerState<H2HChallengeScreen>
           ],
         ),
       ),
-      body: TabBarView(
-        controller: _tabController,
-        children: const [_CreateChallengeTab(), _MyChallengesTab()],
+      body: MenuContentWrapper(
+        child: TabBarView(
+          controller: _tabController,
+          children: const [_CreateChallengeTab(), _MyChallengesTab()],
+        ),
       ),
     );
   }

--- a/lib/features/quiz/h2h_results_screen.dart
+++ b/lib/features/quiz/h2h_results_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/h2h_challenge.dart';
 import '../../game/quiz/quiz_category.dart';
 import '../../game/quiz/quiz_difficulty.dart';
@@ -62,118 +63,120 @@ class _H2HResultsScreenState extends State<H2HResultsScreen>
     return Scaffold(
       backgroundColor: FlitColors.backgroundDark,
       body: SafeArea(
-        child: AnimatedBuilder(
-          animation: _animController,
-          builder: (context, child) {
-            return Opacity(
-              opacity: _fadeIn.value,
-              child: Transform.translate(
-                offset: Offset(0, _slideUp.value),
-                child: child,
-              ),
-            );
-          },
-          child: Column(
-            children: [
-              Expanded(
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 24,
-                  ),
-                  child: Column(
-                    children: [
-                      // Trophy / result badge
-                      _buildResultBadge(isDraw, winnerName),
-                      const SizedBox(height: 16),
+        child: MenuContentWrapper(
+          child: AnimatedBuilder(
+            animation: _animController,
+            builder: (context, child) {
+              return Opacity(
+                opacity: _fadeIn.value,
+                child: Transform.translate(
+                  offset: Offset(0, _slideUp.value),
+                  child: child,
+                ),
+              );
+            },
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 24,
+                    ),
+                    child: Column(
+                      children: [
+                        // Trophy / result badge
+                        _buildResultBadge(isDraw, winnerName),
+                        const SizedBox(height: 16),
 
-                      // Title
-                      Text(
-                        isDraw
-                            ? 'DRAW'
-                            : winnerName != null
-                                ? '$winnerName WINS!'
-                                : 'MATCH COMPLETE',
-                        style: TextStyle(
-                          color: isDraw
-                              ? FlitColors.textSecondary
-                              : FlitColors.gold,
-                          fontSize: 22,
-                          fontWeight: FontWeight.w900,
-                          letterSpacing: 2,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-
-                      // Matchup subtitle
-                      Text(
-                        '${challenge.challengerName} vs ${challenge.challengedName}',
-                        style: const TextStyle(
-                          color: FlitColors.textSecondary,
-                          fontSize: 14,
-                        ),
-                      ),
-                      const SizedBox(height: 6),
-
-                      // Overall score
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 8,
-                        ),
-                        decoration: BoxDecoration(
-                          color: FlitColors.accent.withOpacity(0.1),
-                          borderRadius: BorderRadius.circular(10),
-                          border: Border.all(
-                            color: FlitColors.accent.withOpacity(0.25),
-                          ),
-                        ),
-                        child: Text(
-                          challenge.scoreText,
-                          style: const TextStyle(
-                            color: FlitColors.accent,
-                            fontSize: 24,
-                            fontWeight: FontWeight.w900,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 28),
-
-                      // Round details
-                      const Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          'ROUNDS',
+                        // Title
+                        Text(
+                          isDraw
+                              ? 'DRAW'
+                              : winnerName != null
+                                  ? '$winnerName WINS!'
+                                  : 'MATCH COMPLETE',
                           style: TextStyle(
-                            color: FlitColors.textMuted,
-                            fontSize: 11,
-                            fontWeight: FontWeight.w700,
-                            letterSpacing: 1.5,
+                            color: isDraw
+                                ? FlitColors.textSecondary
+                                : FlitColors.gold,
+                            fontSize: 22,
+                            fontWeight: FontWeight.w900,
+                            letterSpacing: 2,
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 12),
+                        const SizedBox(height: 8),
 
-                      for (var i = 0; i < challenge.rounds.length; i++) ...[
-                        _RoundResultCard(
-                          round: challenge.rounds[i],
-                          roundNumber: i + 1,
-                          challengerName: challenge.challengerName,
-                          challengedName: challenge.challengedName,
+                        // Matchup subtitle
+                        Text(
+                          '${challenge.challengerName} vs ${challenge.challengedName}',
+                          style: const TextStyle(
+                            color: FlitColors.textSecondary,
+                            fontSize: 14,
+                          ),
                         ),
-                        if (i < challenge.rounds.length - 1)
-                          const SizedBox(height: 10),
-                      ],
+                        const SizedBox(height: 6),
 
-                      const SizedBox(height: 24),
-                    ],
+                        // Overall score
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
+                          decoration: BoxDecoration(
+                            color: FlitColors.accent.withOpacity(0.1),
+                            borderRadius: BorderRadius.circular(10),
+                            border: Border.all(
+                              color: FlitColors.accent.withOpacity(0.25),
+                            ),
+                          ),
+                          child: Text(
+                            challenge.scoreText,
+                            style: const TextStyle(
+                              color: FlitColors.accent,
+                              fontSize: 24,
+                              fontWeight: FontWeight.w900,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 28),
+
+                        // Round details
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'ROUNDS',
+                            style: TextStyle(
+                              color: FlitColors.textMuted,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w700,
+                              letterSpacing: 1.5,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+
+                        for (var i = 0; i < challenge.rounds.length; i++) ...[
+                          _RoundResultCard(
+                            round: challenge.rounds[i],
+                            roundNumber: i + 1,
+                            challengerName: challenge.challengerName,
+                            challengedName: challenge.challengedName,
+                          ),
+                          if (i < challenge.rounds.length - 1)
+                            const SizedBox(height: 10),
+                        ],
+
+                        const SizedBox(height: 24),
+                      ],
+                    ),
                   ),
                 ),
-              ),
 
-              // Bottom actions
-              _buildBottomBar(),
-            ],
+                // Bottom actions
+                _buildBottomBar(),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/quiz/quiz_results_screen.dart
+++ b/lib/features/quiz/quiz_results_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/providers/account_provider.dart';
 import '../../data/services/leaderboard_service.dart';
 import '../../game/map/region.dart';
@@ -193,109 +194,111 @@ class _QuizResultsScreenState extends ConsumerState<QuizResultsScreen>
     return Scaffold(
       backgroundColor: FlitColors.backgroundDark,
       body: SafeArea(
-        child: Stack(
-          children: [
-            AnimatedBuilder(
-              animation: _animController,
-              builder: (context, child) {
-                return Opacity(
-                  opacity: _fadeIn.value,
-                  child: Transform.translate(
-                    offset: Offset(0, _slideUp.value),
-                    child: child,
-                  ),
-                );
-              },
-              child: Column(
-                children: [
-                  Expanded(
-                    child: SingleChildScrollView(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 24,
-                      ),
-                      child: Column(
-                        children: [
-                          // Grade badge
-                          _buildGradeBadge(summary.grade),
-                          const SizedBox(height: 20),
+        child: MenuContentWrapper(
+          child: Stack(
+            children: [
+              AnimatedBuilder(
+                animation: _animController,
+                builder: (context, child) {
+                  return Opacity(
+                    opacity: _fadeIn.value,
+                    child: Transform.translate(
+                      offset: Offset(0, _slideUp.value),
+                      child: child,
+                    ),
+                  );
+                },
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: SingleChildScrollView(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 24,
+                        ),
+                        child: Column(
+                          children: [
+                            // Grade badge
+                            _buildGradeBadge(summary.grade),
+                            const SizedBox(height: 20),
 
-                          // Title
-                          Text(
-                            _gradeTitle(summary.grade),
-                            style: const TextStyle(
-                              color: FlitColors.textPrimary,
-                              fontSize: 22,
-                              fontWeight: FontWeight.w900,
-                              letterSpacing: 2,
+                            // Title
+                            Text(
+                              _gradeTitle(summary.grade),
+                              style: const TextStyle(
+                                color: FlitColors.textPrimary,
+                                fontSize: 22,
+                                fontWeight: FontWeight.w900,
+                                letterSpacing: 2,
+                              ),
                             ),
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            '${summary.mode.displayName} — ${summary.categories.length == 1 ? summary.categories.first.displayName : 'Multi'}',
-                            style: const TextStyle(
-                              color: FlitColors.textSecondary,
-                              fontSize: 14,
-                            ),
-                          ),
-                          if (widget.opponentName != null) ...[
                             const SizedBox(height: 8),
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 6,
-                              ),
-                              decoration: BoxDecoration(
-                                color: FlitColors.accent.withOpacity(0.1),
-                                borderRadius: BorderRadius.circular(8),
-                                border: Border.all(
-                                  color: FlitColors.accent.withOpacity(0.25),
-                                ),
-                              ),
-                              child: Text(
-                                'vs ${widget.opponentName}',
-                                style: const TextStyle(
-                                  color: FlitColors.accent,
-                                  fontSize: 13,
-                                  fontWeight: FontWeight.w700,
-                                ),
+                            Text(
+                              '${summary.mode.displayName} — ${summary.categories.length == 1 ? summary.categories.first.displayName : 'Multi'}',
+                              style: const TextStyle(
+                                color: FlitColors.textSecondary,
+                                fontSize: 14,
                               ),
                             ),
-                          ],
-                          const SizedBox(height: 28),
+                            if (widget.opponentName != null) ...[
+                              const SizedBox(height: 8),
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 6,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: FlitColors.accent.withOpacity(0.1),
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                    color: FlitColors.accent.withOpacity(0.25),
+                                  ),
+                                ),
+                                child: Text(
+                                  'vs ${widget.opponentName}',
+                                  style: const TextStyle(
+                                    color: FlitColors.accent,
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                            ],
+                            const SizedBox(height: 28),
 
-                          // Score card (big)
-                          _buildScoreCard(summary),
-                          const SizedBox(height: 12),
-
-                          // Coin reward
-                          if (_coinsEarned > 0) ...[
-                            _buildCoinReward(),
+                            // Score card (big)
+                            _buildScoreCard(summary),
                             const SizedBox(height: 12),
+
+                            // Coin reward
+                            if (_coinsEarned > 0) ...[
+                              _buildCoinReward(),
+                              const SizedBox(height: 12),
+                            ],
+
+                            // Stats grid
+                            _buildStatsGrid(summary),
+                            const SizedBox(height: 16),
+
+                            // Detailed breakdown
+                            _buildBreakdown(summary),
+                            const SizedBox(height: 24),
                           ],
-
-                          // Stats grid
-                          _buildStatsGrid(summary),
-                          const SizedBox(height: 16),
-
-                          // Detailed breakdown
-                          _buildBreakdown(summary),
-                          const SizedBox(height: 24),
-                        ],
+                        ),
                       ),
                     ),
-                  ),
 
-                  // Bottom actions
-                  _buildBottomBar(),
-                ],
+                    // Bottom actions
+                    _buildBottomBar(),
+                  ],
+                ),
               ),
-            ),
-            // Celebration overlay
-            Positioned.fill(
-              child: InkBurstOverlay(key: _inkBurstKey),
-            ),
-          ],
+              // Celebration overlay
+              Positioned.fill(
+                child: InkBurstOverlay(key: _inkBurstKey),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/quiz/quiz_setup_screen.dart
+++ b/lib/features/quiz/quiz_setup_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../game/quiz/flight_school_level.dart';
 import '../../game/quiz/quiz_category.dart';
 import '../../game/quiz/quiz_difficulty.dart';
@@ -150,46 +151,48 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
         iconTheme: const IconThemeData(color: FlitColors.textPrimary),
       ),
       body: SafeArea(
-        child: Column(
-          children: [
-            Expanded(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 20,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _buildHeader(),
-                    const SizedBox(height: 24),
+        child: MenuContentWrapper(
+          child: Column(
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 20,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _buildHeader(),
+                      const SizedBox(height: 24),
 
-                    // Difficulty selector
-                    _buildSectionLabel('DIFFICULTY', Icons.tune),
-                    const SizedBox(height: 10),
-                    _buildDifficultySelector(),
-                    // Area reduction slider (easy mode only)
-                    if (_selectedDifficulty == QuizDifficulty.easy) ...[
-                      const SizedBox(height: 16),
-                      _buildAreaReductionSlider(),
+                      // Difficulty selector
+                      _buildSectionLabel('DIFFICULTY', Icons.tune),
+                      const SizedBox(height: 10),
+                      _buildDifficultySelector(),
+                      // Area reduction slider (easy mode only)
+                      if (_selectedDifficulty == QuizDifficulty.easy) ...[
+                        const SizedBox(height: 16),
+                        _buildAreaReductionSlider(),
+                      ],
+                      const SizedBox(height: 24),
+
+                      _buildSectionLabel('GAME MODE', Icons.videogame_asset),
+                      const SizedBox(height: 10),
+                      ..._buildModeCards(),
+                      const SizedBox(height: 24),
+
+                      _buildSectionLabel('CATEGORIES', Icons.category),
+                      const SizedBox(height: 10),
+                      _buildCategorySection(),
+                      const SizedBox(height: 24),
                     ],
-                    const SizedBox(height: 24),
-
-                    _buildSectionLabel('GAME MODE', Icons.videogame_asset),
-                    const SizedBox(height: 10),
-                    ..._buildModeCards(),
-                    const SizedBox(height: 24),
-
-                    _buildSectionLabel('CATEGORIES', Icons.category),
-                    const SizedBox(height: 10),
-                    _buildCategorySection(),
-                    const SizedBox(height: 24),
-                  ],
+                  ),
                 ),
               ),
-            ),
-            _buildBottomBar(),
-          ],
+              _buildBottomBar(),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/quiz/uncharted_setup_screen.dart
+++ b/lib/features/quiz/uncharted_setup_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/map/region.dart';
 import '../../game/quiz/uncharted_progress.dart';
@@ -97,182 +98,184 @@ class _UnchartedSetupScreenState extends ConsumerState<UnchartedSetupScreen> {
         ],
       ),
       body: SafeArea(
-        child: Column(
-          children: [
-            // Mode toggle.
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: _ModeChip(
-                      label: 'Countries',
-                      subtitle: 'Name the countries',
-                      icon: Icons.map_outlined,
-                      selected: _selectedMode == UnchartedMode.countries,
-                      onTap: () => setState(
-                        () => _selectedMode = UnchartedMode.countries,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: _ModeChip(
-                      label: 'Capitals',
-                      subtitle: 'Name the capitals',
-                      icon: Icons.location_city,
-                      selected: _selectedMode == UnchartedMode.capitals,
-                      onTap: () => setState(
-                        () => _selectedMode = UnchartedMode.capitals,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            // Labels toggle.
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
-              child: GestureDetector(
-                onTap: () => setState(() => _showLabels = !_showLabels),
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-                  decoration: BoxDecoration(
-                    color: _showLabels
-                        ? FlitColors.gold.withValues(alpha: 0.12)
-                        : FlitColors.backgroundMid,
-                    borderRadius: BorderRadius.circular(10),
-                    border: Border.all(
-                      color: _showLabels
-                          ? FlitColors.gold.withValues(alpha: 0.5)
-                          : FlitColors.cardBorder,
-                    ),
-                  ),
-                  child: Row(
-                    children: [
-                      Icon(
-                        _showLabels
-                            ? Icons.label_rounded
-                            : Icons.label_off_rounded,
-                        color: _showLabels
-                            ? FlitColors.gold
-                            : FlitColors.textSecondary,
-                        size: 18,
-                      ),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              'Show Country Names',
-                              style: TextStyle(
-                                color: _showLabels
-                                    ? FlitColors.gold
-                                    : FlitColors.textPrimary,
-                                fontSize: 13,
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                            const Text(
-                              'Labels visible — score halved',
-                              style: TextStyle(
-                                color: FlitColors.textSecondary,
-                                fontSize: 11,
-                              ),
-                            ),
-                          ],
+        child: MenuContentWrapper(
+          child: Column(
+            children: [
+              // Mode toggle.
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: _ModeChip(
+                        label: 'Countries',
+                        subtitle: 'Name the countries',
+                        icon: Icons.map_outlined,
+                        selected: _selectedMode == UnchartedMode.countries,
+                        onTap: () => setState(
+                          () => _selectedMode = UnchartedMode.countries,
                         ),
                       ),
-                      Icon(
-                        _showLabels
-                            ? Icons.check_circle_rounded
-                            : Icons.circle_outlined,
-                        color: _showLabels
-                            ? FlitColors.gold
-                            : FlitColors.textSecondary,
-                        size: 22,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _ModeChip(
+                        label: 'Capitals',
+                        subtitle: 'Name the capitals',
+                        icon: Icons.location_city,
+                        selected: _selectedMode == UnchartedMode.capitals,
+                        onTap: () => setState(
+                          () => _selectedMode = UnchartedMode.capitals,
+                        ),
                       ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-            // Section header.
-            const Padding(
-              padding: EdgeInsets.fromLTRB(16, 12, 16, 8),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  'SELECT REGION',
-                  style: TextStyle(
-                    color: FlitColors.textSecondary,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w700,
-                    letterSpacing: 1.5,
-                  ),
-                ),
-              ),
-            ),
-            // Region list.
-            Expanded(
-              child: ListView.builder(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                itemCount: _regions.length,
-                itemBuilder: (context, index) {
-                  final region = _regions[index];
-                  final areaCount = RegionalData.getAreas(region).length;
-                  final isSelected = region == _selectedRegion;
-                  final key = '${region.name}_${_selectedMode.name}';
-                  final progress =
-                      ref.watch(accountProvider).unchartedProgress[key];
-                  return _RegionCard(
-                    region: region,
-                    areaCount: areaCount,
-                    icon: _regionIcons[region] ?? Icons.public,
-                    selected: isSelected,
-                    progress: progress,
-                    onTap: () => setState(() => _selectedRegion = region),
-                  );
-                },
-              ),
-            ),
-            // Fixed bottom start button.
-            Container(
-              decoration: BoxDecoration(
-                color: FlitColors.backgroundDark,
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.4),
-                    blurRadius: 8,
-                    offset: const Offset(0, -2),
-                  ),
-                ],
-              ),
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-              child: SizedBox(
-                width: double.infinity,
-                height: 52,
-                child: ElevatedButton(
-                  onPressed: _startGame,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: FlitColors.accent,
-                    foregroundColor: FlitColors.textPrimary,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
                     ),
-                    textStyle: const TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.w800,
-                      letterSpacing: 1,
+                  ],
+                ),
+              ),
+              // Labels toggle.
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
+                child: GestureDetector(
+                  onTap: () => setState(() => _showLabels = !_showLabels),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 14, vertical: 10),
+                    decoration: BoxDecoration(
+                      color: _showLabels
+                          ? FlitColors.gold.withValues(alpha: 0.12)
+                          : FlitColors.backgroundMid,
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(
+                        color: _showLabels
+                            ? FlitColors.gold.withValues(alpha: 0.5)
+                            : FlitColors.cardBorder,
+                      ),
+                    ),
+                    child: Row(
+                      children: [
+                        Icon(
+                          _showLabels
+                              ? Icons.label_rounded
+                              : Icons.label_off_rounded,
+                          color: _showLabels
+                              ? FlitColors.gold
+                              : FlitColors.textSecondary,
+                          size: 18,
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Show Country Names',
+                                style: TextStyle(
+                                  color: _showLabels
+                                      ? FlitColors.gold
+                                      : FlitColors.textPrimary,
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              const Text(
+                                'Labels visible — score halved',
+                                style: TextStyle(
+                                  color: FlitColors.textSecondary,
+                                  fontSize: 11,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Icon(
+                          _showLabels
+                              ? Icons.check_circle_rounded
+                              : Icons.circle_outlined,
+                          color: _showLabels
+                              ? FlitColors.gold
+                              : FlitColors.textSecondary,
+                          size: 22,
+                        ),
+                      ],
                     ),
                   ),
-                  child: const Text('START'),
                 ),
               ),
-            ),
-          ],
+              // Section header.
+              const Padding(
+                padding: EdgeInsets.fromLTRB(16, 12, 16, 8),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    'SELECT REGION',
+                    style: TextStyle(
+                      color: FlitColors.textSecondary,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 1.5,
+                    ),
+                  ),
+                ),
+              ),
+              // Region list.
+              Expanded(
+                child: ListView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  itemCount: _regions.length,
+                  itemBuilder: (context, index) {
+                    final region = _regions[index];
+                    final areaCount = RegionalData.getAreas(region).length;
+                    final isSelected = region == _selectedRegion;
+                    final key = '${region.name}_${_selectedMode.name}';
+                    final progress =
+                        ref.watch(accountProvider).unchartedProgress[key];
+                    return _RegionCard(
+                      region: region,
+                      areaCount: areaCount,
+                      icon: _regionIcons[region] ?? Icons.public,
+                      selected: isSelected,
+                      progress: progress,
+                      onTap: () => setState(() => _selectedRegion = region),
+                    );
+                  },
+                ),
+              ),
+              // Fixed bottom start button.
+              Container(
+                decoration: BoxDecoration(
+                  color: FlitColors.backgroundDark,
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.4),
+                      blurRadius: 8,
+                      offset: const Offset(0, -2),
+                    ),
+                  ],
+                ),
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                child: SizedBox(
+                  width: double.infinity,
+                  height: 52,
+                  child: ElevatedButton(
+                    onPressed: _startGame,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: FlitColors.accent,
+                      foregroundColor: FlitColors.textPrimary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      textStyle: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 1,
+                      ),
+                    ),
+                    child: const Text('START'),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/shop/shop_screen.dart
+++ b/lib/features/shop/shop_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/models/economy_config.dart';
 import '../../data/providers/account_provider.dart';
@@ -135,66 +136,68 @@ class _ShopScreenState extends ConsumerState<ShopScreen>
           ),
         ],
       ),
-      body: Column(
-        children: [
-          // Promo banner when shop discount is active.
-          if (hasAnyPromo) _PromoBanner(config: _economyConfig),
-          Expanded(
-            child: TabBarView(
-              controller: _tabController,
-              children: [
-                Column(
-                  children: [
-                    _MysteryPlaneButton(
-                      coins: coins,
-                      ownedIds: ownedIds,
-                      onReveal: (Cosmetic plane) {
-                        ref.read(accountProvider.notifier).purchaseCosmetic(
-                              plane.id,
-                              _MysteryPlaneButton._mysteryCost,
-                            );
-                        setState(() {});
-                      },
-                    ),
-                    Expanded(
-                      child: _CosmeticGrid(
-                        items: CosmeticCatalog.planes,
-                        ownedIds: ownedIds,
-                        equippedId: equippedPlane,
+      body: MenuContentWrapper(
+        child: Column(
+          children: [
+            // Promo banner when shop discount is active.
+            if (hasAnyPromo) _PromoBanner(config: _economyConfig),
+            Expanded(
+              child: TabBarView(
+                controller: _tabController,
+                children: [
+                  Column(
+                    children: [
+                      _MysteryPlaneButton(
                         coins: coins,
-                        level: level,
-                        onPurchase: _purchaseItem,
-                        onEquip: _equipPlane,
-                        economyConfig: _economyConfig,
+                        ownedIds: ownedIds,
+                        onReveal: (Cosmetic plane) {
+                          ref.read(accountProvider.notifier).purchaseCosmetic(
+                                plane.id,
+                                _MysteryPlaneButton._mysteryCost,
+                              );
+                          setState(() {});
+                        },
                       ),
-                    ),
-                  ],
-                ),
-                _CosmeticGrid(
-                  items: CosmeticCatalog.contrails,
-                  ownedIds: ownedIds,
-                  equippedId: equippedContrail,
-                  coins: coins,
-                  level: level,
-                  onPurchase: _purchaseItem,
-                  onEquip: _equipContrail,
-                  economyConfig: _economyConfig,
-                ),
-                _CosmeticGrid(
-                  items: CosmeticCatalog.companions,
-                  ownedIds: ownedIds,
-                  equippedId: equippedCompanion,
-                  coins: coins,
-                  level: level,
-                  onPurchase: _purchaseItem,
-                  onEquip: _equipCompanion,
-                  economyConfig: _economyConfig,
-                ),
-                _GoldShopTab(economyConfig: _economyConfig),
-              ],
+                      Expanded(
+                        child: _CosmeticGrid(
+                          items: CosmeticCatalog.planes,
+                          ownedIds: ownedIds,
+                          equippedId: equippedPlane,
+                          coins: coins,
+                          level: level,
+                          onPurchase: _purchaseItem,
+                          onEquip: _equipPlane,
+                          economyConfig: _economyConfig,
+                        ),
+                      ),
+                    ],
+                  ),
+                  _CosmeticGrid(
+                    items: CosmeticCatalog.contrails,
+                    ownedIds: ownedIds,
+                    equippedId: equippedContrail,
+                    coins: coins,
+                    level: level,
+                    onPurchase: _purchaseItem,
+                    onEquip: _equipContrail,
+                    economyConfig: _economyConfig,
+                  ),
+                  _CosmeticGrid(
+                    items: CosmeticCatalog.companions,
+                    ownedIds: ownedIds,
+                    equippedId: equippedCompanion,
+                    coins: coins,
+                    level: level,
+                    onPurchase: _purchaseItem,
+                    onEquip: _equipCompanion,
+                    economyConfig: _economyConfig,
+                  ),
+                  _GoldShopTab(economyConfig: _economyConfig),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Problem

The app is phone-designed, so on a large screen (desktop browser) every menu stretched edge-to-edge — the PLAY button and the SHOP/PROFILE/FRIENDS/… grid spanned the full viewport, which looked stretched. It should keep a natural, phone-like centred column on wide screens.

## Fix

A single shared layer (no per-screen logic):

- **`lib/core/theme/flit_theme.dart`** — new constant `const double kMaxContentWidth = 560;` (tune in one place).
- **`lib/core/widgets/menu_content_wrapper.dart`** — new `MenuContentWrapper`: `Align(topCenter) → ConstrainedBox(maxWidth: kMaxContentWidth) → child`.
- Wraps the **content** of all **32 menu screens** (home, login, shop, profile, friends, leaderboard, clues, guide, daily, free-flight setup, practice, find-challenger, campaign, flight-school, uncharted/quiz setup, results, license, admin screens, banned/maintenance/update, avatar editor, region select, …). The home game-mode bottom sheet also gets `maxWidth: kMaxContentWidth`.

## Safety / scope

- **Phone layout unchanged** — on narrow screens the 560px cap is never hit.
- **Backgrounds preserved** — on Stack-body screens (home, login) only the overlay is wrapped; the full-bleed `_AnimatedMapBackground` / `_AuthBackground` remain the first Stack child filling the screen (verified in the diff).
- **Full-screen game views intentionally excluded**: `play_screen`, `quiz_game_screen`, `type_in_game_screen`, `uncharted_game_screen`.

## About the large diff

The raw diff looks big (~2200 lines) but it's almost entirely **re-indentation** from wrapping each body in one extra widget. The whitespace-ignored diff (`git diff -w`) is only **175 insertions / 32 deletions** — i.e. the wrapper import + `MenuContentWrapper(child: …)` + one closing paren per screen. No logic changes.

## Validation
- `flutter analyze` on the branch: **0 errors** (760 issues are the pre-existing project baseline of info/warnings; none reference the new code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5)_