### PR TITLE
Fix admin Set License not persisting (debounced write clobbered 25/25/25)

### DIFF
--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -1415,6 +1415,14 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                 },
               );
 
+              // If admin set their own license, force-refresh local state so
+              // the debounced write queue doesn't clobber the admin-set values
+              // with the stale in-memory license on the next _syncAccountState.
+              final currentUserId = ref.read(accountProvider).currentPlayer.id;
+              if (userId == currentUserId) {
+                await ref.read(accountProvider.notifier).adminForceRefresh();
+              }
+
               if (dialogCtx.mounted) Navigator.of(dialogCtx).pop();
               if (!context.mounted) return;
               _snack(


### PR DESCRIPTION
## Bug

In the admin panel, **Set License → 25/25/25** didn't stick — the values reverted within a couple of seconds.

## Root cause

`_showSetLicenseDialog` (`lib/features/admin/admin_screen.dart`) calls the `admin_set_license` Supabase RPC successfully, but the in-memory `AccountNotifier` still holds the **old** license. ~2s later the existing debounce timer (`UserPreferencesService._scheduleSave`) flushes the pending account-state — built from that stale in-memory license — back to Supabase via a normal upsert, **overwriting** the admin-set 25/25/25.

Not a cap issue: `PilotLicense.parseStat()` already accepts 1–25 and the RPC/DB are correct. The only gap was a missing post-RPC state refresh — which the analogous admin "Set Stats" action already does (`adminForceRefresh()`), but the license dialog never did.

## Fix

After the `admin_set_license` RPC, if the admin set **their own** license, force-refresh local state so the debounced write can't clobber it:

```dart
final currentUserId = ref.read(accountProvider).currentPlayer.id;
if (userId == currentUserId) {
  await ref.read(accountProvider.notifier).adminForceRefresh();
}
```

`adminForceRefresh()` clears dirty flags + local caches and reloads from the server, so the new license is applied to in-memory state and the stale pending write is discarded. (Setting *another* user's license is unaffected — no local state to refresh.)

## Validation
- `flutter analyze lib/features/admin/admin_screen.dart` → no new issues (8-line change).

> Note: this touches `admin_screen.dart`, which is also modified by the menu PR (#426) and the upcoming seasonal-vehicles admin section — so a rebase may be needed depending on merge order. I'll handle those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5)_