### PR TITLE
fix(daily): make daily scramble clues identical for all players (statistics-clue inconsistency)

### DIFF
--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -586,10 +586,18 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
       // Derive a per-round seed from the daily seed so each round is different
       // but deterministic across all players.
       final roundSeed = widget.dailySeed! + (_currentRound - 1) * 7919;
+      // preferredClueType is intentionally omitted so the daily clue is purely
+      // seed-determined and IDENTICAL for every player — matching the H2H path
+      // above and the deterministic assumption in
+      // DailyChallenge._computeDifficultyPercent. Passing the player's pilot-
+      // license preferredClueType here biased clue selection per player (a 25%
+      // override chance plus an extra RNG draw that desynced the sequence), so
+      // players whose licence preferred 'stats' saw statistics clues far more
+      // often than others on the same daily. License preferences apply to
+      // hints instead (see _useHint, Tier 1).
       return GameSession.seeded(
         roundSeed,
         allowedClueTypes: widget.enabledClueTypes,
-        preferredClueType: widget.preferredClueType,
         excludedCountryCodes: Set.unmodifiable(_usedDailyCountryCodes),
       );
     }

--- a/test/unit/game/clues/clue_types_test.dart
+++ b/test/unit/game/clues/clue_types_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flit/game/clues/clue_types.dart';
 
@@ -357,6 +359,57 @@ void main() {
       expect(ClueType.nickname.name, equals('nickname'));
       expect(ClueType.landmark.name, equals('landmark'));
       expect(ClueType.flagDescription.name, equals('flagDescription'));
+    });
+  });
+
+  group('Daily Scramble clue fairness (seed-only selection)', () {
+    // Regression guard for the daily-scramble inconsistency bug: the daily must
+    // give every player the same clue for a given seed, so Clue.random is
+    // invoked with the seeded RNG ONLY — never the player's pilot-license
+    // preferredClueType. These tests pin that contract at the level where
+    // preferredClueType actually acts.
+    const allowed = {'flag', 'stats', 'capital', 'borders', 'outline'};
+    const countries = ['FR', 'BR', 'JP', 'EG', 'AU', 'US', 'CN'];
+
+    test('same seed yields identical clue (type + content) for every player',
+        () {
+      for (final code in countries) {
+        for (var seed = 100; seed < 120; seed++) {
+          final playerA =
+              Clue.random(code, allowedTypes: allowed, random: Random(seed));
+          final playerB =
+              Clue.random(code, allowedTypes: allowed, random: Random(seed));
+          // Pure function of (seed, country, allowedTypes): players must match.
+          expect(playerB.type, equals(playerA.type),
+              reason: 'clue type diverged for $code at seed $seed');
+          expect(playerB.displayData, equals(playerA.displayData),
+              reason: 'clue content diverged for $code at seed $seed '
+                  '(stats trio / celebrity must be seed-stable)');
+        }
+      }
+    });
+
+    test('preferredClueType perturbs selection — why the daily must omit it',
+        () {
+      // Characterization: a per-player preferredClueType changes the
+      // deterministic outcome for a fixed seed (a 25% override chance plus an
+      // extra RNG draw that desyncs the sequence). Passing it into the shared
+      // daily made players with different licence preferences diverge — most
+      // visibly, 'stats'-preferring players saw statistics clues far more
+      // often than others on the same daily.
+      var diverged = 0;
+      for (var seed = 0; seed < 300; seed++) {
+        final neutral =
+            Clue.random('FR', allowedTypes: allowed, random: Random(seed));
+        final biased = Clue.random('FR',
+            allowedTypes: allowed,
+            preferredClueType: 'stats',
+            random: Random(seed));
+        if (neutral.type != biased.type) diverged++;
+      }
+      expect(diverged, greaterThan(0),
+          reason: 'preferredClueType should influence selection; it is '
+              'therefore unsafe for the shared daily scramble');
     });
   });
 }


### PR DESCRIPTION
## Problem

Players reported that the **Daily Scramble gives inconsistent clues to different players — especially statistics clues**.

## Root cause

The daily scramble is meant to be a shared puzzle: the country and clue are derived from a date seed so everyone faces the same thing. But the daily path leaked a **per‑player** parameter into clue selection:

- `daily_challenge_screen.dart` passes `preferredClueType: license.preferredClueType` (the player's **pilot‑license** preference) into `PlayScreen`.
- `play_screen.dart` forwarded it into `GameSession.seeded(...)` for the daily.
- In `Clue.random` (`clue_types.dart:140‑147`), a non‑null `preferredClueType` gets a **25% chance to override** the seeded pick — *and* consumes an extra `rng.nextInt(100)` draw that players without a preference don't, which **desyncs the entire random sequence** (clue type, start position, subsequent rounds).

Net effect: two players on the same daily got different clues. Most visibly, a player whose licence preferred **stats** saw statistics clues far more often than everyone else — exactly the reported inconsistency.

The H2H challenge path already avoids this deliberately (it omits `preferredClueType` "so the initial clue is purely seed‑determined and identical for both players"). The daily path simply forgot. `DailyChallenge._computeDifficultyPercent` even *computes* the daily's difficulty assuming deterministic, preference‑free selection — so gameplay didn't match the advertised rating.

## Fix

Omit `preferredClueType` on the daily path so the clue is **purely seed‑determined and identical for every player**, matching the H2H path and the difficulty‑rating assumption. License preferences still apply to **hints** (`_useHint`, Tier 1) — unchanged.

`enabledClueTypes` is left as‑is: it comes from the date‑derived daily *theme* (`'All Clues'`, `'Stats Master'`, …), which is shared by all players.

## Tests

Added a `Daily Scramble clue fairness` group to `clue_types_test.dart`:
- **same seed yields identical clue (type + content) for every player** — pins determinism, including the stats trio and celebrity pick.
- **`preferredClueType` perturbs selection** — characterization proving why it's unsafe for the shared daily.

All clue tests pass (31/31); `flutter analyze` clean on the changed files.

## Scope note

This is correctly scoped to the **shared/ranked** daily. H2H is already fair; campaign and free‑play are solo, where personalising the clue to the player's licence is intended. The unseeded `Random()` in the regional sports‑team builders only runs in solo free‑play (`GameSession.random`) and is harmless there.

> Note: the pre‑commit run showed one flaky failure in `error_service_test.dart` (a flush‑concurrency/backoff timing test); it passes 22/22 in isolation and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRjNwZHS5KuStTYrytDjJ5)_