### PR TITLE
feat: Triangulation daily mini-game + Mission Board menu bracket

### DIFF
--- a/lib/core/utils/math_utils.dart
+++ b/lib/core/utils/math_utils.dart
@@ -1,7 +1,54 @@
 import 'dart:math';
 
+import 'package:flame/components.dart';
+
 /// Degrees-to-radians conversion constant.
 const double deg2rad = pi / 180.0;
 
 /// Radians-to-degrees conversion constant.
 const double rad2deg = 180.0 / pi;
+
+/// Kilometres per degree of great-circle arc (mean Earth radius).
+const double kmPerDegree = 111.195;
+
+/// Great-circle angular distance between two (lng, lat) points, in degrees.
+double greatCircleDistDeg(Vector2 a, Vector2 b) {
+  final lat1 = a.y * deg2rad;
+  final lat2 = b.y * deg2rad;
+  final dLat = (b.y - a.y) * deg2rad;
+  final dLng = (b.x - a.x) * deg2rad;
+
+  final h = sin(dLat / 2) * sin(dLat / 2) +
+      cos(lat1) * cos(lat2) * sin(dLng / 2) * sin(dLng / 2);
+  final c = 2 * atan2(sqrt(h), sqrt(1 - h));
+  return c * rad2deg;
+}
+
+/// Great-circle distance between two (lng, lat) points, in kilometres.
+double greatCircleKm(Vector2 a, Vector2 b) =>
+    greatCircleDistDeg(a, b) * kmPerDegree;
+
+/// Initial great-circle bearing from [from] to [to], in radians.
+///
+/// Points are (lng, lat) in degrees. Result is a navigation bearing:
+/// 0 = north, positive clockwise, in the range (-pi, pi].
+double initialBearingRad(Vector2 from, Vector2 to) {
+  final lat1 = from.y * deg2rad;
+  final lng1 = from.x * deg2rad;
+  final lat2 = to.y * deg2rad;
+  final lng2 = to.x * deg2rad;
+  final dLng = lng2 - lng1;
+
+  final y = sin(dLng) * cos(lat2);
+  final x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLng);
+  return atan2(y, x);
+}
+
+/// Initial great-circle bearing from [from] to [to], in compass degrees.
+///
+/// Points are (lng, lat) in degrees. Result is normalised to [0, 360):
+/// 0 = north, 90 = east, 180 = south, 270 = west.
+double initialBearingDeg(Vector2 from, Vector2 to) {
+  final deg = initialBearingRad(from, to) * rad2deg;
+  return (deg % 360 + 360) % 360;
+}

--- a/lib/core/widgets/country_outline_painter.dart
+++ b/lib/core/widgets/country_outline_painter.dart
@@ -1,0 +1,87 @@
+import 'dart:math' as math;
+
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart';
+
+/// Draws a country's border polygons as a flat, north-up silhouette that
+/// fills the available box.
+///
+/// Shared by the Explore clue browser and the Triangulation compass so all
+/// modes render outlines identically (see CLAUDE.md: shared rendering lives
+/// at the shared layer).
+class CountryOutlinePainter extends CustomPainter {
+  CountryOutlinePainter(
+    this.polygons, {
+    required this.fillColor,
+    required this.strokeColor,
+    this.strokeWidth = 1.0,
+    this.padding = 2.0,
+  });
+
+  /// Multi-polygon border data, each point as (lng, lat) degrees.
+  final List<List<Vector2>> polygons;
+  final Color fillColor;
+  final Color strokeColor;
+  final double strokeWidth;
+  final double padding;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (polygons.isEmpty || size.isEmpty) return;
+
+    final firstPt = polygons.first.first;
+    var minX = firstPt.x;
+    var maxX = firstPt.x;
+    var minY = firstPt.y;
+    var maxY = firstPt.y;
+    for (final poly in polygons) {
+      for (final p in poly) {
+        minX = math.min(minX, p.x);
+        maxX = math.max(maxX, p.x);
+        minY = math.min(minY, p.y);
+        maxY = math.max(maxY, p.y);
+      }
+    }
+
+    final rangeX = maxX - minX;
+    final rangeY = maxY - minY;
+    if (rangeX == 0 || rangeY == 0) return;
+
+    final drawW = size.width - padding * 2;
+    final drawH = size.height - padding * 2;
+    final scale = math.min(drawW / rangeX, drawH / rangeY);
+    final offsetX = padding + (drawW - rangeX * scale) / 2;
+    final offsetY = padding + (drawH - rangeY * scale) / 2;
+
+    final path = Path();
+    for (final poly in polygons) {
+      for (var i = 0; i < poly.length; i++) {
+        final x = offsetX + (poly[i].x - minX) * scale;
+        // Flip Y so north is up.
+        final y = offsetY + (maxY - poly[i].y) * scale;
+        if (i == 0) {
+          path.moveTo(x, y);
+        } else {
+          path.lineTo(x, y);
+        }
+      }
+      path.close();
+    }
+
+    canvas.drawPath(path, Paint()..color = fillColor);
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = strokeColor
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = strokeWidth,
+    );
+  }
+
+  @override
+  bool shouldRepaint(CountryOutlinePainter old) =>
+      polygons != old.polygons ||
+      fillColor != old.fillColor ||
+      strokeColor != old.strokeColor ||
+      strokeWidth != old.strokeWidth;
+}

--- a/lib/features/explore/country_clues_screen.dart
+++ b/lib/features/explore/country_clues_screen.dart
@@ -1,11 +1,9 @@
-import 'dart:math' as math;
-
 import 'package:flag/flag.dart';
-import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/country_outline_painter.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/services/clue_report_service.dart';
 import '../../game/clues/clue_types.dart';
@@ -1321,80 +1319,24 @@ class _FlagWidget extends StatelessWidget {
 
 enum _OutlineQuality { good, fair, poor }
 
-class _OutlinePainter extends CustomPainter {
-  _OutlinePainter(this.polygons, {this.quality = _OutlineQuality.good});
-
-  final List<List<Vector2>> polygons;
-  final _OutlineQuality quality;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    if (polygons.isEmpty || size.isEmpty) return;
-
-    final firstPt = polygons.first.first;
-    var minX = firstPt.x;
-    var maxX = firstPt.x;
-    var minY = firstPt.y;
-    var maxY = firstPt.y;
-    for (final poly in polygons) {
-      for (final p in poly) {
-        minX = math.min(minX, p.x);
-        maxX = math.max(maxX, p.x);
-        minY = math.min(minY, p.y);
-        maxY = math.max(maxY, p.y);
-      }
-    }
-
-    final rangeX = maxX - minX;
-    final rangeY = maxY - minY;
-    if (rangeX == 0 || rangeY == 0) return;
-
-    const padding = 2.0;
-    final drawW = size.width - padding * 2;
-    final drawH = size.height - padding * 2;
-    final scale = math.min(drawW / rangeX, drawH / rangeY);
-    final offsetX = padding + (drawW - rangeX * scale) / 2;
-    final offsetY = padding + (drawH - rangeY * scale) / 2;
-
-    final path = Path();
-    for (final poly in polygons) {
-      for (var i = 0; i < poly.length; i++) {
-        final x = offsetX + (poly[i].x - minX) * scale;
-        final y = offsetY + (maxY - poly[i].y) * scale;
-        if (i == 0) {
-          path.moveTo(x, y);
-        } else {
-          path.lineTo(x, y);
-        }
-      }
-      path.close();
-    }
-
-    final fillColor = quality == _OutlineQuality.good
-        ? FlitColors.landMass.withOpacity(0.5)
-        : quality == _OutlineQuality.fair
-            ? FlitColors.warning.withOpacity(0.25)
-            : FlitColors.error.withOpacity(0.2);
-
-    final strokeColor = quality == _OutlineQuality.good
-        ? FlitColors.accent
-        : quality == _OutlineQuality.fair
-            ? FlitColors.warning
-            : FlitColors.error;
-
-    canvas.drawPath(path, Paint()..color = fillColor);
-    canvas.drawPath(
-      path,
-      Paint()
-        ..color = strokeColor
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 1.0,
-    );
-  }
-
-  @override
-  bool shouldRepaint(_OutlinePainter old) =>
-      polygons != old.polygons || quality != old.quality;
+/// Thin wrapper mapping outline quality to colours; the actual silhouette
+/// drawing lives in the shared [CountryOutlinePainter].
+class _OutlinePainter extends CountryOutlinePainter {
+  _OutlinePainter(
+    super.polygons, {
+    _OutlineQuality quality = _OutlineQuality.good,
+  }) : super(
+          fillColor: quality == _OutlineQuality.good
+              ? FlitColors.landMass.withOpacity(0.5)
+              : quality == _OutlineQuality.fair
+                  ? FlitColors.warning.withOpacity(0.25)
+                  : FlitColors.error.withOpacity(0.2),
+          strokeColor: quality == _OutlineQuality.good
+              ? FlitColors.accent
+              : quality == _OutlineQuality.fair
+                  ? FlitColors.warning
+                  : FlitColors.error,
+        );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -28,6 +28,8 @@ import '../profile/profile_screen.dart';
 import '../quiz/daily_briefing_screen.dart';
 import '../quiz/flight_school_screen.dart';
 import '../quiz/uncharted_setup_screen.dart';
+import '../triangulation/daily_triangulation_screen.dart';
+import '../triangulation/triangulation_setup_screen.dart';
 import '../shop/shop_screen.dart';
 import '../campaign/campaign_screen.dart';
 import '../../game/tutorial/mode_requirements.dart';
@@ -420,6 +422,58 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              // ── MISSION BOARD — daily challenges, same for all pilots ──
+              const _SectionLabel(
+                icon: Icons.push_pin_rounded,
+                label: 'MISSION BOARD',
+              ),
+              const SizedBox(height: 12),
+              _GameModeCard(
+                title: 'Daily Triangulation',
+                subtitle: 'Track the hidden capital by its bearings',
+                icon: Icons.explore_rounded,
+                isHighlighted: true,
+                isRedHighlighted: true,
+                isLocked: _isLocked('daily_triangulation'),
+                unlockHint: _lockHint('daily_triangulation'),
+                onTap: () => _closeSheetAndNavigate(
+                  ctx,
+                  const DailyTriangulationScreen(),
+                ),
+              ),
+              const SizedBox(height: 10),
+              if (_dailyScrambleEnabled) ...[
+                _GameModeCard(
+                  title: 'Daily Scramble',
+                  subtitle: "Today's challenge — compete for glory",
+                  icon: Icons.today_rounded,
+                  isHighlighted: true,
+                  isRedHighlighted: true,
+                  isLocked: _isLocked('daily_challenge'),
+                  unlockHint: _lockHint('daily_challenge'),
+                  onTap: () => _closeSheetAndNavigate(
+                    ctx,
+                    const DailyChallengeScreen(),
+                  ),
+                ),
+                const SizedBox(height: 10),
+              ],
+              _GameModeCard(
+                title: 'Daily Briefing',
+                subtitle: 'Daily quiz challenge — same for all pilots',
+                icon: Icons.assignment_rounded,
+                isHighlighted: true,
+                isRedHighlighted: true,
+                isLocked: _isLocked('daily_briefing'),
+                unlockHint: _lockHint('daily_briefing'),
+                onTap: () => _closeSheetAndNavigate(
+                  ctx,
+                  const DailyBriefingScreen(),
+                ),
+              ),
+
+              const SizedBox(height: 20),
+
               // ── FLIGHT DECK — globe & flying modes ──
               const _SectionLabel(
                 icon: Icons.flight_takeoff_rounded,
@@ -438,23 +492,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                 ),
               ),
               const SizedBox(height: 10),
-              // Daily modes in red
-              if (_dailyScrambleEnabled) ...[
-                _GameModeCard(
-                  title: 'Daily Scramble',
-                  subtitle: "Today's challenge — compete for glory",
-                  icon: Icons.today_rounded,
-                  isHighlighted: true,
-                  isRedHighlighted: true,
-                  isLocked: _isLocked('daily_challenge'),
-                  unlockHint: _lockHint('daily_challenge'),
-                  onTap: () => _closeSheetAndNavigate(
-                    ctx,
-                    const DailyChallengeScreen(),
-                  ),
-                ),
-                const SizedBox(height: 10),
-              ],
               _GameModeCard(
                 title: 'Free Flight',
                 subtitle: 'Explore the world at your own pace',
@@ -506,16 +543,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
               ),
               const SizedBox(height: 12),
               _GameModeCard(
-                title: 'Daily Briefing',
-                subtitle: 'Daily quiz challenge — same for all pilots',
-                icon: Icons.assignment_rounded,
-                isHighlighted: true,
-                isRedHighlighted: true,
-                isLocked: _isLocked('daily_briefing'),
-                unlockHint: _lockHint('daily_briefing'),
+                title: 'Triangulation',
+                subtitle: 'Hunt hidden capitals by compass bearing',
+                icon: Icons.explore,
                 onTap: () => _closeSheetAndNavigate(
                   ctx,
-                  const DailyBriefingScreen(),
+                  const TriangulationSetupScreen(),
                 ),
               ),
               const SizedBox(height: 10),

--- a/lib/features/triangulation/daily_triangulation_screen.dart
+++ b/lib/features/triangulation/daily_triangulation_screen.dart
@@ -1,0 +1,332 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
+import '../../data/models/daily_result.dart';
+import '../../game/triangulation/daily_triangulation.dart';
+import 'triangulation_game_screen.dart';
+
+/// Lobby for the Daily Triangulation: shows today's theme and rules, and
+/// either the play button or (once played) the result with share.
+class DailyTriangulationScreen extends StatefulWidget {
+  const DailyTriangulationScreen({super.key});
+
+  @override
+  State<DailyTriangulationScreen> createState() =>
+      _DailyTriangulationScreenState();
+}
+
+class _DailyTriangulationScreenState extends State<DailyTriangulationScreen> {
+  late final DailyTriangulation _daily;
+  String? _completedShareText;
+  int? _completedScore;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _daily = DailyTriangulation.forToday();
+    _loadResult();
+  }
+
+  Future<void> _loadResult() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (!mounted) return;
+    setState(() {
+      _completedShareText =
+          prefs.getString('daily_triangulation_${_daily.dateKey}');
+      _completedScore =
+          prefs.getInt('daily_triangulation_score_${_daily.dateKey}');
+      _loading = false;
+    });
+  }
+
+  Future<void> _play() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => TriangulationGameScreen(
+          config: _daily.toConfig(),
+          daily: _daily,
+        ),
+      ),
+    );
+    // Refresh: the game screen records the result on completion.
+    await _loadResult();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final played = _completedShareText != null;
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      appBar: AppBar(
+        backgroundColor: FlitColors.backgroundMid,
+        title: const Text(
+          'Daily Triangulation',
+          style: TextStyle(color: FlitColors.textPrimary),
+        ),
+        centerTitle: true,
+        iconTheme: const IconThemeData(color: FlitColors.textPrimary),
+      ),
+      body: SafeArea(
+        child: MenuContentWrapper(
+          child: _loading
+              ? const Center(
+                  child: CircularProgressIndicator(color: FlitColors.accent),
+                )
+              : SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    children: [
+                      _buildHeader(),
+                      const SizedBox(height: 16),
+                      _buildRules(),
+                      const SizedBox(height: 24),
+                      if (played) _buildResult() else _buildPlayButton(),
+                    ],
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() => Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: FlitColors.error.withOpacity(0.5)),
+        ),
+        child: Column(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: FlitColors.error.withOpacity(0.15),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: const Icon(
+                Icons.explore,
+                color: FlitColors.error,
+                size: 32,
+              ),
+            ),
+            const SizedBox(height: 14),
+            Text(
+              'TRIANGULATION #${_daily.dayNumber}',
+              style: const TextStyle(
+                color: FlitColors.textPrimary,
+                fontSize: 22,
+                fontWeight: FontWeight.w900,
+                letterSpacing: 3,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12,
+                vertical: 5,
+              ),
+              decoration: BoxDecoration(
+                color: FlitColors.gold.withOpacity(0.12),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: FlitColors.gold.withOpacity(0.35)),
+              ),
+              child: Text(
+                "Today's theme: ${_daily.theme.title}",
+                style: const TextStyle(
+                  color: FlitColors.gold,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            const SizedBox(height: 10),
+            const Text(
+              'Same puzzle for every pilot.\n'
+              'Your guesses make it yours.',
+              style: TextStyle(
+                color: FlitColors.textSecondary,
+                fontSize: 13,
+                height: 1.4,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+
+  Widget _buildRules() => Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: FlitColors.cardBorder),
+        ),
+        child: const Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _RuleRow(
+              icon: Icons.explore,
+              text: 'Each arrow points from the hidden capital toward a '
+                  'known place — cross-reference them to close in.',
+            ),
+            _RuleRow(
+              icon: Icons.replay,
+              text: '3 hidden capitals, 5 guesses each. Wrong guesses join '
+                  'the compass in red.',
+            ),
+            _RuleRow(
+              icon: Icons.timer_outlined,
+              text: 'Full marks inside 10 seconds, decaying to 60s. Wild '
+                  'guesses cost more than near misses.',
+            ),
+            _RuleRow(
+              icon: Icons.star_outline,
+              text: 'Name the capital for full points — the country alone '
+                  'scores ×0.7.',
+            ),
+          ],
+        ),
+      );
+
+  Widget _buildPlayButton() => SizedBox(
+        width: double.infinity,
+        height: 54,
+        child: ElevatedButton.icon(
+          onPressed: _play,
+          icon: const Icon(Icons.flight_takeoff, size: 22),
+          label: const Text(
+            'START TRIANGULATION',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w900,
+              letterSpacing: 2,
+            ),
+          ),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: FlitColors.error,
+            foregroundColor: FlitColors.textPrimary,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+            ),
+            elevation: 4,
+          ),
+        ),
+      );
+
+  Widget _buildResult() => Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: FlitColors.gold.withOpacity(0.4)),
+        ),
+        child: Column(
+          children: [
+            const Text(
+              'FLOWN FOR TODAY',
+              style: TextStyle(
+                color: FlitColors.gold,
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 2,
+              ),
+            ),
+            const SizedBox(height: 10),
+            if (_completedScore != null)
+              Text(
+                '${DailyResult.formatScore(_completedScore!)} pts',
+                style: const TextStyle(
+                  color: FlitColors.textPrimary,
+                  fontSize: 26,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            const SizedBox(height: 10),
+            Text(
+              _completedShareText!,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: FlitColors.textSecondary,
+                fontSize: 13,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 14),
+            SizedBox(
+              width: double.infinity,
+              height: 48,
+              child: ElevatedButton.icon(
+                onPressed: () {
+                  Clipboard.setData(
+                    ClipboardData(text: _completedShareText!),
+                  );
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Result copied — paste to share!'),
+                    ),
+                  );
+                },
+                icon: const Icon(Icons.share, size: 18),
+                label: const Text(
+                  'SHARE',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w900,
+                    letterSpacing: 2,
+                  ),
+                ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: FlitColors.gold,
+                  foregroundColor: FlitColors.backgroundDark,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              'Come back tomorrow for a new puzzle',
+              style: TextStyle(color: FlitColors.textMuted, fontSize: 12),
+            ),
+          ],
+        ),
+      );
+}
+
+class _RuleRow extends StatelessWidget {
+  const _RuleRow({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: FlitColors.accent, size: 18),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                text,
+                style: const TextStyle(
+                  color: FlitColors.textSecondary,
+                  fontSize: 13,
+                  height: 1.4,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+}

--- a/lib/features/triangulation/triangulation_game_screen.dart
+++ b/lib/features/triangulation/triangulation_game_screen.dart
@@ -1,0 +1,889 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flag/flag.dart';
+import 'package:flame/components.dart' show Vector2;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
+import '../../data/models/daily_result.dart';
+import '../../game/map/country_data.dart';
+import '../../game/quiz/fuzzy_match.dart';
+import '../../game/triangulation/daily_triangulation.dart';
+import '../../game/triangulation/triangulation_session.dart';
+import '../../game/triangulation/triangulation_share.dart';
+import 'widgets/triangulation_compass.dart';
+
+/// The Triangulation gameplay screen: compass + guess input, round results
+/// on a map, and a final summary with spoiler-free share text.
+class TriangulationGameScreen extends StatefulWidget {
+  const TriangulationGameScreen({
+    super.key,
+    required this.config,
+    this.daily,
+  });
+
+  final TriangulationConfig config;
+
+  /// Set when playing the daily puzzle — enables the day-number share
+  /// header and records completion so the puzzle can't be replayed.
+  final DailyTriangulation? daily;
+
+  @override
+  State<TriangulationGameScreen> createState() =>
+      _TriangulationGameScreenState();
+}
+
+/// One entry the player can type/tap: either a country or its capital.
+class _GuessCandidate {
+  const _GuessCandidate({
+    required this.code,
+    required this.display,
+    required this.viaCapital,
+  });
+
+  final String code;
+  final String display;
+  final bool viaCapital;
+}
+
+class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
+  late final TriangulationSession _session;
+  late final FuzzyMatcher _countryMatcher;
+  late final FuzzyMatcher _capitalMatcher;
+  late final List<_GuessCandidate> _candidates;
+
+  final Stopwatch _stopwatch = Stopwatch();
+  Timer? _ticker;
+  final TextEditingController _inputController = TextEditingController();
+  final FocusNode _inputFocus = FocusNode();
+
+  bool _showingRoundResult = false;
+  bool _finished = false;
+  String? _feedback;
+
+  @override
+  void initState() {
+    super.initState();
+    _session = TriangulationSession(widget.config);
+
+    final eligible = CountryData.playableCountries
+        .where((c) => CountryData.getCapital(c.code) != null)
+        .toList();
+    _countryMatcher = FuzzyMatcher({for (final c in eligible) c.code: c.name});
+    _capitalMatcher = FuzzyMatcher({
+      for (final c in eligible) c.code: CountryData.getCapital(c.code)!.name,
+    });
+    _candidates = [
+      for (final c in eligible) ...[
+        _GuessCandidate(code: c.code, display: c.name, viaCapital: false),
+        _GuessCandidate(
+          code: c.code,
+          display: CountryData.getCapital(c.code)!.name,
+          viaCapital: true,
+        ),
+      ],
+    ];
+
+    _stopwatch.start();
+    _ticker = Timer.periodic(
+      const Duration(seconds: 1),
+      (_) => setState(() {}),
+    );
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    _inputController.dispose();
+    _inputFocus.dispose();
+    super.dispose();
+  }
+
+  Set<String> get _guessedCodes =>
+      _session.currentRound.guesses.map((g) => g.countryCode).toSet();
+
+  List<_GuessCandidate> _suggestionsFor(String input) {
+    final query = input.trim().toLowerCase();
+    if (query.length < 2) return const [];
+    final guessed = _guessedCodes;
+    final starts = <_GuessCandidate>[];
+    final contains = <_GuessCandidate>[];
+    for (final c in _candidates) {
+      if (guessed.contains(c.code)) continue;
+      final name = c.display.toLowerCase();
+      if (name.startsWith(query)) {
+        starts.add(c);
+      } else if (name.contains(query)) {
+        contains.add(c);
+      }
+    }
+    return [...starts, ...contains].take(6).toList();
+  }
+
+  void _submitTyped(String input) {
+    if (input.trim().isEmpty) return;
+    // Prefer capital matches (full points), then country names; both
+    // matchers are typo-tolerant with alias support.
+    final capitalMatch =
+        _capitalMatcher.bestMatch(input, excludeCodes: _guessedCodes);
+    final countryMatch =
+        _countryMatcher.bestMatch(input, excludeCodes: _guessedCodes);
+    _GuessCandidate? chosen;
+    if (capitalMatch != null &&
+        (countryMatch == null ||
+            capitalMatch.distance <= countryMatch.distance)) {
+      chosen = _GuessCandidate(
+        code: capitalMatch.code,
+        display: capitalMatch.canonicalName,
+        viaCapital: true,
+      );
+    } else if (countryMatch != null) {
+      chosen = _GuessCandidate(
+        code: countryMatch.code,
+        display: countryMatch.canonicalName,
+        viaCapital: false,
+      );
+    }
+    if (chosen == null) {
+      setState(() => _feedback = 'No country or capital matches "$input"');
+      return;
+    }
+    _submitCandidate(chosen);
+  }
+
+  void _submitCandidate(_GuessCandidate candidate) {
+    if (_session.currentRound.isOver) return;
+    final guess = _session.submitGuess(
+      candidate.code,
+      viaCapital: candidate.viaCapital,
+      elapsedMs: _stopwatch.elapsedMilliseconds,
+    );
+    _inputController.clear();
+    setState(() {
+      _feedback = guess.isCorrect
+          ? null
+          : '${proximityEmoji(guess.distanceKm)} '
+              '${guess.viaCapital ? guess.capitalName : guess.countryName}'
+              ' — not it';
+      if (_session.currentRound.isOver) {
+        _stopwatch.stop();
+        _showingRoundResult = true;
+        _feedback = null;
+      }
+    });
+  }
+
+  Future<void> _continueFromResult() async {
+    if (_session.isLastRound) {
+      await _recordDailyResult();
+      setState(() {
+        _showingRoundResult = false;
+        _finished = true;
+      });
+      return;
+    }
+    _session.advanceRound();
+    _stopwatch
+      ..reset()
+      ..start();
+    setState(() => _showingRoundResult = false);
+  }
+
+  Future<void> _recordDailyResult() async {
+    final daily = widget.daily;
+    if (daily == null) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      'daily_triangulation_${daily.dateKey}',
+      buildTriangulationShareText(_session, dayNumber: daily.dayNumber),
+    );
+    await prefs.setInt(
+      'daily_triangulation_score_${daily.dateKey}',
+      _session.totalScore,
+    );
+  }
+
+  String get _shareText => buildTriangulationShareText(
+        _session,
+        dayNumber: widget.daily?.dayNumber ?? 0,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget body;
+    if (_finished) {
+      body = _SummaryView(
+        session: _session,
+        shareText: _shareText,
+        isDaily: widget.daily != null,
+      );
+    } else if (_showingRoundResult) {
+      body = _RoundResultView(
+        state: _session.currentRound,
+        isLastRound: _session.isLastRound,
+        onContinue: _continueFromResult,
+      );
+    } else {
+      body = _buildPlayView();
+    }
+
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      appBar: AppBar(
+        backgroundColor: FlitColors.backgroundMid,
+        title: Text(
+          widget.daily != null ? 'Daily Triangulation' : 'Triangulation',
+          style: const TextStyle(color: FlitColors.textPrimary),
+        ),
+        centerTitle: true,
+        iconTheme: const IconThemeData(color: FlitColors.textPrimary),
+      ),
+      body: SafeArea(child: MenuContentWrapper(child: body)),
+    );
+  }
+
+  Widget _buildPlayView() {
+    final state = _session.currentRound;
+    final suggestions = _suggestionsFor(_inputController.text);
+    final seconds = _stopwatch.elapsedMilliseconds ~/ 1000;
+
+    return Column(
+      children: [
+        _StatusBar(
+          roundNumber: _session.currentRoundNumber,
+          totalRounds: _session.rounds.length,
+          guessesRemaining: _session.guessesRemaining,
+          totalGuesses: widget.config.guessesPerRound,
+          seconds: seconds,
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Column(
+              children: [
+                TriangulationCompass(
+                  clues: state.round.clues,
+                  wrongGuesses: state.wrongGuesses,
+                  clueTypes: widget.config.clueTypes,
+                  labelTypes: widget.config.labelTypes,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Arrows point from the hidden capital toward each place',
+                  style: TextStyle(
+                    color: FlitColors.textMuted.withOpacity(0.8),
+                    fontSize: 11,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (_feedback != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              _feedback!,
+              style: const TextStyle(
+                color: FlitColors.warning,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        if (suggestions.isNotEmpty)
+          Container(
+            height: 44,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: [
+                for (final s in suggestions)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 8, top: 6),
+                    child: ActionChip(
+                      backgroundColor: FlitColors.cardBackground,
+                      side: BorderSide(
+                        color: s.viaCapital
+                            ? FlitColors.gold.withOpacity(0.6)
+                            : FlitColors.cardBorder,
+                      ),
+                      label: Text(
+                        s.viaCapital ? '${s.display} ★' : s.display,
+                        style: const TextStyle(
+                          color: FlitColors.textPrimary,
+                          fontSize: 12,
+                        ),
+                      ),
+                      onPressed: () => _submitCandidate(s),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 6, 12, 12),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _inputController,
+                  focusNode: _inputFocus,
+                  onChanged: (_) => setState(() => _feedback = null),
+                  onSubmitted: _submitTyped,
+                  textInputAction: TextInputAction.send,
+                  style: const TextStyle(color: FlitColors.textPrimary),
+                  decoration: InputDecoration(
+                    hintText: 'Capital (full pts) or country (×0.7)…',
+                    hintStyle: const TextStyle(
+                      color: FlitColors.textMuted,
+                      fontSize: 13,
+                    ),
+                    filled: true,
+                    fillColor: FlitColors.cardBackground,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 12,
+                    ),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide:
+                          const BorderSide(color: FlitColors.cardBorder),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide:
+                          const BorderSide(color: FlitColors.cardBorder),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: const BorderSide(color: FlitColors.accent),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              SizedBox(
+                height: 46,
+                child: ElevatedButton(
+                  onPressed: () => _submitTyped(_inputController.text),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: FlitColors.accent,
+                    foregroundColor: FlitColors.textPrimary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Icon(Icons.explore),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Status bar: round, guesses, timer
+// ─────────────────────────────────────────────────────────────────────────
+
+class _StatusBar extends StatelessWidget {
+  const _StatusBar({
+    required this.roundNumber,
+    required this.totalRounds,
+    required this.guessesRemaining,
+    required this.totalGuesses,
+    required this.seconds,
+  });
+
+  final int roundNumber;
+  final int totalRounds;
+  final int guessesRemaining;
+  final int totalGuesses;
+  final int seconds;
+
+  @override
+  Widget build(BuildContext context) {
+    // Full points inside 10s, decaying to 60s — tint the timer to match.
+    final timerColor = seconds <= 10
+        ? FlitColors.success
+        : seconds < 60
+            ? FlitColors.warning
+            : FlitColors.error;
+    return Container(
+      color: FlitColors.backgroundMid,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            'ROUND $roundNumber/$totalRounds',
+            style: const TextStyle(
+              color: FlitColors.textSecondary,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 1.5,
+            ),
+          ),
+          Row(
+            children: [
+              for (var i = 0; i < totalGuesses; i++)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 2),
+                  child: Icon(
+                    i < guessesRemaining
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_off,
+                    size: 12,
+                    color: i < guessesRemaining
+                        ? FlitColors.accent
+                        : FlitColors.textMuted,
+                  ),
+                ),
+            ],
+          ),
+          Row(
+            children: [
+              Icon(Icons.timer_outlined, size: 14, color: timerColor),
+              const SizedBox(width: 4),
+              Text(
+                '${seconds ~/ 60}:${(seconds % 60).toString().padLeft(2, '0')}',
+                style: TextStyle(
+                  color: timerColor,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Round result: answer revealed on a map
+// ─────────────────────────────────────────────────────────────────────────
+
+class _RoundResultView extends StatelessWidget {
+  const _RoundResultView({
+    required this.state,
+    required this.isLastRound,
+    required this.onContinue,
+  });
+
+  final TriangulationRoundState state;
+  final bool isLastRound;
+  final VoidCallback onContinue;
+
+  @override
+  Widget build(BuildContext context) {
+    final round = state.round;
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                Text(
+                  state.solved ? 'TRIANGULATED!' : 'TARGET LOST',
+                  style: TextStyle(
+                    color: state.solved ? FlitColors.success : FlitColors.error,
+                    fontSize: 22,
+                    fontWeight: FontWeight.w900,
+                    letterSpacing: 3,
+                  ),
+                ),
+                const SizedBox(height: 14),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    if (round.targetCountryCode.length == 2 &&
+                        !round.targetCountryCode.startsWith('X'))
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(4),
+                        child: Flag.fromString(
+                          round.targetCountryCode,
+                          height: 30,
+                          width: 45,
+                          fit: BoxFit.contain,
+                          borderRadius: 4,
+                        ),
+                      ),
+                    const SizedBox(width: 10),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          round.targetCapitalName,
+                          style: const TextStyle(
+                            color: FlitColors.textPrimary,
+                            fontSize: 20,
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                        Text(
+                          round.targetCountryName,
+                          style: const TextStyle(
+                            color: FlitColors.textSecondary,
+                            fontSize: 14,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                // The reveal: world map with the target and every guess.
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: Container(
+                    color: FlitColors.backgroundMid,
+                    child: AspectRatio(
+                      aspectRatio: 2,
+                      child: CustomPaint(
+                        painter: _ResultMapPainter(
+                          targetLngLat: round.targetCapitalLngLat,
+                          guesses: state.wrongGuesses,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                if (state.wrongGuesses.isNotEmpty)
+                  Column(
+                    children: [
+                      for (final g in state.wrongGuesses)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 2),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                proximityEmoji(g.distanceKm),
+                                style: const TextStyle(fontSize: 12),
+                              ),
+                              const SizedBox(width: 6),
+                              Text(
+                                '${g.countryName} — '
+                                '${g.distanceKm.round()} km away',
+                                style: const TextStyle(
+                                  color: FlitColors.textSecondary,
+                                  fontSize: 13,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                    ],
+                  ),
+                const SizedBox(height: 12),
+                Text(
+                  '+${DailyResult.formatScore(state.score)} pts',
+                  style: TextStyle(
+                    color:
+                        state.solved ? FlitColors.gold : FlitColors.textMuted,
+                    fontSize: 24,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                if (state.solved && state.solvedAsCountry)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 4),
+                    child: Text(
+                      'Solved by country name (×0.7)',
+                      style: TextStyle(
+                        color: FlitColors.textMuted,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: SizedBox(
+            width: double.infinity,
+            height: 52,
+            child: ElevatedButton(
+              onPressed: onContinue,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: FlitColors.accent,
+                foregroundColor: FlitColors.textPrimary,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+              ),
+              child: Text(
+                isLastRound ? 'SEE RESULTS' : 'NEXT ROUND',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w900,
+                  letterSpacing: 2,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Equirectangular world map with the target capital (gold star) and each
+/// wrong guess (red dot), auto-framed around the action.
+class _ResultMapPainter extends CustomPainter {
+  _ResultMapPainter({required this.targetLngLat, required this.guesses});
+
+  final Vector2 targetLngLat;
+  final List<TriangulationGuess> guesses;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final landPaint = Paint()..color = FlitColors.landMass.withOpacity(0.45);
+    final borderPaint = Paint()
+      ..color = FlitColors.border.withOpacity(0.6)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.6;
+
+    Offset project(double lng, double lat) => Offset(
+          (lng + 180) / 360 * size.width,
+          (90 - lat) / 180 * size.height,
+        );
+
+    for (final country in CountryData.countries) {
+      for (final poly in country.polygons) {
+        if (poly.length < 3) continue;
+        final path = Path();
+        for (var i = 0; i < poly.length; i++) {
+          final pt = project(poly[i].x, poly[i].y);
+          if (i == 0) {
+            path.moveTo(pt.dx, pt.dy);
+          } else {
+            path.lineTo(pt.dx, pt.dy);
+          }
+        }
+        path.close();
+        canvas.drawPath(path, landPaint);
+        canvas.drawPath(path, borderPaint);
+      }
+    }
+
+    // Guess dots + connector lines toward the target.
+    final target = project(targetLngLat.x, targetLngLat.y);
+    for (final g in guesses) {
+      final pos = project(g.capitalLngLat.x, g.capitalLngLat.y);
+      canvas.drawLine(
+        pos,
+        target,
+        Paint()
+          ..color = FlitColors.error.withOpacity(0.5)
+          ..strokeWidth = 1,
+      );
+      canvas.drawCircle(pos, 3.5, Paint()..color = FlitColors.error);
+    }
+
+    // Target star.
+    _drawStar(canvas, target, 7, Paint()..color = FlitColors.gold);
+  }
+
+  void _drawStar(Canvas canvas, Offset center, double r, Paint paint) {
+    final path = Path();
+    for (var i = 0; i < 10; i++) {
+      final radius = i.isEven ? r : r * 0.45;
+      final angle = -math.pi / 2 + i * math.pi / 5;
+      final pt =
+          center + Offset(math.cos(angle) * radius, math.sin(angle) * radius);
+      if (i == 0) {
+        path.moveTo(pt.dx, pt.dy);
+      } else {
+        path.lineTo(pt.dx, pt.dy);
+      }
+    }
+    path.close();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_ResultMapPainter old) =>
+      targetLngLat != old.targetLngLat || guesses.length != old.guesses.length;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Final summary + share
+// ─────────────────────────────────────────────────────────────────────────
+
+class _SummaryView extends StatelessWidget {
+  const _SummaryView({
+    required this.session,
+    required this.shareText,
+    required this.isDaily,
+  });
+
+  final TriangulationSession session;
+  final String shareText;
+  final bool isDaily;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              children: [
+                const Icon(Icons.explore, color: FlitColors.gold, size: 44),
+                const SizedBox(height: 10),
+                Text(
+                  '${session.solvedRounds}/${session.rounds.length} '
+                  'TRIANGULATED',
+                  style: const TextStyle(
+                    color: FlitColors.textPrimary,
+                    fontSize: 20,
+                    fontWeight: FontWeight.w900,
+                    letterSpacing: 2,
+                  ),
+                ),
+                const SizedBox(height: 18),
+                for (var i = 0; i < session.rounds.length; i++)
+                  _roundRow(i, session.rounds[i]),
+                const SizedBox(height: 18),
+                Text(
+                  '${DailyResult.formatScore(session.totalScore)} pts',
+                  style: const TextStyle(
+                    color: FlitColors.gold,
+                    fontSize: 30,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                Text(
+                  'Time: ${DailyResult.formatTime(session.totalTimeMs)}',
+                  style: const TextStyle(
+                    color: FlitColors.textSecondary,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              if (isDaily)
+                SizedBox(
+                  width: double.infinity,
+                  height: 52,
+                  child: ElevatedButton.icon(
+                    onPressed: () {
+                      Clipboard.setData(ClipboardData(text: shareText));
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Result copied — paste to share!'),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.share),
+                    label: const Text(
+                      'SHARE RESULT',
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w900,
+                        letterSpacing: 2,
+                      ),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: FlitColors.gold,
+                      foregroundColor: FlitColors.backgroundDark,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                    ),
+                  ),
+                ),
+              if (isDaily) const SizedBox(height: 10),
+              SizedBox(
+                width: double.infinity,
+                height: 52,
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: FlitColors.cardBackground,
+                    foregroundColor: FlitColors.textPrimary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                      side: const BorderSide(color: FlitColors.cardBorder),
+                    ),
+                  ),
+                  child: const Text(
+                    'DONE',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w900,
+                      letterSpacing: 2,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _roundRow(int index, TriangulationRoundState state) {
+    final squares = StringBuffer();
+    for (final g in state.guesses.where((g) => !g.isCorrect)) {
+      squares.write(proximityEmoji(g.distanceKm));
+    }
+    squares.write(state.solved ? '✅' : '❌');
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SizedBox(
+            width: 110,
+            child: Text(
+              state.round.targetCapitalName,
+              textAlign: TextAlign.right,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: FlitColors.textSecondary,
+                fontSize: 13,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Text(squares.toString(), style: const TextStyle(fontSize: 14)),
+          const SizedBox(width: 10),
+          SizedBox(
+            width: 80,
+            child: Text(
+              '${DailyResult.formatScore(state.score)} pts',
+              style: const TextStyle(
+                color: FlitColors.textPrimary,
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/triangulation/triangulation_setup_screen.dart
+++ b/lib/features/triangulation/triangulation_setup_screen.dart
@@ -1,0 +1,458 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../../core/services/game_settings.dart';
+import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/menu_content_wrapper.dart';
+import '../../game/clues/clue_types.dart';
+import '../../game/triangulation/triangulation_session.dart';
+import '../../game/triangulation/triangulation_target.dart';
+import 'triangulation_game_screen.dart';
+
+/// Free-play setup for Triangulation: pick clue visuals, marker labels,
+/// rounds, marker count, and difficulty — then play with a random seed.
+class TriangulationSetupScreen extends StatefulWidget {
+  const TriangulationSetupScreen({super.key});
+
+  @override
+  State<TriangulationSetupScreen> createState() =>
+      _TriangulationSetupScreenState();
+}
+
+class _ClueChipMeta {
+  const _ClueChipMeta(this.type, this.name, this.icon);
+  final ClueType type;
+  final String name;
+  final IconData icon;
+}
+
+class _LabelChipMeta {
+  const _LabelChipMeta(this.label, this.name, this.icon);
+  final TriLabel label;
+  final String name;
+  final IconData icon;
+}
+
+const List<_ClueChipMeta> _clueChips = [
+  _ClueChipMeta(ClueType.flag, 'Flags', Icons.flag),
+  _ClueChipMeta(ClueType.outline, 'Outlines', Icons.crop_square),
+  _ClueChipMeta(ClueType.borders, 'Borders', Icons.border_all),
+  _ClueChipMeta(ClueType.capital, 'Capitals', Icons.location_city),
+];
+
+const List<_LabelChipMeta> _labelChips = [
+  _LabelChipMeta(TriLabel.country, 'Country name', Icons.public),
+  _LabelChipMeta(TriLabel.capital, 'Capital', Icons.location_city),
+  _LabelChipMeta(TriLabel.leader, 'World leader', Icons.person),
+  _LabelChipMeta(TriLabel.language, 'Language', Icons.translate),
+];
+
+const List<int> _roundOptions = [1, 3, 5, 10];
+const List<int> _markerOptions = [3, 4, 5, 6];
+
+class _TriangulationSetupScreenState extends State<TriangulationSetupScreen> {
+  final Set<ClueType> _clueTypes = {ClueType.flag};
+  final Set<TriLabel> _labelTypes = {TriLabel.capital};
+  int _rounds = 3;
+  int _markers = 5;
+
+  void _toggleClue(ClueType type) {
+    setState(() {
+      if (_clueTypes.contains(type)) {
+        // Keep at least one visual clue so markers aren't blank.
+        if (_clueTypes.length > 1) _clueTypes.remove(type);
+      } else {
+        _clueTypes.add(type);
+      }
+    });
+  }
+
+  void _toggleLabel(TriLabel label) {
+    setState(() {
+      // Labels can all be off — flags-with-no-labels is a legit hard mode.
+      if (!_labelTypes.remove(label)) _labelTypes.add(label);
+    });
+  }
+
+  void _start() {
+    final config = TriangulationConfig(
+      seed: Random().nextInt(1 << 31),
+      rounds: _rounds,
+      markerCount: _markers,
+      clueTypes: Set.unmodifiable(_clueTypes),
+      labelTypes: Set.unmodifiable(_labelTypes),
+      difficulty: GameSettings.instance.difficulty,
+    );
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute<void>(
+        builder: (_) => TriangulationGameScreen(config: config),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: FlitColors.backgroundDark,
+      appBar: AppBar(
+        backgroundColor: FlitColors.backgroundMid,
+        title: const Text(
+          'Triangulation',
+          style: TextStyle(color: FlitColors.textPrimary),
+        ),
+        centerTitle: true,
+        iconTheme: const IconThemeData(color: FlitColors.textPrimary),
+      ),
+      body: SafeArea(
+        child: MenuContentWrapper(
+          child: Column(
+            children: [
+              ListenableBuilder(
+                listenable: GameSettings.instance,
+                builder: (context, _) => _DifficultyBar(
+                  difficulty: GameSettings.instance.difficulty,
+                  onChanged: (d) => GameSettings.instance.difficulty = d,
+                ),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 20,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _buildHeader(),
+                      const SizedBox(height: 20),
+                      _sectionLabel('ROUNDS', Icons.repeat),
+                      const SizedBox(height: 10),
+                      _numberSelector(
+                        _roundOptions,
+                        _rounds,
+                        (v) => setState(() => _rounds = v),
+                      ),
+                      const SizedBox(height: 20),
+                      _sectionLabel('COMPASS MARKERS', Icons.explore),
+                      const SizedBox(height: 10),
+                      _numberSelector(
+                        _markerOptions,
+                        _markers,
+                        (v) => setState(() => _markers = v),
+                      ),
+                      const SizedBox(height: 20),
+                      _sectionLabel('CLUE TYPES', Icons.tune),
+                      const SizedBox(height: 10),
+                      _chipWrap([
+                        for (final meta in _clueChips)
+                          _buildChip(
+                            name: meta.name,
+                            icon: meta.icon,
+                            selected: _clueTypes.contains(meta.type),
+                            onTap: () => _toggleClue(meta.type),
+                          ),
+                      ]),
+                      const SizedBox(height: 20),
+                      _sectionLabel('MARKER LABELS', Icons.label_outline),
+                      const SizedBox(height: 10),
+                      _chipWrap([
+                        for (final meta in _labelChips)
+                          _buildChip(
+                            name: meta.name,
+                            icon: meta.icon,
+                            selected: _labelTypes.contains(meta.label),
+                            onTap: () => _toggleLabel(meta.label),
+                          ),
+                      ]),
+                      const SizedBox(height: 8),
+                      const Text(
+                        'Stack as many clue types and labels as you like — '
+                        'every marker box shows them all. No labels at all '
+                        'is the expert run.',
+                        style: TextStyle(
+                          color: FlitColors.textMuted,
+                          fontSize: 12,
+                          height: 1.4,
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                    ],
+                  ),
+                ),
+              ),
+              _buildBottomBar(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() => Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: FlitColors.cardBorder),
+        ),
+        child: Column(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: FlitColors.accent.withOpacity(0.15),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: const Icon(
+                Icons.explore,
+                color: FlitColors.accent,
+                size: 32,
+              ),
+            ),
+            const SizedBox(height: 14),
+            const Text(
+              'TRIANGULATION',
+              style: TextStyle(
+                color: FlitColors.textPrimary,
+                fontSize: 22,
+                fontWeight: FontWeight.w900,
+                letterSpacing: 3,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'A hidden capital. A compass of bearings.\n'
+              'Cross-reference the arrows and close in.',
+              style: TextStyle(
+                color: FlitColors.textSecondary,
+                fontSize: 14,
+                height: 1.4,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+
+  Widget _sectionLabel(String label, IconData icon) => Row(
+        children: [
+          Icon(icon, color: FlitColors.textMuted, size: 16),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: const TextStyle(
+              color: FlitColors.textMuted,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 1.5,
+            ),
+          ),
+        ],
+      );
+
+  Widget _numberSelector(
+    List<int> options,
+    int selected,
+    ValueChanged<int> onChanged,
+  ) =>
+      Container(
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: FlitColors.cardBorder),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: options.map((value) {
+            final isSelected = selected == value;
+            return GestureDetector(
+              onTap: () => onChanged(value),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 20,
+                  vertical: 10,
+                ),
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? FlitColors.accent.withOpacity(0.2)
+                      : Colors.transparent,
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                    color:
+                        isSelected ? FlitColors.accent : FlitColors.cardBorder,
+                    width: isSelected ? 1.5 : 1,
+                  ),
+                ),
+                child: Text(
+                  '$value',
+                  style: TextStyle(
+                    color:
+                        isSelected ? FlitColors.accent : FlitColors.textMuted,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            );
+          }).toList(),
+        ),
+      );
+
+  Widget _chipWrap(List<Widget> chips) => Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: chips,
+      );
+
+  Widget _buildChip({
+    required String name,
+    required IconData icon,
+    required bool selected,
+    required VoidCallback onTap,
+  }) =>
+      GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: selected
+                ? FlitColors.accent.withOpacity(0.2)
+                : FlitColors.cardBackground,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: selected ? FlitColors.accent : FlitColors.cardBorder,
+              width: selected ? 1.5 : 1,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                icon,
+                size: 16,
+                color: selected ? FlitColors.accent : FlitColors.textMuted,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                name,
+                style: TextStyle(
+                  color:
+                      selected ? FlitColors.accent : FlitColors.textSecondary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+  Widget _buildBottomBar() => Container(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+        decoration: const BoxDecoration(
+          color: FlitColors.backgroundMid,
+          border: Border(top: BorderSide(color: FlitColors.cardBorder)),
+        ),
+        child: SizedBox(
+          width: double.infinity,
+          height: 54,
+          child: ElevatedButton(
+            onPressed: _start,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: FlitColors.accent,
+              foregroundColor: FlitColors.textPrimary,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+              ),
+              elevation: 4,
+            ),
+            child: Text(
+              'START TRIANGULATION (×$_rounds)',
+              style: const TextStyle(
+                fontSize: 17,
+                fontWeight: FontWeight.w900,
+                letterSpacing: 2,
+              ),
+            ),
+          ),
+        ),
+      );
+}
+
+// Same difficulty bar as free_flight_setup_screen / region_select_screen.
+class _DifficultyBar extends StatelessWidget {
+  const _DifficultyBar({required this.difficulty, required this.onChanged});
+
+  final GameDifficulty difficulty;
+  final ValueChanged<GameDifficulty> onChanged;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        color: FlitColors.backgroundMid,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Row(
+          children: [
+            const Icon(Icons.tune, color: FlitColors.textSecondary, size: 18),
+            const SizedBox(width: 8),
+            const Text(
+              'Difficulty',
+              style: TextStyle(
+                color: FlitColors.textSecondary,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(width: 12),
+            ...GameDifficulty.values.map((d) {
+              final isActive = d == difficulty;
+              return Padding(
+                padding: const EdgeInsets.only(right: 6),
+                child: GestureDetector(
+                  onTap: () => onChanged(d),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 5,
+                    ),
+                    decoration: BoxDecoration(
+                      color: isActive
+                          ? _color(d).withOpacity(0.2)
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: isActive ? _color(d) : FlitColors.cardBorder,
+                        width: isActive ? 1.5 : 1,
+                      ),
+                    ),
+                    child: Text(
+                      d.displayName.toUpperCase(),
+                      style: TextStyle(
+                        color: isActive ? _color(d) : FlitColors.textMuted,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            }),
+          ],
+        ),
+      );
+
+  static Color _color(GameDifficulty d) {
+    switch (d) {
+      case GameDifficulty.easy:
+        return FlitColors.success;
+      case GameDifficulty.normal:
+        return FlitColors.accent;
+      case GameDifficulty.hard:
+        return FlitColors.gold;
+    }
+  }
+}

--- a/lib/features/triangulation/widgets/compass_painter.dart
+++ b/lib/features/triangulation/widgets/compass_painter.dart
@@ -1,0 +1,200 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/flit_colors.dart';
+
+/// Converts a compass bearing (0 = N, clockwise, degrees) to a screen-space
+/// unit vector (north = up).
+Offset bearingToDirection(double bearingDeg) {
+  final rad = bearingDeg * math.pi / 180.0;
+  return Offset(math.sin(rad), -math.cos(rad));
+}
+
+/// Paints the Triangulation compass rose: a central mystery circle,
+/// cardinal ticks, one solid arrow per starting clue, and a dashed
+/// [FlitColors.error] arrow per wrong guess.
+///
+/// Info boxes at the arrow tips are Flutter widgets layered above this
+/// painter (see TriangulationCompass); this painter draws only the rose
+/// and the arrows so hit-testing and text stay in the widget tree.
+class CompassPainter extends CustomPainter {
+  CompassPainter({
+    required this.clueBearingsDeg,
+    required this.guessBearingsDeg,
+    required this.circleRadiusFraction,
+    required this.arrowEndFraction,
+  });
+
+  /// Bearings of the starting clue markers (solid arrows).
+  final List<double> clueBearingsDeg;
+
+  /// Bearings of wrong guesses (dashed red arrows).
+  final List<double> guessBearingsDeg;
+
+  /// Central circle radius as a fraction of the shortest side.
+  final double circleRadiusFraction;
+
+  /// Arrow tip radius as a fraction of the shortest side.
+  final double arrowEndFraction;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final side = math.min(size.width, size.height);
+    final circleR = side * circleRadiusFraction;
+    final arrowEnd = side * arrowEndFraction;
+
+    _drawRose(canvas, center, circleR);
+
+    for (final bearing in clueBearingsDeg) {
+      _drawArrow(
+        canvas,
+        center,
+        bearing,
+        circleR,
+        arrowEnd,
+        color: FlitColors.textPrimary,
+        dashed: false,
+      );
+    }
+    for (final bearing in guessBearingsDeg) {
+      _drawArrow(
+        canvas,
+        center,
+        bearing,
+        circleR,
+        arrowEnd,
+        color: FlitColors.error,
+        dashed: true,
+      );
+    }
+  }
+
+  void _drawRose(Canvas canvas, Offset center, double circleR) {
+    // Paper-toned disc with a double ring for the vintage-atlas feel.
+    canvas.drawCircle(
+      center,
+      circleR,
+      Paint()..color = FlitColors.backgroundLight,
+    );
+    canvas.drawCircle(
+      center,
+      circleR,
+      Paint()
+        ..color = FlitColors.textSecondary
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2.0,
+    );
+    canvas.drawCircle(
+      center,
+      circleR - 5,
+      Paint()
+        ..color = FlitColors.textSecondary.withOpacity(0.35)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.0,
+    );
+
+    // Cardinal ticks + letters just inside the ring.
+    const cardinals = ['N', 'E', 'S', 'W'];
+    for (var i = 0; i < 4; i++) {
+      final dir = bearingToDirection(i * 90.0);
+      final tickStart = center + dir * (circleR - 4);
+      final tickEnd = center + dir * circleR;
+      canvas.drawLine(
+        tickStart,
+        tickEnd,
+        Paint()
+          ..color = FlitColors.textSecondary
+          ..strokeWidth = 2.0,
+      );
+      final tp = TextPainter(
+        text: TextSpan(
+          text: cardinals[i],
+          style: TextStyle(
+            color: FlitColors.textSecondary.withOpacity(0.7),
+            fontSize: circleR * 0.16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      final labelPos = center + dir * (circleR - 12 - circleR * 0.1);
+      tp.paint(
+        canvas,
+        labelPos - Offset(tp.width / 2, tp.height / 2),
+      );
+    }
+  }
+
+  void _drawArrow(
+    Canvas canvas,
+    Offset center,
+    double bearingDeg,
+    double fromR,
+    double toR, {
+    required Color color,
+    required bool dashed,
+  }) {
+    final dir = bearingToDirection(bearingDeg);
+    final start = center + dir * fromR;
+    final end = center + dir * toR;
+
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 2.2
+      ..strokeCap = StrokeCap.round
+      ..style = PaintingStyle.stroke;
+
+    if (dashed) {
+      _drawDashedLine(canvas, start, end, paint);
+    } else {
+      canvas.drawLine(start, end, paint);
+    }
+
+    // Arrowhead: two short strokes angled back from the tip.
+    final headLen = math.max(7.0, (toR - fromR) * 0.22);
+    const headAngle = 0.46; // radians off the shaft
+    final back = -dir;
+    final left = _rotate(back, headAngle) * headLen;
+    final right = _rotate(back, -headAngle) * headLen;
+    canvas.drawLine(end, end + left, paint);
+    canvas.drawLine(end, end + right, paint);
+  }
+
+  static Offset _rotate(Offset v, double rad) => Offset(
+        v.dx * math.cos(rad) - v.dy * math.sin(rad),
+        v.dx * math.sin(rad) + v.dy * math.cos(rad),
+      );
+
+  void _drawDashedLine(Canvas canvas, Offset start, Offset end, Paint paint) {
+    const dashLen = 6.0;
+    const gapLen = 4.0;
+    final path = Path()
+      ..moveTo(start.dx, start.dy)
+      ..lineTo(end.dx, end.dy);
+    for (final metric in path.computeMetrics()) {
+      var distance = 0.0;
+      while (distance < metric.length) {
+        final next = math.min(distance + dashLen, metric.length);
+        canvas.drawPath(metric.extractPath(distance, next), paint);
+        distance = next + gapLen;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(CompassPainter old) =>
+      !_listEquals(clueBearingsDeg, old.clueBearingsDeg) ||
+      !_listEquals(guessBearingsDeg, old.guessBearingsDeg) ||
+      circleRadiusFraction != old.circleRadiusFraction ||
+      arrowEndFraction != old.arrowEndFraction;
+
+  static bool _listEquals(List<double> a, List<double> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/lib/features/triangulation/widgets/triangulation_compass.dart
+++ b/lib/features/triangulation/widgets/triangulation_compass.dart
@@ -1,0 +1,411 @@
+import 'dart:math' as math;
+
+import 'package:flag/flag.dart';
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/flit_colors.dart';
+import '../../../core/widgets/country_outline_painter.dart';
+import '../../../game/clues/clue_types.dart';
+import '../../../game/map/country_data.dart';
+import '../../../game/triangulation/triangulation_session.dart';
+import '../../../game/triangulation/triangulation_target.dart';
+import 'compass_painter.dart';
+
+/// The Triangulation compass: mystery circle in the centre, one arrow per
+/// clue location at its true bearing from the hidden capital, and a dashed
+/// red arrow per wrong guess. Each arrow tip carries an info box holding
+/// all enabled clue visuals and labels for that location.
+///
+/// Sized by its parent; always renders square via [AspectRatio]. All
+/// placement is fractional (no absolute positioning) so it scales across
+/// phone/tablet/web.
+class TriangulationCompass extends StatelessWidget {
+  const TriangulationCompass({
+    super.key,
+    required this.clues,
+    required this.wrongGuesses,
+    required this.clueTypes,
+    required this.labelTypes,
+    this.centerLabel = 'CAPITAL',
+  });
+
+  final List<TriangulationClue> clues;
+  final List<TriangulationGuess> wrongGuesses;
+  final Set<ClueType> clueTypes;
+  final Set<TriLabel> labelTypes;
+  final String centerLabel;
+
+  static const double _circleFraction = 0.15;
+  static const double _arrowEndFraction = 0.30;
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 1,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final side = math.min(constraints.maxWidth, constraints.maxHeight);
+          final center = Offset(side / 2, side / 2);
+
+          final markers = <_MarkerLayout>[
+            for (final clue in clues)
+              _MarkerLayout(
+                bearingDeg: clue.bearingFromTargetDeg,
+                isGuess: false,
+                clue: clue,
+              ),
+            for (final guess in wrongGuesses)
+              _MarkerLayout(
+                bearingDeg: guess.bearingFromTargetDeg,
+                isGuess: true,
+                guess: guess,
+              ),
+          ];
+          _relaxAngles(markers);
+
+          final boxWidth = (side * 0.24).clamp(72.0, 116.0);
+          // Anchor boxes past the arrow tips but inside the square.
+          final boxRadius = math.min(
+            side * (_arrowEndFraction + 0.11),
+            side / 2 - boxWidth * 0.35,
+          );
+          // Neighbours still crowded after angular relaxation alternate
+          // onto an inner ring (just clear of the rose) so their boxes
+          // stack radially, not on top of each other.
+          final innerBoxRadius = side * (_circleFraction + 0.135);
+
+          return Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Positioned.fill(
+                child: CustomPaint(
+                  painter: CompassPainter(
+                    clueBearingsDeg: [
+                      for (final m in markers)
+                        if (!m.isGuess) m.bearingDeg,
+                    ],
+                    guessBearingsDeg: [
+                      for (final m in markers)
+                        if (m.isGuess) m.bearingDeg,
+                    ],
+                    circleRadiusFraction: _circleFraction,
+                    arrowEndFraction: _arrowEndFraction,
+                  ),
+                ),
+              ),
+              // Mystery label in the centre circle.
+              Positioned(
+                left: center.dx - side * _circleFraction,
+                top: center.dy - side * _circleFraction,
+                width: side * _circleFraction * 2,
+                height: side * _circleFraction * 2,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      centerLabel,
+                      style: TextStyle(
+                        color: FlitColors.textSecondary,
+                        fontSize: (side * 0.028).clamp(9.0, 13.0),
+                        letterSpacing: 2,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    Text(
+                      '?',
+                      style: TextStyle(
+                        color: FlitColors.textPrimary,
+                        fontSize: (side * 0.075).clamp(20.0, 34.0),
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              for (final marker in markers)
+                _positionedBox(
+                  marker,
+                  center,
+                  marker.ring == 0 ? boxRadius : innerBoxRadius,
+                  boxWidth,
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _positionedBox(
+    _MarkerLayout marker,
+    Offset center,
+    double radius,
+    double boxWidth,
+  ) {
+    // Boxes sit at the (possibly relaxed) display angle; the arrow itself
+    // always points at the true bearing.
+    final dir = bearingToDirection(marker.displayAngleDeg);
+    final anchor = center + dir * radius;
+    return Positioned(
+      left: anchor.dx - boxWidth / 2,
+      top: anchor.dy,
+      width: boxWidth,
+      // Centre the box on its anchor regardless of its intrinsic height.
+      child: FractionalTranslation(
+        translation: const Offset(0, -0.5),
+        child: marker.isGuess
+            ? _GuessInfoBox(guess: marker.guess!)
+            : _ClueInfoBox(
+                clue: marker.clue!,
+                clueTypes: clueTypes,
+                labelTypes: labelTypes,
+              ),
+      ),
+    );
+  }
+
+  /// Spreads markers apart so info boxes don't overlap: iteratively pushes
+  /// neighbours to a minimum angular separation. Only the box display
+  /// angles move (capped at ±10° so each box stays attached to its arrow
+  /// tip); the arrows themselves always point at the true bearing.
+  static void _relaxAngles(List<_MarkerLayout> markers) {
+    if (markers.length < 2) return;
+    // Minimum separation shrinks as the compass gets crowded.
+    final minGap = math.min(40.0, 320.0 / markers.length);
+    const maxShift = 10.0; // never move an arrow more than this off-true
+    markers.sort((a, b) => a.displayAngleDeg.compareTo(b.displayAngleDeg));
+    for (var pass = 0; pass < 6; pass++) {
+      var moved = false;
+      for (var i = 0; i < markers.length; i++) {
+        final a = markers[i];
+        final b = markers[(i + 1) % markers.length];
+        var gap = b.displayAngleDeg - a.displayAngleDeg;
+        if (i == markers.length - 1) gap += 360;
+        if (gap < minGap) {
+          final push = (minGap - gap) / 2;
+          a.displayAngleDeg =
+              _clampShift(a.bearingDeg, a.displayAngleDeg - push, maxShift);
+          b.displayAngleDeg =
+              _clampShift(b.bearingDeg, b.displayAngleDeg + push, maxShift);
+          moved = true;
+        }
+      }
+      if (!moved) break;
+    }
+    // Any pair still closer than the minimum gap after relaxation gets
+    // staggered across two rings so the boxes never fully stack.
+    for (var i = 1; i < markers.length; i++) {
+      final gap = markers[i].displayAngleDeg - markers[i - 1].displayAngleDeg;
+      if (gap < minGap * 0.9) {
+        markers[i].ring = markers[i - 1].ring == 0 ? 1 : 0;
+      }
+    }
+  }
+
+  static double _clampShift(double trueDeg, double proposed, double max) {
+    var delta = proposed - trueDeg;
+    while (delta > 180) {
+      delta -= 360;
+    }
+    while (delta < -180) {
+      delta += 360;
+    }
+    return trueDeg + delta.clamp(-max, max);
+  }
+}
+
+class _MarkerLayout {
+  _MarkerLayout({
+    required this.bearingDeg,
+    required this.isGuess,
+    this.clue,
+    this.guess,
+  }) : displayAngleDeg = bearingDeg;
+
+  final double bearingDeg;
+  final bool isGuess;
+  final TriangulationClue? clue;
+  final TriangulationGuess? guess;
+  double displayAngleDeg;
+
+  /// 0 = outer ring (default), 1 = inner ring for crowded neighbours.
+  int ring = 0;
+}
+
+/// Info box for a starting clue: stacks every enabled visual and label.
+class _ClueInfoBox extends StatelessWidget {
+  const _ClueInfoBox({
+    required this.clue,
+    required this.clueTypes,
+    required this.labelTypes,
+  });
+
+  final TriangulationClue clue;
+  final Set<ClueType> clueTypes;
+  final Set<TriLabel> labelTypes;
+
+  @override
+  Widget build(BuildContext context) {
+    final visuals = <Widget>[];
+    if (clueTypes.contains(ClueType.flag)) {
+      visuals.add(_MarkerFlag(code: clue.countryCode));
+    }
+    if (clueTypes.contains(ClueType.outline)) {
+      final polygons =
+          CountryData.getCountry(clue.countryCode)?.polygons ?? const [];
+      visuals.add(
+        SizedBox(
+          width: 40,
+          height: 30,
+          child: CustomPaint(
+            painter: CountryOutlinePainter(
+              polygons,
+              fillColor: FlitColors.landMass.withOpacity(0.5),
+              strokeColor: FlitColors.textPrimary,
+            ),
+          ),
+        ),
+      );
+    }
+
+    final lines = <String>[];
+    for (final label in TriLabel.values) {
+      if (!labelTypes.contains(label)) continue;
+      final text = clue.labelText(label);
+      if (text != null) lines.add(text);
+    }
+    // ClueType.capital shows the capital name even when the capital label
+    // isn't separately enabled.
+    if (clueTypes.contains(ClueType.capital) &&
+        !labelTypes.contains(TriLabel.capital)) {
+      lines.add(clue.capitalName);
+    }
+    if (clueTypes.contains(ClueType.borders)) {
+      final neighbors = Clue.getNeighbors(clue.countryCode);
+      if (neighbors.isNotEmpty) {
+        final shown = neighbors.take(3).join(', ');
+        lines.add(
+          neighbors.length > 3 ? 'Borders: $shown…' : 'Borders: $shown',
+        );
+      }
+    }
+
+    return _InfoBoxFrame(
+      borderColor: FlitColors.cardBorder,
+      textColor: FlitColors.textPrimary,
+      visuals: visuals,
+      lines: lines,
+    );
+  }
+}
+
+/// Info box for a wrong guess: red-tinted, flag + guessed name only (no
+/// distance — bearing plus distance would give the answer away).
+class _GuessInfoBox extends StatelessWidget {
+  const _GuessInfoBox({required this.guess});
+
+  final TriangulationGuess guess;
+
+  @override
+  Widget build(BuildContext context) {
+    return _InfoBoxFrame(
+      borderColor: FlitColors.error,
+      textColor: FlitColors.error,
+      visuals: [_MarkerFlag(code: guess.countryCode)],
+      lines: [
+        if (guess.viaCapital && guess.capitalName.isNotEmpty)
+          guess.capitalName
+        else
+          guess.countryName,
+      ],
+    );
+  }
+}
+
+class _InfoBoxFrame extends StatelessWidget {
+  const _InfoBoxFrame({
+    required this.borderColor,
+    required this.textColor,
+    required this.visuals,
+    required this.lines,
+  });
+
+  final Color borderColor;
+  final Color textColor;
+  final List<Widget> visuals;
+  final List<String> lines;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 5),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground.withOpacity(0.92),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: borderColor),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (visuals.isNotEmpty)
+            Wrap(
+              spacing: 4,
+              runSpacing: 2,
+              alignment: WrapAlignment.center,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: visuals,
+            ),
+          for (final line in lines)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                line,
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: textColor,
+                  fontSize: 10.5,
+                  fontWeight: FontWeight.w600,
+                  height: 1.15,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Small flag with the shared emoji fallback for unsupported codes.
+class _MarkerFlag extends StatelessWidget {
+  const _MarkerFlag({required this.code});
+
+  final String code;
+
+  @override
+  Widget build(BuildContext context) {
+    if (code.length == 2 && !code.startsWith('X')) {
+      try {
+        return ClipRRect(
+          borderRadius: BorderRadius.circular(3),
+          child: Flag.fromString(
+            code,
+            height: 22,
+            width: 33,
+            fit: BoxFit.contain,
+            borderRadius: 3,
+          ),
+        );
+      } catch (_) {
+        // fall through to emoji
+      }
+    }
+    final emoji = code.length == 2
+        ? String.fromCharCodes(
+            code.toUpperCase().codeUnits.map((c) => c + 127397),
+          )
+        : code;
+    return Text(emoji, style: const TextStyle(fontSize: 16));
+  }
+}

--- a/lib/game/flit_game.dart
+++ b/lib/game/flit_game.dart
@@ -1445,15 +1445,7 @@ class FlitGame extends FlameGame
     }
 
     // Compute initial bearing from plane to waymarker (great-circle).
-    final lat1 = _worldPosition.y * deg2rad;
-    final lng1 = _worldPosition.x * deg2rad;
-    final lat2 = _waymarker!.y * deg2rad;
-    final lng2 = _waymarker!.x * deg2rad;
-    final dLng = lng2 - lng1;
-
-    final y = sin(dLng) * cos(lat2);
-    final x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLng);
-    final targetBearing = atan2(y, x);
+    final targetBearing = initialBearingRad(_worldPosition, _waymarker!);
 
     final currentBearing = _heading + pi / 2;
 
@@ -1811,15 +1803,5 @@ class FlitGame extends FlameGame
   }
 
   /// Great-circle angular distance between two (lng, lat) points, in degrees.
-  double _greatCircleDistDeg(Vector2 a, Vector2 b) {
-    final lat1 = a.y * deg2rad;
-    final lat2 = b.y * deg2rad;
-    final dLat = (b.y - a.y) * deg2rad;
-    final dLng = (b.x - a.x) * deg2rad;
-
-    final h = sin(dLat / 2) * sin(dLat / 2) +
-        cos(lat1) * cos(lat2) * sin(dLng / 2) * sin(dLng / 2);
-    final c = 2 * atan2(sqrt(h), sqrt(1 - h));
-    return c * rad2deg;
-  }
+  double _greatCircleDistDeg(Vector2 a, Vector2 b) => greatCircleDistDeg(a, b);
 }

--- a/lib/game/triangulation/daily_triangulation.dart
+++ b/lib/game/triangulation/daily_triangulation.dart
@@ -1,0 +1,111 @@
+import 'dart:math';
+
+import '../../core/services/game_settings.dart';
+import '../clues/clue_types.dart';
+import 'triangulation_session.dart';
+import 'triangulation_target.dart';
+
+/// A rotating daily theme: which clue visuals and labels appear on the
+/// compass markers today.
+class DailyTriangulationTheme {
+  const DailyTriangulationTheme({
+    required this.title,
+    required this.clueTypes,
+    required this.labelTypes,
+  });
+
+  final String title;
+  final Set<ClueType> clueTypes;
+  final Set<TriLabel> labelTypes;
+}
+
+/// The daily Triangulation puzzle: same date → same seed → same theme,
+/// targets, and starting clues for every player.
+class DailyTriangulation {
+  const DailyTriangulation({
+    required this.date,
+    required this.seed,
+    required this.theme,
+  });
+
+  /// UTC date (midnight) of this puzzle.
+  final DateTime date;
+
+  /// Deterministic seed derived from the date (YYYYMMDD, same scheme as
+  /// Daily Scramble so it is proven cross-platform).
+  final int seed;
+
+  final DailyTriangulationTheme theme;
+
+  /// Fixed daily structure: 3 hidden targets, 5 guesses each.
+  static const int roundCount = 3;
+  static const int guessesPerRound = 5;
+  static const int markerCount = 5;
+
+  /// Epoch for the share-text day number (#1 = launch day).
+  static final DateTime epoch = DateTime.utc(2026, 7, 4);
+
+  /// Days since [epoch], 1-based, for "Triangulation #N" share text.
+  int get dayNumber => date.difference(epoch).inDays + 1;
+
+  String get dateKey => '${date.year.toString().padLeft(4, '0')}-'
+      '${date.month.toString().padLeft(2, '0')}-'
+      '${date.day.toString().padLeft(2, '0')}';
+
+  static const List<DailyTriangulationTheme> _themes = [
+    DailyTriangulationTheme(
+      title: 'Flags & Capitals',
+      clueTypes: {ClueType.flag},
+      labelTypes: {TriLabel.capital},
+    ),
+    DailyTriangulationTheme(
+      title: 'Silhouette Sweep',
+      clueTypes: {ClueType.outline},
+      labelTypes: {TriLabel.country},
+    ),
+    DailyTriangulationTheme(
+      title: 'Full Recon',
+      clueTypes: {ClueType.flag, ClueType.outline},
+      labelTypes: {TriLabel.country, TriLabel.capital},
+    ),
+    DailyTriangulationTheme(
+      title: "Leaders' Summit",
+      clueTypes: {ClueType.flag},
+      labelTypes: {TriLabel.leader},
+    ),
+    DailyTriangulationTheme(
+      title: 'Polyglot Patrol',
+      clueTypes: {ClueType.outline},
+      labelTypes: {TriLabel.language},
+    ),
+  ];
+
+  factory DailyTriangulation.forDate(DateTime date) {
+    final normalised = DateTime.utc(date.year, date.month, date.day);
+    final seed =
+        normalised.year * 10000 + normalised.month * 100 + normalised.day;
+    // Offset the theme RNG so today's theme rotation doesn't mirror the
+    // Daily Scramble's (both derive from the same date seed).
+    final rng = Random(seed + 31);
+    return DailyTriangulation(
+      date: normalised,
+      seed: seed,
+      theme: _themes[rng.nextInt(_themes.length)],
+    );
+  }
+
+  factory DailyTriangulation.forToday() =>
+      DailyTriangulation.forDate(DateTime.now().toUtc());
+
+  /// Build the session config for this daily puzzle.
+  TriangulationConfig toConfig() => TriangulationConfig(
+        seed: seed,
+        rounds: roundCount,
+        guessesPerRound: guessesPerRound,
+        markerCount: markerCount,
+        clueTypes: theme.clueTypes,
+        labelTypes: theme.labelTypes,
+        difficulty: GameDifficulty.normal,
+        isDaily: true,
+      );
+}

--- a/lib/game/triangulation/triangulation_scoring.dart
+++ b/lib/game/triangulation/triangulation_scoring.dart
@@ -1,0 +1,69 @@
+/// Scoring constants and helpers for the Triangulation game mode.
+///
+/// Mirrors the Daily Scramble curve (daily_result.dart): full marks within
+/// 10s, linear time decay to 60s, scaled by the country difficulty
+/// multiplier — plus a per-wrong-guess proximity penalty unique to this
+/// mode (a near-miss costs little, a wild guess costs a lot).
+library;
+
+import '../data/country_difficulty.dart';
+
+/// Base score per round.
+const int triBaseScore = 10000;
+
+/// Proximity thresholds (km) shared by scoring and the share-grid colours.
+const double triHotKm = 500;
+const double triWarmKm = 2000;
+const double triCoolKm = 5000;
+
+/// Distance at which the proximity penalty saturates.
+const double triMaxPenaltyKm = 8000;
+
+/// Flat cost of any wrong guess.
+const int triWrongGuessFloor = 200;
+
+/// Distance-scaled cost on top of the floor (at >= [triMaxPenaltyKm]).
+const int triWrongGuessDistanceMax = 2300;
+
+/// Multiplier applied when the round is solved via the country name
+/// instead of the capital.
+const double triCountryAnswerMultiplier = 0.7;
+
+/// Penalty for one wrong guess, based on how far the guessed capital is
+/// from the target capital. Direct neighbours are softened by half.
+int triProximityPenalty(double distanceKm, {bool isNeighbor = false}) {
+  final frac = (distanceKm / triMaxPenaltyKm).clamp(0.0, 1.0);
+  final penalty =
+      triWrongGuessFloor + (triWrongGuessDistanceMax * frac).round();
+  return isNeighbor ? penalty ~/ 2 : penalty;
+}
+
+/// Time penalty: 0 within 10s, linear to 5000 at 60s (same curve as
+/// DailyRoundResult.computeTimeScore).
+int triTimePenalty(int timeMs) {
+  final seconds = timeMs / 1000.0;
+  if (seconds <= 10) return 0;
+  if (seconds >= 60) return 5000;
+  return ((seconds - 10) / 50.0 * 5000).round();
+}
+
+/// Final round score.
+///
+/// Expired (unsolved) rounds score 0. Otherwise:
+///   raw   = base − timePenalty − Σ proximityPenalties
+///   score = raw × difficultyMultiplier(target) × (0.7 if solved by country)
+int computeTriangulationScore({
+  required bool solved,
+  required bool solvedAsCountry,
+  required int timeMs,
+  required List<int> wrongGuessPenalties,
+  required String targetCountryCode,
+}) {
+  if (!solved) return 0;
+  final proximityTotal = wrongGuessPenalties.fold<int>(0, (sum, p) => sum + p);
+  final raw = triBaseScore - triTimePenalty(timeMs) - proximityTotal;
+  if (raw <= 0) return 0;
+  var score = raw * difficultyMultiplier(targetCountryCode);
+  if (solvedAsCountry) score *= triCountryAnswerMultiplier;
+  return score.round().clamp(0, triBaseScore);
+}

--- a/lib/game/triangulation/triangulation_session.dart
+++ b/lib/game/triangulation/triangulation_session.dart
@@ -1,0 +1,204 @@
+import 'package:flame/components.dart';
+
+import '../../core/services/game_settings.dart';
+import '../../core/utils/math_utils.dart';
+import '../clues/clue_types.dart';
+import '../map/country_data.dart';
+import 'triangulation_scoring.dart';
+import 'triangulation_target.dart';
+
+/// Configuration for a Triangulation game (daily or free play).
+class TriangulationConfig {
+  const TriangulationConfig({
+    required this.seed,
+    this.rounds = 3,
+    this.guessesPerRound = 5,
+    this.markerCount = 5,
+    this.clueTypes = const {ClueType.flag},
+    this.labelTypes = const {TriLabel.capital},
+    this.difficulty = GameDifficulty.normal,
+    this.isDaily = false,
+  });
+
+  final int seed;
+  final int rounds;
+  final int guessesPerRound;
+  final int markerCount;
+
+  /// Visual clue types shown in each marker's info box
+  /// (flag / outline / borders / capital supported).
+  final Set<ClueType> clueTypes;
+
+  /// Label types shown in each marker's info box.
+  final Set<TriLabel> labelTypes;
+
+  final GameDifficulty difficulty;
+  final bool isDaily;
+
+  /// Whether clue anchors must have leader/language stats available.
+  bool get requiresStats =>
+      labelTypes.contains(TriLabel.leader) ||
+      labelTypes.contains(TriLabel.language);
+}
+
+/// One guess the player has made in a round.
+class TriangulationGuess {
+  const TriangulationGuess({
+    required this.countryCode,
+    required this.countryName,
+    required this.capitalName,
+    required this.capitalLngLat,
+    required this.viaCapital,
+    required this.isCorrect,
+    required this.distanceKm,
+    required this.bearingFromTargetDeg,
+    required this.penalty,
+  });
+
+  final String countryCode;
+  final String countryName;
+  final String capitalName;
+
+  /// Guessed capital coordinates as (lng, lat) degrees.
+  final Vector2 capitalLngLat;
+
+  /// True when the player typed the capital name (full points on solve);
+  /// false when they answered with the country name (reduced multiplier).
+  final bool viaCapital;
+
+  final bool isCorrect;
+
+  /// Great-circle distance from the guessed capital to the target capital.
+  final double distanceKm;
+
+  /// Bearing from the target capital to the guessed capital — this is the
+  /// red marker added to the compass for a wrong guess.
+  final double bearingFromTargetDeg;
+
+  /// Proximity penalty charged for this guess (0 when correct).
+  final int penalty;
+}
+
+/// Live state for one round.
+class TriangulationRoundState {
+  TriangulationRoundState(this.round);
+
+  final TriangulationRound round;
+  final List<TriangulationGuess> guesses = [];
+  bool solved = false;
+  bool expired = false;
+  int elapsedMs = 0;
+  int score = 0;
+
+  bool get isOver => solved || expired;
+  bool get solvedAsCountry =>
+      solved && guesses.isNotEmpty && !guesses.last.viaCapital;
+  List<TriangulationGuess> get wrongGuesses =>
+      guesses.where((g) => !g.isCorrect).toList();
+}
+
+/// A full Triangulation game: [TriangulationConfig.rounds] hidden targets,
+/// each guessable up to [TriangulationConfig.guessesPerRound] times.
+///
+/// Deterministic from the config seed: on a daily seed every player gets
+/// identical targets and starting clues; games diverge only through each
+/// player's own guesses.
+class TriangulationSession {
+  TriangulationSession(this.config) {
+    final usedTargets = <String>{};
+    for (var i = 0; i < config.rounds; i++) {
+      final round = TriangulationRound.generate(
+        seed: config.seed + i * 7919,
+        difficulty: config.difficulty,
+        markerCount: config.markerCount,
+        requireStats: config.requiresStats,
+        excludedTargetCodes: Set.unmodifiable(usedTargets),
+      );
+      usedTargets.add(round.targetCountryCode);
+      rounds.add(TriangulationRoundState(round));
+    }
+  }
+
+  final TriangulationConfig config;
+  final List<TriangulationRoundState> rounds = [];
+  int _currentIndex = 0;
+
+  TriangulationRoundState get currentRound => rounds[_currentIndex];
+  int get currentRoundNumber => _currentIndex + 1;
+  bool get isLastRound => _currentIndex >= rounds.length - 1;
+  bool get isFinished => rounds.every((r) => r.isOver);
+  int get totalScore => rounds.fold(0, (sum, r) => sum + r.score);
+  int get totalTimeMs => rounds.fold(0, (sum, r) => sum + r.elapsedMs);
+  int get solvedRounds => rounds.where((r) => r.solved).length;
+
+  int get guessesRemaining =>
+      config.guessesPerRound - currentRound.guesses.length;
+
+  /// Submit a guess for the current round. [countryCode] must be an ISO
+  /// code resolved by the input matcher; [viaCapital] records whether the
+  /// player typed the capital or the country name. [elapsedMs] is the
+  /// round timer at the moment of the guess.
+  ///
+  /// Returns the recorded guess. When wrong, its bearing becomes a new
+  /// red marker on the compass. Solves or expires the round as needed.
+  TriangulationGuess submitGuess(
+    String countryCode, {
+    required bool viaCapital,
+    required int elapsedMs,
+  }) {
+    final state = currentRound;
+    assert(!state.isOver, 'Round is already over');
+
+    final round = state.round;
+    final country = CountryData.getCountry(countryCode);
+    final capital = CountryData.getCapital(countryCode);
+    final capitalLngLat = capital?.location ?? round.targetCapitalLngLat;
+
+    final isCorrect = countryCode == round.targetCountryCode;
+    final distanceKm = isCorrect
+        ? 0.0
+        : greatCircleKm(round.targetCapitalLngLat, capitalLngLat);
+    final isNeighbor = Clue.getNeighbors(round.targetCountryCode)
+        .map((n) => n.toLowerCase())
+        .contains((country?.name ?? '').toLowerCase());
+
+    final guess = TriangulationGuess(
+      countryCode: countryCode,
+      countryName: country?.name ?? countryCode,
+      capitalName: capital?.name ?? '',
+      capitalLngLat: capitalLngLat,
+      viaCapital: viaCapital,
+      isCorrect: isCorrect,
+      distanceKm: distanceKm,
+      bearingFromTargetDeg:
+          initialBearingDeg(round.targetCapitalLngLat, capitalLngLat),
+      penalty: isCorrect
+          ? 0
+          : triProximityPenalty(distanceKm, isNeighbor: isNeighbor),
+    );
+    state.guesses.add(guess);
+    state.elapsedMs = elapsedMs;
+
+    if (isCorrect) {
+      state.solved = true;
+    } else if (state.guesses.length >= config.guessesPerRound) {
+      state.expired = true;
+    }
+    if (state.isOver) {
+      state.score = computeTriangulationScore(
+        solved: state.solved,
+        solvedAsCountry: state.solvedAsCountry,
+        timeMs: state.elapsedMs,
+        wrongGuessPenalties: state.wrongGuesses.map((g) => g.penalty).toList(),
+        targetCountryCode: round.targetCountryCode,
+      );
+    }
+    return guess;
+  }
+
+  /// Move to the next round after the current one is over.
+  void advanceRound() {
+    assert(currentRound.isOver, 'Current round is not over yet');
+    if (!isLastRound) _currentIndex++;
+  }
+}

--- a/lib/game/triangulation/triangulation_share.dart
+++ b/lib/game/triangulation/triangulation_share.dart
@@ -1,0 +1,52 @@
+import '../../data/models/daily_result.dart';
+import 'triangulation_scoring.dart';
+import 'triangulation_session.dart';
+
+/// Spoiler-free share text for a finished Triangulation game.
+///
+/// One line of squares per round — one square per guess, coloured by how
+/// close that guess was to the hidden capital — ending in the outcome.
+/// Reveals nothing about the answer, only how sharply the player homed in:
+///
+/// ```
+///      🛫 🧭 🛬
+/// Flit Triangulation #128  2/3
+/// 🟩✅
+/// 🟥🟨🟩✅
+/// 🟥🟥🟧🟨🟥❌
+/// Score: 21,480 pts
+/// Time: 1m42s
+/// ```
+String buildTriangulationShareText(
+  TriangulationSession session, {
+  required int dayNumber,
+}) {
+  final rows = session.rounds.map(_roundRow).join('\n');
+  final score = DailyResult.formatScore(session.totalScore);
+  final time = DailyResult.formatTime(session.totalTimeMs);
+  return '     \u{1F6EB} \u{1F9ED} \u{1F6EC}\n'
+      'Flit Triangulation #$dayNumber  '
+      '${session.solvedRounds}/${session.rounds.length}\n'
+      '$rows\n'
+      'Score: $score pts\n'
+      'Time: $time';
+}
+
+String _roundRow(TriangulationRoundState state) {
+  final squares = StringBuffer();
+  for (final guess in state.guesses) {
+    if (guess.isCorrect) continue; // the outcome mark covers the solve
+    squares.write(proximityEmoji(guess.distanceKm));
+  }
+  squares.write(state.solved ? '✅' : '❌');
+  return squares.toString();
+}
+
+/// Proximity square for a wrong guess — thresholds shared with scoring so
+/// share colours and penalties stay consistent.
+String proximityEmoji(double distanceKm) {
+  if (distanceKm < triHotKm) return '\u{1F7E9}'; // green: red hot
+  if (distanceKm < triWarmKm) return '\u{1F7E8}'; // yellow: warm
+  if (distanceKm < triCoolKm) return '\u{1F7E7}'; // orange: cool
+  return '\u{1F7E5}'; // red: cold
+}

--- a/lib/game/triangulation/triangulation_target.dart
+++ b/lib/game/triangulation/triangulation_target.dart
@@ -1,0 +1,200 @@
+import 'dart:math';
+
+import 'package:flame/components.dart';
+
+import '../../core/services/game_settings.dart';
+import '../../core/utils/math_utils.dart';
+import '../clues/clue_types.dart';
+import '../data/country_difficulty.dart';
+import '../map/country_data.dart';
+
+/// Label types that can accompany a clue marker on the compass.
+enum TriLabel { country, capital, leader, language }
+
+/// Display metadata for a [TriLabel].
+extension TriLabelMeta on TriLabel {
+  String get displayName {
+    switch (this) {
+      case TriLabel.country:
+        return 'Country';
+      case TriLabel.capital:
+        return 'Capital';
+      case TriLabel.leader:
+        return 'Leader';
+      case TriLabel.language:
+        return 'Language';
+    }
+  }
+}
+
+/// A known location shown on the compass, with the true bearing from the
+/// hidden target's capital to this location's capital.
+class TriangulationClue {
+  const TriangulationClue({
+    required this.countryCode,
+    required this.countryName,
+    required this.capitalName,
+    required this.capitalLngLat,
+    required this.bearingFromTargetDeg,
+    required this.distanceFromTargetKm,
+  });
+
+  final String countryCode;
+  final String countryName;
+  final String capitalName;
+
+  /// Capital coordinates as (lng, lat) degrees.
+  final Vector2 capitalLngLat;
+
+  /// Compass bearing (0 = N, clockwise) from the hidden target's capital
+  /// to this clue's capital.
+  final double bearingFromTargetDeg;
+
+  /// Great-circle distance from the hidden target's capital, in km.
+  final double distanceFromTargetKm;
+
+  /// Label text for a given label type; null when data is unavailable.
+  String? labelText(TriLabel label) {
+    switch (label) {
+      case TriLabel.country:
+        return countryName;
+      case TriLabel.capital:
+        return capitalName;
+      case TriLabel.leader:
+        final v = Clue.getAllCountryStats(countryCode)['headOfState'];
+        return (v == null || v.isEmpty) ? null : v;
+      case TriLabel.language:
+        final v = Clue.getAllCountryStats(countryCode)['language'];
+        return (v == null || v.isEmpty) ? null : v;
+    }
+  }
+}
+
+/// One hidden target plus its starting clue markers, generated
+/// deterministically from a seed.
+class TriangulationRound {
+  TriangulationRound({
+    required this.targetCountryCode,
+    required this.targetCountryName,
+    required this.targetCapitalName,
+    required this.targetCapitalLngLat,
+    required this.clues,
+  });
+
+  final String targetCountryCode;
+  final String targetCountryName;
+  final String targetCapitalName;
+
+  /// Target capital coordinates as (lng, lat) degrees.
+  final Vector2 targetCapitalLngLat;
+
+  /// Starting clue markers (same for every player on a daily seed).
+  final List<TriangulationClue> clues;
+
+  /// Countries eligible as targets or clue anchors: playable, with a
+  /// capital that has coordinates.
+  static List<CountryShape> _eligibleCountries() =>
+      CountryData.playableCountries
+          .where((c) => CountryData.getCapital(c.code) != null)
+          .toList();
+
+  /// Target pool for a difficulty, mirroring the free-flight thresholds
+  /// in game_session.dart.
+  static List<CountryShape> _targetPool(GameDifficulty difficulty) {
+    final all = _eligibleCountries();
+    switch (difficulty) {
+      case GameDifficulty.easy:
+        return all
+            .where((c) => countryDifficultyRating(c.code) <= easyThreshold)
+            .toList();
+      case GameDifficulty.normal:
+        return all
+            .where((c) => countryDifficultyRating(c.code) <= normalThreshold)
+            .toList();
+      case GameDifficulty.hard:
+        return all
+            .where((c) => countryDifficultyRating(c.code) >= hardMinimum)
+            .toList();
+    }
+  }
+
+  /// Generates a round from [seed]. Same seed → same target and clues.
+  ///
+  /// [requireStats] filters clue anchors to countries with leader/language
+  /// stats so enabled labels always have text. [excludedTargetCodes] prevents
+  /// target repeats across a multi-round game.
+  factory TriangulationRound.generate({
+    required int seed,
+    required GameDifficulty difficulty,
+    int markerCount = 5,
+    bool requireStats = false,
+    Set<String> excludedTargetCodes = const {},
+  }) {
+    final rng = Random(seed);
+
+    var targetPool = _targetPool(difficulty)
+        .where((c) => !excludedTargetCodes.contains(c.code))
+        .toList();
+    if (targetPool.isEmpty) targetPool = _eligibleCountries();
+    final target = targetPool[rng.nextInt(targetPool.length)];
+    final targetCapital = CountryData.getCapital(target.code)!;
+
+    // Clue anchors: recognisable countries (rating within the normal pool)
+    // so the reference points don't add a second identification puzzle.
+    var anchors = _eligibleCountries()
+        .where((c) =>
+            c.code != target.code &&
+            countryDifficultyRating(c.code) <= normalThreshold)
+        .toList();
+    if (requireStats) {
+      anchors = anchors
+          .where((c) =>
+              (Clue.getAllCountryStats(c.code)['headOfState'] ?? '')
+                  .isNotEmpty &&
+              (Clue.getAllCountryStats(c.code)['language'] ?? '').isNotEmpty)
+          .toList();
+    }
+    anchors.shuffle(rng);
+
+    // Greedily spread markers around the compass: prefer anchors whose
+    // bearing lands in an unused octant so arrows don't cluster.
+    final clues = <TriangulationClue>[];
+    final usedOctants = <int>{};
+    final deferred = <TriangulationClue>[];
+    for (final c in anchors) {
+      if (clues.length >= markerCount) break;
+      final capital = CountryData.getCapital(c.code)!;
+      final bearing =
+          initialBearingDeg(targetCapital.location, capital.location);
+      final clue = TriangulationClue(
+        countryCode: c.code,
+        countryName: c.name,
+        capitalName: capital.name,
+        capitalLngLat: capital.location,
+        bearingFromTargetDeg: bearing,
+        distanceFromTargetKm:
+            greatCircleKm(targetCapital.location, capital.location),
+      );
+      final octant = (bearing / 45.0).floor() % 8;
+      if (usedOctants.contains(octant)) {
+        deferred.add(clue);
+      } else {
+        usedOctants.add(octant);
+        clues.add(clue);
+      }
+    }
+    // Fill any remaining slots from the deferred (clustered) candidates.
+    for (final clue in deferred) {
+      if (clues.length >= markerCount) break;
+      clues.add(clue);
+    }
+
+    return TriangulationRound(
+      targetCountryCode: target.code,
+      targetCountryName: target.name,
+      targetCapitalName: targetCapital.name,
+      targetCapitalLngLat: targetCapital.location,
+      clues: clues,
+    );
+  }
+}

--- a/lib/game/tutorial/mode_requirements.dart
+++ b/lib/game/tutorial/mode_requirements.dart
@@ -49,6 +49,13 @@ const List<ModeRequirement> modeRequirements = [
   ModeRequirement(modeId: 'training_sortie', displayName: 'Training Sortie'),
   ModeRequirement(modeId: 'uncharted', displayName: 'Uncharted'),
   ModeRequirement(modeId: 'flight_school', displayName: 'Flight School'),
+  ModeRequirement(modeId: 'triangulation', displayName: 'Triangulation'),
+  ModeRequirement(
+    modeId: 'daily_triangulation',
+    displayName: 'Daily Triangulation',
+    requiredLevel: 3,
+    requiredMissionId: 'hint_strategy',
+  ),
   ModeRequirement(
     modeId: 'daily_briefing',
     displayName: 'Daily Briefing',

--- a/test/unit/game/triangulation/triangulation_test.dart
+++ b/test/unit/game/triangulation/triangulation_test.dart
@@ -1,0 +1,278 @@
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flit/core/services/game_settings.dart';
+import 'package:flit/core/utils/math_utils.dart';
+import 'package:flit/game/map/country_data.dart';
+import 'package:flit/game/triangulation/daily_triangulation.dart';
+import 'package:flit/game/triangulation/triangulation_scoring.dart';
+import 'package:flit/game/triangulation/triangulation_session.dart';
+import 'package:flit/game/triangulation/triangulation_share.dart';
+import 'package:flit/game/triangulation/triangulation_target.dart';
+
+void main() {
+  group('bearing and distance helpers', () {
+    test('due north bearing is 0', () {
+      expect(
+        initialBearingDeg(Vector2(0, 0), Vector2(0, 10)),
+        closeTo(0, 0.01),
+      );
+    });
+
+    test('due east bearing is 90', () {
+      expect(
+        initialBearingDeg(Vector2(0, 0), Vector2(10, 0)),
+        closeTo(90, 0.01),
+      );
+    });
+
+    test('due south bearing is 180, due west 270', () {
+      expect(
+        initialBearingDeg(Vector2(0, 10), Vector2(0, 0)),
+        closeTo(180, 0.01),
+      );
+      expect(
+        initialBearingDeg(Vector2(10, 0), Vector2(0, 0)),
+        closeTo(270, 0.01),
+      );
+    });
+
+    test('Islamabad→Bishkek points roughly north (screenshot geometry)', () {
+      final islamabad = Vector2(73.04, 33.68);
+      final bishkek = Vector2(74.59, 42.87);
+      final bearing = initialBearingDeg(islamabad, bishkek);
+      expect(bearing, greaterThan(0));
+      expect(bearing, lessThan(20));
+    });
+
+    test('Islamabad→Tianjin points east-northeast', () {
+      final islamabad = Vector2(73.04, 33.68);
+      final tianjin = Vector2(117.20, 39.13);
+      final bearing = initialBearingDeg(islamabad, tianjin);
+      expect(bearing, greaterThan(50));
+      expect(bearing, lessThan(80));
+    });
+
+    test('London→Paris distance is about 343 km', () {
+      final london = Vector2(-0.1276, 51.5074);
+      final paris = Vector2(2.3522, 48.8566);
+      expect(greatCircleKm(london, paris), closeTo(343, 15));
+    });
+  });
+
+  group('daily determinism', () {
+    test('same date yields identical seed and theme', () {
+      final a = DailyTriangulation.forDate(DateTime.utc(2026, 7, 4));
+      final b = DailyTriangulation.forDate(DateTime.utc(2026, 7, 4));
+      expect(a.seed, b.seed);
+      expect(a.seed, 20260704);
+      expect(a.theme.title, b.theme.title);
+    });
+
+    test('same seed yields identical targets, clues, and bearings', () {
+      final daily = DailyTriangulation.forDate(DateTime.utc(2026, 7, 4));
+      final s1 = TriangulationSession(daily.toConfig());
+      final s2 = TriangulationSession(daily.toConfig());
+      expect(s1.rounds.length, DailyTriangulation.roundCount);
+      for (var i = 0; i < s1.rounds.length; i++) {
+        final r1 = s1.rounds[i].round;
+        final r2 = s2.rounds[i].round;
+        expect(r1.targetCountryCode, r2.targetCountryCode);
+        expect(
+          r1.clues.map((c) => c.countryCode).toList(),
+          r2.clues.map((c) => c.countryCode).toList(),
+        );
+        expect(
+          r1.clues.map((c) => c.bearingFromTargetDeg).toList(),
+          r2.clues.map((c) => c.bearingFromTargetDeg).toList(),
+        );
+      }
+    });
+
+    test('rounds have distinct targets', () {
+      final daily = DailyTriangulation.forDate(DateTime.utc(2026, 7, 4));
+      final session = TriangulationSession(daily.toConfig());
+      final targets =
+          session.rounds.map((r) => r.round.targetCountryCode).toSet();
+      expect(targets.length, session.rounds.length);
+    });
+
+    test('day number counts from launch epoch', () {
+      final launch = DailyTriangulation.forDate(DateTime.utc(2026, 7, 4));
+      expect(launch.dayNumber, 1);
+      final later = DailyTriangulation.forDate(DateTime.utc(2026, 7, 14));
+      expect(later.dayNumber, 11);
+    });
+  });
+
+  group('round generation', () {
+    test('clue markers exclude the target and have valid bearings', () {
+      final round = TriangulationRound.generate(
+        seed: 42,
+        difficulty: GameDifficulty.normal,
+      );
+      expect(round.clues.length, 5);
+      for (final clue in round.clues) {
+        expect(clue.countryCode, isNot(round.targetCountryCode));
+        expect(clue.bearingFromTargetDeg, inInclusiveRange(0, 360));
+        expect(clue.distanceFromTargetKm, greaterThan(0));
+      }
+      expect(
+        round.clues.map((c) => c.countryCode).toSet().length,
+        round.clues.length,
+      );
+    });
+
+    test('leader/language labels only pick anchors with stats', () {
+      final round = TriangulationRound.generate(
+        seed: 7,
+        difficulty: GameDifficulty.normal,
+        requireStats: true,
+      );
+      for (final clue in round.clues) {
+        expect(clue.labelText(TriLabel.leader), isNotNull);
+        expect(clue.labelText(TriLabel.language), isNotNull);
+      }
+    });
+  });
+
+  group('scoring', () {
+    test('perfect solve scores base times difficulty multiplier', () {
+      final score = computeTriangulationScore(
+        solved: true,
+        solvedAsCountry: false,
+        timeMs: 5000,
+        wrongGuessPenalties: const [],
+        targetCountryCode: 'FR',
+      );
+      expect(score, greaterThan(0));
+      expect(score, lessThanOrEqualTo(triBaseScore));
+    });
+
+    test('time decay matches the daily scramble curve', () {
+      expect(triTimePenalty(5000), 0);
+      expect(triTimePenalty(10000), 0);
+      expect(triTimePenalty(35000), 2500);
+      expect(triTimePenalty(60000), 5000);
+      expect(triTimePenalty(120000), 5000);
+    });
+
+    test('proximity penalty orders neighbour < mid < far', () {
+      // Luxembourg target: France ~290 km (neighbour), Portugal ~1700 km,
+      // Brazil ~9200 km.
+      final france = triProximityPenalty(290, isNeighbor: true);
+      final portugal = triProximityPenalty(1700);
+      final brazil = triProximityPenalty(9200);
+      expect(france, lessThan(portugal));
+      expect(portugal, lessThan(brazil));
+      expect(brazil, triWrongGuessFloor + triWrongGuessDistanceMax);
+    });
+
+    test('country-name solve scores 0.7x of capital solve', () {
+      final viaCapital = computeTriangulationScore(
+        solved: true,
+        solvedAsCountry: false,
+        timeMs: 5000,
+        wrongGuessPenalties: const [],
+        targetCountryCode: 'FR',
+      );
+      final viaCountry = computeTriangulationScore(
+        solved: true,
+        solvedAsCountry: true,
+        timeMs: 5000,
+        wrongGuessPenalties: const [],
+        targetCountryCode: 'FR',
+      );
+      expect(viaCountry, (viaCapital * 0.7).round());
+    });
+
+    test('expired round scores 0', () {
+      final score = computeTriangulationScore(
+        solved: false,
+        solvedAsCountry: false,
+        timeMs: 5000,
+        wrongGuessPenalties: const [500, 500, 500, 500, 500],
+        targetCountryCode: 'FR',
+      );
+      expect(score, 0);
+    });
+  });
+
+  group('session flow', () {
+    TriangulationSession makeSession() => TriangulationSession(
+          const TriangulationConfig(seed: 99, rounds: 1),
+        );
+
+    String wrongCode(TriangulationSession session, Set<String> used) {
+      final target = session.currentRound.round.targetCountryCode;
+      return CountryData.playableCountries
+          .firstWhere(
+            (c) =>
+                c.code != target &&
+                !used.contains(c.code) &&
+                CountryData.getCapital(c.code) != null,
+          )
+          .code;
+    }
+
+    test('correct guess solves the round and scores', () {
+      final session = makeSession();
+      final guess = session.submitGuess(
+        session.currentRound.round.targetCountryCode,
+        viaCapital: true,
+        elapsedMs: 4000,
+      );
+      expect(guess.isCorrect, isTrue);
+      expect(session.currentRound.solved, isTrue);
+      expect(session.currentRound.score, greaterThan(0));
+      expect(session.isFinished, isTrue);
+    });
+
+    test('wrong guesses add compass markers and expire after 5', () {
+      final session = makeSession();
+      final used = <String>{};
+      for (var i = 0; i < 5; i++) {
+        final code = wrongCode(session, used);
+        used.add(code);
+        final guess = session.submitGuess(
+          code,
+          viaCapital: false,
+          elapsedMs: 3000 * (i + 1),
+        );
+        expect(guess.isCorrect, isFalse);
+        expect(guess.penalty, greaterThan(0));
+        expect(guess.bearingFromTargetDeg, inInclusiveRange(0, 360));
+      }
+      expect(session.currentRound.expired, isTrue);
+      expect(session.currentRound.wrongGuesses.length, 5);
+      expect(session.currentRound.score, 0);
+    });
+  });
+
+  group('share text', () {
+    test('proximity emoji thresholds match scoring constants', () {
+      expect(proximityEmoji(triHotKm - 1), '\u{1F7E9}');
+      expect(proximityEmoji(triWarmKm - 1), '\u{1F7E8}');
+      expect(proximityEmoji(triCoolKm - 1), '\u{1F7E7}');
+      expect(proximityEmoji(triCoolKm + 1), '\u{1F7E5}');
+    });
+
+    test('share text is spoiler-free and shows outcome per round', () {
+      final session = TriangulationSession(
+        const TriangulationConfig(seed: 99, rounds: 1),
+      );
+      final round = session.currentRound.round;
+      session.submitGuess(
+        round.targetCountryCode,
+        viaCapital: true,
+        elapsedMs: 4000,
+      );
+      final text = buildTriangulationShareText(session, dayNumber: 12);
+      expect(text, contains('Flit Triangulation #12'));
+      expect(text, contains('1/1'));
+      expect(text, contains('✅'));
+      expect(text, isNot(contains(round.targetCapitalName)));
+      expect(text, isNot(contains(round.targetCountryName)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

New **Triangulation** game mode (the "city angle"-style bearings game) plus a **MISSION BOARD** bracket at the top of the play menu that gathers all daily challenges in one place.

### Mission Board (menu restructure)
- New `MISSION BOARD` section above FLIGHT DECK / BRIEFING ROOM in the mode sheet
- All three dailies live there: **Daily Triangulation** (new), **Daily Scramble**, **Daily Briefing** (moved out of their old sections, red-highlight treatment preserved)
- Free-play **Triangulation** joins the Briefing Room next to Flight School / Uncharted
- Modes registered in `mode_requirements.dart` (`daily_triangulation` gated at level 3 / `hint_strategy`, matching Daily Briefing)

### The game
- A hidden capital is revealed only through compass arrows pointing at the **true great-circle bearing** from it to known clue locations; the player triangulates the answer
- Wrong guesses join the compass as **red dashed bearings**, so every game becomes unique
- Each marker's arrow tip carries an info box stacking **all enabled clue visuals** (flag / outline / borders / capital) **and labels** (country / capital / world leader / language), with angular relaxation + ring staggering so boxes don't overlap
- Guess input is typo-tolerant (reuses `FuzzyMatcher` + country aliases) and accepts **capital (full points) or country (×0.7)**

### Daily variant
- Date-seeded (`YYYYMMDD`, same proven scheme as Daily Scramble; per-round stride `7919`) — everyone gets identical targets and clues
- 3 rounds × 5 guesses, rotating clue/label theme, one play per day (local persistence)
- **Spoiler-free share grid**: one square per guess coloured by proximity (🟩<500 km · 🟨<2000 · 🟧<5000 · 🟥 beyond), ✅/❌ outcome per round, day number + score — copied to clipboard like the Daily Scramble share

### Scoring
- Mirrors Daily Scramble: 10,000 base, full marks ≤10 s, linear decay to 60 s, × country difficulty multiplier
- Plus per-wrong-guess **proximity penalty** (neighbour softened ×0.5): for a Luxembourg target, France deducts less than Portugal, which deducts far less than Brazil
- Round result reveals the answer + all guesses on a world map with distances

### Shared-layer reuse (per CLAUDE.md)
- `initialBearingRad/Deg`, `greatCircleDistDeg/Km` added to `math_utils.dart`; `flit_game.dart` refactored to use them (removed duplicated private impls)
- Country silhouette painter extracted to shared `CountryOutlinePainter`; Explore's clue browser now delegates to it

## Testing
- 21 new unit tests: bearing/haversine vs known geometry (incl. the Islamabad→Bishkek/Tianjin screenshot layout), daily-seed determinism, distinct round targets, time-decay curve parity, proximity-penalty ordering, ×0.7 country answers, 5-guess expiry, spoiler-free share text
- Full suite: **833/833 passing**; `flutter analyze` 0 errors; compass visually verified via golden render (arrows at true bearings, boxes non-overlapping, wrong-guess markers legible)

## Follow-ups (not in this PR)
- Supabase leaderboard table + coin/economy reward for the daily (needs a schema decision like `daily_briefing_scores`)
- Feature-flag gate (`daily_triangulation_enabled`) if staged rollout is wanted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_