### PR TITLE
feat(triangulation): frameless compass markers when no labels selected

### DIFF
--- a/lib/features/triangulation/widgets/compass_painter.dart
+++ b/lib/features/triangulation/widgets/compass_painter.dart
@@ -115,6 +115,9 @@ class CompassPainter extends CustomPainter {
             color: FlitColors.textSecondary.withOpacity(0.7),
             fontSize: circleR * 0.16,
             fontWeight: FontWeight.w600,
+            // Roboto ships with MaterialApp on every platform; naming it
+            // keeps TextPainter output consistent (and real in goldens).
+            fontFamily: 'Roboto',
           ),
         ),
         textDirection: TextDirection.ltr,

--- a/lib/features/triangulation/widgets/triangulation_compass.dart
+++ b/lib/features/triangulation/widgets/triangulation_compass.dart
@@ -143,19 +143,28 @@ class TriangulationCompass extends StatelessWidget {
               ),
               for (var i = 0; i < markers.length; i++)
                 Positioned(
-                  left: positions[i].dx - boxWidth / 2,
+                  left: positions[i].dx - sizes[i].width / 2,
                   top: positions[i].dy - sizes[i].height / 2,
-                  width: boxWidth,
-                  child: _InfoBoxFrame(
-                    borderColor: markers[i].isGuess
-                        ? FlitColors.error
-                        : FlitColors.cardBorder,
-                    textColor: markers[i].isGuess
-                        ? FlitColors.error
-                        : FlitColors.textPrimary,
-                    visuals: markers[i].visuals,
-                    lines: markers[i].lines,
-                  ),
+                  width: sizes[i].width,
+                  // No text to hold → no card: just the bare visual(s) at
+                  // the arrow tip (e.g. flags-only expert mode).
+                  child: markers[i].lines.isEmpty
+                      ? Wrap(
+                          spacing: 4,
+                          alignment: WrapAlignment.center,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: markers[i].visuals,
+                        )
+                      : _InfoBoxFrame(
+                          borderColor: markers[i].isGuess
+                              ? FlitColors.error
+                              : FlitColors.cardBorder,
+                          textColor: markers[i].isGuess
+                              ? FlitColors.error
+                              : FlitColors.textPrimary,
+                          visuals: markers[i].visuals,
+                          lines: markers[i].lines,
+                        ),
                 ),
             ],
           );
@@ -245,6 +254,15 @@ class TriangulationCompass extends StatelessWidget {
   /// paddings and text metrics. Kept deliberately slightly generous so the
   /// collision layout leaves breathing room.
   Size _estimateBoxSize(_MarkerContent marker, double boxWidth) {
+    // Markers with no text render frameless (bare visuals), so their size
+    // is just the visuals' footprint — the collision layout then packs
+    // them much tighter.
+    if (marker.lines.isEmpty) {
+      var width = 0.0;
+      if (marker.hasFlag) width += 33;
+      if (marker.hasOutline) width += 40 + (marker.hasFlag ? 4 : 0);
+      return Size(math.max(width, 24), marker.hasOutline ? 30 : 22);
+    }
     final innerWidth = boxWidth - 12; // horizontal padding
     var height = 10.0; // vertical padding
     if (marker.visuals.isNotEmpty) {


### PR DESCRIPTION
## Summary

Follow-up to #433/#434 addressing marker busyness:

- **Markers with no text render bare** — when the info box would contain no labels (flags-only, outlines-only, or flag+outline modes), the card chrome is dropped entirely and just the visual(s) sit at the arrow tip. Flag + outline sit side by side.
- The collision layout uses the much tighter frameless footprint, so label-free compasses pack close to the arrows and read far cleaner.
- Wrong guesses always carry the guessed name, so they keep their red card — the red frame stays the "this was wrong" signal.
- Painter's cardinal letters (N/E/S/W) explicitly use Roboto (bundled by MaterialApp on all platforms) for consistent rendering.

Note on earlier screenshots: the "blocked-out boxes" were the Flutter golden-test placeholder font (every glyph renders as a filled square), not game rendering — the goldens now load real Roboto so renders show actual text. Nothing was ever drawn for unselected clue types; boxes only contain what's enabled.

## Testing
- Two goldens regenerated and visually verified with real fonts: full-box worst case (5 clues + 4 guesses, zero overlaps) and the new frameless flags+outlines mode
- All 21 triangulation unit tests pass; full suite green via pre-commit hook; `flutter analyze` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_