### PR TITLE
feat(triangulation): rhumb bearings, target-type rotation, daily brief

### DIFF
--- a/lib/core/utils/math_utils.dart
+++ b/lib/core/utils/math_utils.dart
@@ -52,3 +52,22 @@ double initialBearingDeg(Vector2 from, Vector2 to) {
   final deg = initialBearingRad(from, to) * rad2deg;
   return (deg % 360 + 360) % 360;
 }
+
+/// Rhumb-line (loxodrome) bearing from [from] to [to], in compass degrees
+/// normalised to [0, 360).
+///
+/// This is the constant heading you'd follow on a Mercator map — the
+/// direction players intuitively expect (a great-circle initial bearing to
+/// a far-away point can cross near a pole, e.g. Colombo→Mexico City reads
+/// "north", which is technically right but violates map sense).
+double rhumbBearingDeg(Vector2 from, Vector2 to) {
+  final lat1 = from.y * deg2rad;
+  final lat2 = to.y * deg2rad;
+  var dLng = (to.x - from.x) * deg2rad;
+  // Take the shorter way around the antimeridian.
+  if (dLng.abs() > pi) dLng -= dLng.sign * 2 * pi;
+
+  final dPsi = log(tan(pi / 4 + lat2 / 2) / tan(pi / 4 + lat1 / 2));
+  final deg = atan2(dLng, dPsi) * rad2deg;
+  return (deg % 360 + 360) % 360;
+}

--- a/lib/features/triangulation/daily_triangulation_screen.dart
+++ b/lib/features/triangulation/daily_triangulation_screen.dart
@@ -5,7 +5,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/daily_result.dart';
+import '../../game/clues/clue_types.dart';
+import '../../game/data/country_difficulty.dart';
 import '../../game/triangulation/daily_triangulation.dart';
+import '../../game/triangulation/triangulation_target.dart';
 import 'triangulation_game_screen.dart';
 
 /// Lobby for the Daily Triangulation: shows today's theme and rules, and
@@ -82,6 +85,8 @@ class _DailyTriangulationScreenState extends State<DailyTriangulationScreen> {
                     children: [
                       _buildHeader(),
                       const SizedBox(height: 16),
+                      _buildBrief(),
+                      const SizedBox(height: 16),
                       _buildRules(),
                       const SizedBox(height: 24),
                       if (played) _buildResult() else _buildPlayButton(),
@@ -145,13 +150,27 @@ class _DailyTriangulationScreenState extends State<DailyTriangulationScreen> {
                 ),
               ),
             ),
-            const SizedBox(height: 10),
-            const Text(
-              'Same puzzle for every pilot.\n'
-              'Your guesses make it yours.',
-              style: TextStyle(
+            const SizedBox(height: 8),
+            Text(
+              _daily.theme.description,
+              style: const TextStyle(
                 color: FlitColors.textSecondary,
                 fontSize: 13,
+                height: 1.4,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 10),
+            _DifficultyIndicator(
+              percent: _daily.difficultyPercent,
+              label: _daily.difficultyLabelText,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Same puzzle for every pilot. Your guesses make it yours.',
+              style: TextStyle(
+                color: FlitColors.textMuted,
+                fontSize: 12,
                 height: 1.4,
               ),
               textAlign: TextAlign.center,
@@ -160,40 +179,178 @@ class _DailyTriangulationScreenState extends State<DailyTriangulationScreen> {
         ),
       );
 
-  Widget _buildRules() => Container(
-        width: double.infinity,
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: FlitColors.cardBackground,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: FlitColors.cardBorder),
-        ),
-        child: const Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _RuleRow(
-              icon: Icons.explore,
-              text: 'Each arrow points from the hidden capital toward a '
-                  'known place — cross-reference them to close in.',
+  /// Scramble-style brief: what you're hunting and exactly which clue
+  /// visuals/labels today's markers carry.
+  Widget _buildBrief() {
+    final theme = _daily.theme;
+    final isCapital = theme.targetType == TriTargetType.capital;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FlitColors.cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'TARGET',
+            style: TextStyle(
+              color: FlitColors.textMuted,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 1.2,
             ),
-            _RuleRow(
-              icon: Icons.replay,
-              text: '3 hidden capitals, 5 guesses each. Wrong guesses join '
-                  'the compass in red.',
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              _BriefChip(
+                icon: isCapital ? Icons.location_city_rounded : Icons.public,
+                label: theme.targetType.displayName,
+                color: FlitColors.error,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  isCapital
+                      ? 'Capital = full pts, country = ×0.7'
+                      : 'Answer with the country name',
+                  style: const TextStyle(
+                    color: FlitColors.textMuted,
+                    fontSize: 11.5,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          const Text(
+            'ACTIVE CLUES',
+            style: TextStyle(
+              color: FlitColors.textMuted,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 1.2,
             ),
-            _RuleRow(
-              icon: Icons.timer_outlined,
-              text: 'Full marks inside 10 seconds, decaying to 60s. Wild '
-                  'guesses cost more than near misses.',
-            ),
-            _RuleRow(
-              icon: Icons.star_outline,
-              text: 'Name the capital for full points — the country alone '
-                  'scores ×0.7.',
-            ),
-          ],
-        ),
-      );
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final type in theme.clueTypes)
+                _BriefChip(
+                  icon: _clueIcon(type),
+                  label: _clueLabel(type),
+                  color: FlitColors.accent,
+                ),
+              if (theme.labelTypes.isEmpty)
+                const _BriefChip(
+                  icon: Icons.visibility_off_rounded,
+                  label: 'No labels — expert!',
+                  color: FlitColors.warning,
+                )
+              else
+                for (final label in theme.labelTypes)
+                  _BriefChip(
+                    icon: _labelIcon(label),
+                    label: '${label.displayName} label',
+                    color: FlitColors.gold,
+                  ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  static IconData _clueIcon(ClueType type) {
+    switch (type) {
+      case ClueType.flag:
+        return Icons.flag_rounded;
+      case ClueType.outline:
+        return Icons.crop_square_rounded;
+      case ClueType.borders:
+        return Icons.border_all_rounded;
+      case ClueType.capital:
+        return Icons.location_city_rounded;
+      default:
+        return Icons.help_outline_rounded;
+    }
+  }
+
+  static String _clueLabel(ClueType type) {
+    switch (type) {
+      case ClueType.flag:
+        return 'Flags';
+      case ClueType.outline:
+        return 'Outlines';
+      case ClueType.borders:
+        return 'Borders';
+      case ClueType.capital:
+        return 'Capitals';
+      default:
+        return type.name;
+    }
+  }
+
+  static IconData _labelIcon(TriLabel label) {
+    switch (label) {
+      case TriLabel.country:
+        return Icons.public;
+      case TriLabel.capital:
+        return Icons.location_city_rounded;
+      case TriLabel.leader:
+        return Icons.person_rounded;
+      case TriLabel.language:
+        return Icons.translate_rounded;
+    }
+  }
+
+  Widget _buildRules() {
+    final isCapital = _daily.theme.targetType == TriTargetType.capital;
+    final what = isCapital ? 'capitals' : 'countries';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FlitColors.cardBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const _RuleRow(
+            icon: Icons.explore,
+            text: 'Each arrow points from the hidden target toward a '
+                'known place — cross-reference them to close in.',
+          ),
+          _RuleRow(
+            icon: Icons.replay,
+            text: '3 hidden $what, 5 guesses each. Wrong guesses join '
+                'the compass in red.',
+          ),
+          const _RuleRow(
+            icon: Icons.timer_outlined,
+            text: 'Full marks inside 10 seconds, decaying to 60s. Wild '
+                'guesses cost more than near misses.',
+          ),
+          _RuleRow(
+            icon: Icons.star_outline,
+            text: isCapital
+                ? 'Name the capital for full points — the country alone '
+                    'scores ×0.7.'
+                : 'Only country names count today — capitals are not '
+                    'accepted.',
+          ),
+        ],
+      ),
+    );
+  }
 
   Widget _buildPlayButton() => SizedBox(
         width: double.infinity,
@@ -300,6 +457,94 @@ class _DailyTriangulationScreenState extends State<DailyTriangulationScreen> {
           ],
         ),
       );
+}
+
+/// Small icon+label pill used in the daily brief (same visual language as
+/// the Daily Scramble's clue chips).
+class _BriefChip extends StatelessWidget {
+  const _BriefChip({
+    required this.icon,
+    required this.label,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: color.withOpacity(0.12),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: color.withOpacity(0.35)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: color, size: 14),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: TextStyle(
+                color: color,
+                fontSize: 11.5,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      );
+}
+
+/// Difficulty pill matching the Daily Scramble's (label + percent on the
+/// shared green→red band scale).
+class _DifficultyIndicator extends StatelessWidget {
+  const _DifficultyIndicator({required this.percent, required this.label});
+
+  final int percent;
+  final String label;
+
+  static const List<Color> _gradientColors = [
+    Color(0xFF4CAF50), // green — Clear Skies
+    Color(0xFF8BC34A), // light green — Tailwind
+    Color(0xFFFFEB3B), // yellow — Fair Weather
+    Color(0xFFFFC107), // amber — Crosswinds
+    Color(0xFFFF9800), // orange — Turbulence
+    Color(0xFFFF5722), // deep orange — Storm Front
+    Color(0xFFF44336), // red — Cat-5 Headwind
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final index = difficultyBandIndex(percent / 100.0);
+    final color = _gradientColors[index.clamp(0, _gradientColors.length - 1)];
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.15),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withOpacity(0.3)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.speed_rounded, color: color, size: 14),
+          const SizedBox(width: 6),
+          Text(
+            '$label  $percent%',
+            style: TextStyle(
+              color: color,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 class _RuleRow extends StatelessWidget {

--- a/lib/features/triangulation/triangulation_game_screen.dart
+++ b/lib/features/triangulation/triangulation_game_screen.dart
@@ -15,6 +15,7 @@ import '../../game/quiz/fuzzy_match.dart';
 import '../../game/triangulation/daily_triangulation.dart';
 import '../../game/triangulation/triangulation_session.dart';
 import '../../game/triangulation/triangulation_share.dart';
+import '../../game/triangulation/triangulation_target.dart';
 import 'widgets/triangulation_compass.dart';
 
 /// The Triangulation gameplay screen: compass + guess input, round results
@@ -53,8 +54,11 @@ class _GuessCandidate {
 class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
   late final TriangulationSession _session;
   late final FuzzyMatcher _countryMatcher;
-  late final FuzzyMatcher _capitalMatcher;
+  FuzzyMatcher? _capitalMatcher;
   late final List<_GuessCandidate> _candidates;
+
+  bool get _isCapitalTarget =>
+      widget.config.targetType == TriTargetType.capital;
 
   final Stopwatch _stopwatch = Stopwatch();
   Timer? _ticker;
@@ -74,17 +78,22 @@ class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
         .where((c) => CountryData.getCapital(c.code) != null)
         .toList();
     _countryMatcher = FuzzyMatcher({for (final c in eligible) c.code: c.name});
-    _capitalMatcher = FuzzyMatcher({
-      for (final c in eligible) c.code: CountryData.getCapital(c.code)!.name,
-    });
+    // On country-target days capitals are not answer candidates at all —
+    // only country names count.
+    if (_isCapitalTarget) {
+      _capitalMatcher = FuzzyMatcher({
+        for (final c in eligible) c.code: CountryData.getCapital(c.code)!.name,
+      });
+    }
     _candidates = [
       for (final c in eligible) ...[
         _GuessCandidate(code: c.code, display: c.name, viaCapital: false),
-        _GuessCandidate(
-          code: c.code,
-          display: CountryData.getCapital(c.code)!.name,
-          viaCapital: true,
-        ),
+        if (_isCapitalTarget)
+          _GuessCandidate(
+            code: c.code,
+            display: CountryData.getCapital(c.code)!.name,
+            viaCapital: true,
+          ),
       ],
     ];
 
@@ -127,9 +136,10 @@ class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
   void _submitTyped(String input) {
     if (input.trim().isEmpty) return;
     // Prefer capital matches (full points), then country names; both
-    // matchers are typo-tolerant with alias support.
+    // matchers are typo-tolerant with alias support. On country-target
+    // days there is no capital matcher — only country names resolve.
     final capitalMatch =
-        _capitalMatcher.bestMatch(input, excludeCodes: _guessedCodes);
+        _capitalMatcher?.bestMatch(input, excludeCodes: _guessedCodes);
     final countryMatch =
         _countryMatcher.bestMatch(input, excludeCodes: _guessedCodes);
     _GuessCandidate? chosen;
@@ -149,7 +159,11 @@ class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
       );
     }
     if (chosen == null) {
-      setState(() => _feedback = 'No country or capital matches "$input"');
+      setState(
+        () => _feedback = _isCapitalTarget
+            ? 'No country or capital matches "$input"'
+            : 'No country matches "$input"',
+      );
       return;
     }
     _submitCandidate(chosen);
@@ -220,11 +234,13 @@ class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
         session: _session,
         shareText: _shareText,
         isDaily: widget.daily != null,
+        isCapitalTarget: _isCapitalTarget,
       );
     } else if (_showingRoundResult) {
       body = _RoundResultView(
         state: _session.currentRound,
         isLastRound: _session.isLastRound,
+        isCapitalTarget: _isCapitalTarget,
         onContinue: _continueFromResult,
       );
     } else {
@@ -270,10 +286,13 @@ class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
                   wrongGuesses: state.wrongGuesses,
                   clueTypes: widget.config.clueTypes,
                   labelTypes: widget.config.labelTypes,
+                  centerLabel: _isCapitalTarget ? 'CAPITAL' : 'COUNTRY',
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Arrows point from the hidden capital toward each place',
+                  'Arrows point from the hidden '
+                  '${_isCapitalTarget ? 'capital' : 'country'} '
+                  'toward each place',
                   style: TextStyle(
                     color: FlitColors.textMuted.withOpacity(0.8),
                     fontSize: 11,
@@ -338,7 +357,9 @@ class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
                   textInputAction: TextInputAction.send,
                   style: const TextStyle(color: FlitColors.textPrimary),
                   decoration: InputDecoration(
-                    hintText: 'Capital (full pts) or country (×0.7)…',
+                    hintText: _isCapitalTarget
+                        ? 'Capital (full pts) or country (×0.7)…'
+                        : 'Name the country…',
                     hintStyle: const TextStyle(
                       color: FlitColors.textMuted,
                       fontSize: 13,
@@ -476,11 +497,13 @@ class _RoundResultView extends StatelessWidget {
   const _RoundResultView({
     required this.state,
     required this.isLastRound,
+    required this.isCapitalTarget,
     required this.onContinue,
   });
 
   final TriangulationRoundState state;
   final bool isLastRound;
+  final bool isCapitalTarget;
   final VoidCallback onContinue;
 
   @override
@@ -522,8 +545,11 @@ class _RoundResultView extends StatelessWidget {
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
+                        // Lead with whatever the player was hunting.
                         Text(
-                          round.targetCapitalName,
+                          isCapitalTarget
+                              ? round.targetCapitalName
+                              : round.targetCountryName,
                           style: const TextStyle(
                             color: FlitColors.textPrimary,
                             fontSize: 20,
@@ -531,7 +557,9 @@ class _RoundResultView extends StatelessWidget {
                           ),
                         ),
                         Text(
-                          round.targetCountryName,
+                          isCapitalTarget
+                              ? round.targetCountryName
+                              : round.targetCapitalName,
                           style: const TextStyle(
                             color: FlitColors.textSecondary,
                             fontSize: 14,
@@ -553,12 +581,59 @@ class _RoundResultView extends StatelessWidget {
                         painter: _ResultMapPainter(
                           targetLngLat: round.targetCapitalLngLat,
                           guesses: state.wrongGuesses,
+                          clues: round.clues,
                         ),
                       ),
                     ),
                   ),
                 ),
-                const SizedBox(height: 10),
+                const SizedBox(height: 8),
+                // Map legend.
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.star, color: FlitColors.gold, size: 13),
+                    const SizedBox(width: 3),
+                    const Text(
+                      'answer',
+                      style: TextStyle(
+                        color: FlitColors.textMuted,
+                        fontSize: 11,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    const Icon(
+                      Icons.circle_outlined,
+                      color: FlitColors.accent,
+                      size: 11,
+                    ),
+                    const SizedBox(width: 3),
+                    const Text(
+                      'clues',
+                      style: TextStyle(
+                        color: FlitColors.textMuted,
+                        fontSize: 11,
+                      ),
+                    ),
+                    if (state.wrongGuesses.isNotEmpty) ...[
+                      const SizedBox(width: 12),
+                      const Icon(
+                        Icons.circle,
+                        color: FlitColors.error,
+                        size: 11,
+                      ),
+                      const SizedBox(width: 3),
+                      const Text(
+                        'your guesses',
+                        style: TextStyle(
+                          color: FlitColors.textMuted,
+                          fontSize: 11,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+                const SizedBox(height: 8),
                 if (state.wrongGuesses.isNotEmpty)
                   Column(
                     children: [
@@ -641,13 +716,19 @@ class _RoundResultView extends StatelessWidget {
   }
 }
 
-/// Equirectangular world map with the target capital (gold star) and each
-/// wrong guess (red dot), auto-framed around the action.
+/// Equirectangular world map with the target capital (gold star), each
+/// wrong guess (red dot), and the round's original clue anchors (accent
+/// ringed dots) so the reveal shows the full triangulation picture.
 class _ResultMapPainter extends CustomPainter {
-  _ResultMapPainter({required this.targetLngLat, required this.guesses});
+  _ResultMapPainter({
+    required this.targetLngLat,
+    required this.guesses,
+    required this.clues,
+  });
 
   final Vector2 targetLngLat;
   final List<TriangulationGuess> guesses;
+  final List<TriangulationClue> clues;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -680,8 +761,35 @@ class _ResultMapPainter extends CustomPainter {
       }
     }
 
-    // Guess dots + connector lines toward the target.
     final target = project(targetLngLat.x, targetLngLat.y);
+
+    // Original clue anchors: accent ringed dots with a faint line to the
+    // target, so the reveal shows what the arrows were pointing at.
+    for (final clue in clues) {
+      final pos = project(clue.capitalLngLat.x, clue.capitalLngLat.y);
+      canvas.drawLine(
+        pos,
+        target,
+        Paint()
+          ..color = FlitColors.textSecondary.withOpacity(0.3)
+          ..strokeWidth = 0.8,
+      );
+      canvas.drawCircle(
+        pos,
+        3,
+        Paint()..color = FlitColors.backgroundDark,
+      );
+      canvas.drawCircle(
+        pos,
+        3,
+        Paint()
+          ..color = FlitColors.accent
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1.6,
+      );
+    }
+
+    // Guess dots + connector lines toward the target.
     for (final g in guesses) {
       final pos = project(g.capitalLngLat.x, g.capitalLngLat.y);
       canvas.drawLine(
@@ -717,7 +825,9 @@ class _ResultMapPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_ResultMapPainter old) =>
-      targetLngLat != old.targetLngLat || guesses.length != old.guesses.length;
+      targetLngLat != old.targetLngLat ||
+      guesses.length != old.guesses.length ||
+      clues.length != old.clues.length;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -729,11 +839,13 @@ class _SummaryView extends StatelessWidget {
     required this.session,
     required this.shareText,
     required this.isDaily,
+    required this.isCapitalTarget,
   });
 
   final TriangulationSession session;
   final String shareText;
   final bool isDaily;
+  final bool isCapitalTarget;
 
   @override
   Widget build(BuildContext context) {
@@ -859,7 +971,9 @@ class _SummaryView extends StatelessWidget {
           SizedBox(
             width: 110,
             child: Text(
-              state.round.targetCapitalName,
+              isCapitalTarget
+                  ? state.round.targetCapitalName
+                  : state.round.targetCountryName,
               textAlign: TextAlign.right,
               overflow: TextOverflow.ellipsis,
               style: const TextStyle(

--- a/lib/features/triangulation/triangulation_setup_screen.dart
+++ b/lib/features/triangulation/triangulation_setup_screen.dart
@@ -54,6 +54,7 @@ const List<int> _markerOptions = [3, 4, 5, 6];
 class _TriangulationSetupScreenState extends State<TriangulationSetupScreen> {
   final Set<ClueType> _clueTypes = {ClueType.flag};
   final Set<TriLabel> _labelTypes = {TriLabel.capital};
+  TriTargetType _targetType = TriTargetType.capital;
   int _rounds = 3;
   int _markers = 5;
 
@@ -83,6 +84,7 @@ class _TriangulationSetupScreenState extends State<TriangulationSetupScreen> {
       clueTypes: Set.unmodifiable(_clueTypes),
       labelTypes: Set.unmodifiable(_labelTypes),
       difficulty: GameSettings.instance.difficulty,
+      targetType: _targetType,
     );
     Navigator.of(context).pushReplacement(
       MaterialPageRoute<void>(
@@ -125,6 +127,10 @@ class _TriangulationSetupScreenState extends State<TriangulationSetupScreen> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       _buildHeader(),
+                      const SizedBox(height: 20),
+                      _sectionLabel('TARGET', Icons.my_location),
+                      const SizedBox(height: 10),
+                      _buildTargetSelector(),
                       const SizedBox(height: 20),
                       _sectionLabel('ROUNDS', Icons.repeat),
                       const SizedBox(height: 10),
@@ -250,6 +256,66 @@ class _TriangulationSetupScreenState extends State<TriangulationSetupScreen> {
             ),
           ),
         ],
+      );
+
+  Widget _buildTargetSelector() => Container(
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: FlitColors.cardBorder),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: TriTargetType.values.map((type) {
+            final isSelected = _targetType == type;
+            return GestureDetector(
+              onTap: () => setState(() => _targetType = type),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 18,
+                  vertical: 10,
+                ),
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? FlitColors.accent.withOpacity(0.2)
+                      : Colors.transparent,
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                    color:
+                        isSelected ? FlitColors.accent : FlitColors.cardBorder,
+                    width: isSelected ? 1.5 : 1,
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      type == TriTargetType.capital
+                          ? Icons.location_city_rounded
+                          : Icons.public,
+                      size: 16,
+                      color:
+                          isSelected ? FlitColors.accent : FlitColors.textMuted,
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      type.displayName,
+                      style: TextStyle(
+                        color: isSelected
+                            ? FlitColors.accent
+                            : FlitColors.textMuted,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }).toList(),
+        ),
       );
 
   Widget _numberSelector(

--- a/lib/features/triangulation/widgets/compass_painter.dart
+++ b/lib/features/triangulation/widgets/compass_painter.dart
@@ -115,6 +115,9 @@ class CompassPainter extends CustomPainter {
             color: FlitColors.textSecondary.withOpacity(0.7),
             fontSize: circleR * 0.16,
             fontWeight: FontWeight.w600,
+            // Roboto ships with MaterialApp on every platform; naming it
+            // keeps TextPainter output consistent (and real in goldens).
+            fontFamily: 'Roboto',
           ),
         ),
         textDirection: TextDirection.ltr,

--- a/lib/features/triangulation/widgets/triangulation_compass.dart
+++ b/lib/features/triangulation/widgets/triangulation_compass.dart
@@ -143,19 +143,28 @@ class TriangulationCompass extends StatelessWidget {
               ),
               for (var i = 0; i < markers.length; i++)
                 Positioned(
-                  left: positions[i].dx - boxWidth / 2,
+                  left: positions[i].dx - sizes[i].width / 2,
                   top: positions[i].dy - sizes[i].height / 2,
-                  width: boxWidth,
-                  child: _InfoBoxFrame(
-                    borderColor: markers[i].isGuess
-                        ? FlitColors.error
-                        : FlitColors.cardBorder,
-                    textColor: markers[i].isGuess
-                        ? FlitColors.error
-                        : FlitColors.textPrimary,
-                    visuals: markers[i].visuals,
-                    lines: markers[i].lines,
-                  ),
+                  width: sizes[i].width,
+                  // No text to hold → no card: just the bare visual(s) at
+                  // the arrow tip (e.g. flags-only expert mode).
+                  child: markers[i].lines.isEmpty
+                      ? Wrap(
+                          spacing: 4,
+                          alignment: WrapAlignment.center,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: markers[i].visuals,
+                        )
+                      : _InfoBoxFrame(
+                          borderColor: markers[i].isGuess
+                              ? FlitColors.error
+                              : FlitColors.cardBorder,
+                          textColor: markers[i].isGuess
+                              ? FlitColors.error
+                              : FlitColors.textPrimary,
+                          visuals: markers[i].visuals,
+                          lines: markers[i].lines,
+                        ),
                 ),
             ],
           );
@@ -245,6 +254,15 @@ class TriangulationCompass extends StatelessWidget {
   /// paddings and text metrics. Kept deliberately slightly generous so the
   /// collision layout leaves breathing room.
   Size _estimateBoxSize(_MarkerContent marker, double boxWidth) {
+    // Markers with no text render frameless (bare visuals), so their size
+    // is just the visuals' footprint — the collision layout then packs
+    // them much tighter.
+    if (marker.lines.isEmpty) {
+      var width = 0.0;
+      if (marker.hasFlag) width += 33;
+      if (marker.hasOutline) width += 40 + (marker.hasFlag ? 4 : 0);
+      return Size(math.max(width, 24), marker.hasOutline ? 30 : 22);
+    }
     final innerWidth = boxWidth - 12; // horizontal padding
     var height = 10.0; // vertical padding
     if (marker.visuals.isNotEmpty) {

--- a/lib/game/triangulation/daily_triangulation.dart
+++ b/lib/game/triangulation/daily_triangulation.dart
@@ -2,30 +2,39 @@ import 'dart:math';
 
 import '../../core/services/game_settings.dart';
 import '../clues/clue_types.dart';
+import '../data/country_difficulty.dart';
 import 'triangulation_session.dart';
 import 'triangulation_target.dart';
 
-/// A rotating daily theme: which clue visuals and labels appear on the
-/// compass markers today.
+/// A rotating daily theme: what the player hunts (capital or country) and
+/// which clue visuals and labels appear on the compass markers today.
 class DailyTriangulationTheme {
   const DailyTriangulationTheme({
     required this.title,
+    required this.description,
+    required this.targetType,
     required this.clueTypes,
     required this.labelTypes,
   });
 
   final String title;
+  final String description;
+  final TriTargetType targetType;
   final Set<ClueType> clueTypes;
   final Set<TriLabel> labelTypes;
+
+  /// Label-free themes are the expert runs.
+  bool get isExpert => labelTypes.isEmpty;
 }
 
 /// The daily Triangulation puzzle: same date → same seed → same theme,
-/// targets, and starting clues for every player.
+/// target type, difficulty, targets, and starting clues for every player.
 class DailyTriangulation {
   const DailyTriangulation({
     required this.date,
     required this.seed,
     required this.theme,
+    required this.difficulty,
   });
 
   /// UTC date (midnight) of this puzzle.
@@ -36,6 +45,10 @@ class DailyTriangulation {
   final int seed;
 
   final DailyTriangulationTheme theme;
+
+  /// Which target-country pool today draws from (rotates deterministically,
+  /// weighted toward normal).
+  final GameDifficulty difficulty;
 
   /// Fixed daily structure: 3 hidden targets, 5 guesses each.
   static const int roundCount = 3;
@@ -55,28 +68,52 @@ class DailyTriangulation {
   static const List<DailyTriangulationTheme> _themes = [
     DailyTriangulationTheme(
       title: 'Flags & Capitals',
+      description: 'Flags with their capitals — hunt the hidden capital.',
+      targetType: TriTargetType.capital,
       clueTypes: {ClueType.flag},
       labelTypes: {TriLabel.capital},
     ),
     DailyTriangulationTheme(
       title: 'Silhouette Sweep',
+      description: 'Country shapes point the way — name the hidden country.',
+      targetType: TriTargetType.country,
       clueTypes: {ClueType.outline},
       labelTypes: {TriLabel.country},
     ),
     DailyTriangulationTheme(
       title: 'Full Recon',
+      description: 'Everything on the table: flags, shapes, and names.',
+      targetType: TriTargetType.capital,
       clueTypes: {ClueType.flag, ClueType.outline},
       labelTypes: {TriLabel.country, TriLabel.capital},
     ),
     DailyTriangulationTheme(
       title: "Leaders' Summit",
+      description: 'Flags with their heads of state — find the country.',
+      targetType: TriTargetType.country,
       clueTypes: {ClueType.flag},
       labelTypes: {TriLabel.leader},
     ),
     DailyTriangulationTheme(
       title: 'Polyglot Patrol',
+      description: 'Shapes and spoken tongues — find the country.',
+      targetType: TriTargetType.country,
       clueTypes: {ClueType.outline},
       labelTypes: {TriLabel.language},
+    ),
+    DailyTriangulationTheme(
+      title: 'Silent Compass',
+      description: 'Bare flags, no names. Expert bearings only.',
+      targetType: TriTargetType.capital,
+      clueTypes: {ClueType.flag},
+      labelTypes: {},
+    ),
+    DailyTriangulationTheme(
+      title: 'Ghost Shapes',
+      description: 'Unlabelled silhouettes. For seasoned navigators.',
+      targetType: TriTargetType.country,
+      clueTypes: {ClueType.outline},
+      labelTypes: {},
     ),
   ];
 
@@ -84,13 +121,24 @@ class DailyTriangulation {
     final normalised = DateTime.utc(date.year, date.month, date.day);
     final seed =
         normalised.year * 10000 + normalised.month * 100 + normalised.day;
-    // Offset the theme RNG so today's theme rotation doesn't mirror the
-    // Daily Scramble's (both derive from the same date seed).
+    // Offset the theme RNG so today's rotation doesn't mirror the Daily
+    // Scramble's (both derive from the same date seed). Draw order is
+    // load-bearing: theme first, then difficulty — changing it changes
+    // every day's puzzle.
     final rng = Random(seed + 31);
+    final theme = _themes[rng.nextInt(_themes.length)];
+    // Difficulty pool: weighted 1/4 easy, 1/2 normal, 1/4 hard.
+    final roll = rng.nextInt(4);
+    final difficulty = roll == 0
+        ? GameDifficulty.easy
+        : roll == 3
+            ? GameDifficulty.hard
+            : GameDifficulty.normal;
     return DailyTriangulation(
       date: normalised,
       seed: seed,
-      theme: _themes[rng.nextInt(_themes.length)],
+      theme: theme,
+      difficulty: difficulty,
     );
   }
 
@@ -105,7 +153,41 @@ class DailyTriangulation {
         markerCount: markerCount,
         clueTypes: theme.clueTypes,
         labelTypes: theme.labelTypes,
-        difficulty: GameDifficulty.normal,
+        difficulty: difficulty,
+        targetType: theme.targetType,
         isDaily: true,
       );
+
+  /// Difficulty percent for the lobby pill (0–100), Scramble-style.
+  ///
+  /// Simulates today's 3 rounds with the exact same seeds and dedup the
+  /// session uses, so the displayed number reflects the real targets:
+  /// average target obscurity, nudged up for label-free (expert) and
+  /// outline-only clue configs. Pair with [difficultyLabel] for the text.
+  int get difficultyPercent {
+    final config = toConfig();
+    final usedTargets = <String>{};
+    var total = 0.0;
+    for (var i = 0; i < roundCount; i++) {
+      final round = TriangulationRound.generate(
+        seed: seed + i * 7919,
+        difficulty: difficulty,
+        markerCount: markerCount,
+        requireStats: config.requiresStats,
+        excludedTargetCodes: Set.unmodifiable(usedTargets),
+      );
+      usedTargets.add(round.targetCountryCode);
+      total += countryDifficultyRating(round.targetCountryCode);
+    }
+    var percent = (total / roundCount * 100).round();
+    if (theme.isExpert) percent += 15;
+    if (theme.clueTypes.length == 1 &&
+        theme.clueTypes.contains(ClueType.outline)) {
+      percent += 5;
+    }
+    return percent.clamp(0, 100);
+  }
+
+  /// Scramble-style difficulty label for [difficultyPercent].
+  String get difficultyLabelText => difficultyLabel(difficultyPercent / 100.0);
 }

--- a/lib/game/triangulation/triangulation_session.dart
+++ b/lib/game/triangulation/triangulation_session.dart
@@ -17,6 +17,7 @@ class TriangulationConfig {
     this.clueTypes = const {ClueType.flag},
     this.labelTypes = const {TriLabel.capital},
     this.difficulty = GameDifficulty.normal,
+    this.targetType = TriTargetType.capital,
     this.isDaily = false,
   });
 
@@ -24,6 +25,11 @@ class TriangulationConfig {
   final int rounds;
   final int guessesPerRound;
   final int markerCount;
+
+  /// What the player is hunting. Capital days: capital = full points,
+  /// country = ×0.7. Country days: only country names are answer
+  /// candidates (the UI offers no capital entries).
+  final TriTargetType targetType;
 
   /// Visual clue types shown in each marker's info box
   /// (flag / outline / borders / capital supported).
@@ -170,8 +176,9 @@ class TriangulationSession {
       viaCapital: viaCapital,
       isCorrect: isCorrect,
       distanceKm: distanceKm,
+      // Rhumb bearing, matching the clue arrows' flat-map convention.
       bearingFromTargetDeg:
-          initialBearingDeg(round.targetCapitalLngLat, capitalLngLat),
+          rhumbBearingDeg(round.targetCapitalLngLat, capitalLngLat),
       penalty: isCorrect
           ? 0
           : triProximityPenalty(distanceKm, isNeighbor: isNeighbor),
@@ -187,7 +194,10 @@ class TriangulationSession {
     if (state.isOver) {
       state.score = computeTriangulationScore(
         solved: state.solved,
-        solvedAsCountry: state.solvedAsCountry,
+        // The ×0.7 country-name discount only exists on capital days;
+        // on country days the country name IS the asked-for answer.
+        solvedAsCountry:
+            state.solvedAsCountry && config.targetType == TriTargetType.capital,
         timeMs: state.elapsedMs,
         wrongGuessPenalties: state.wrongGuesses.map((g) => g.penalty).toList(),
         targetCountryCode: round.targetCountryCode,

--- a/lib/game/triangulation/triangulation_target.dart
+++ b/lib/game/triangulation/triangulation_target.dart
@@ -8,6 +8,23 @@ import '../clues/clue_types.dart';
 import '../data/country_difficulty.dart';
 import '../map/country_data.dart';
 
+/// What the player is hunting: the hidden capital city or the country
+/// itself. Bearings are capital-anchored in both modes; this changes what
+/// counts as the answer and how the game talks about the target.
+enum TriTargetType { capital, country }
+
+/// Display metadata for a [TriTargetType].
+extension TriTargetTypeMeta on TriTargetType {
+  String get displayName {
+    switch (this) {
+      case TriTargetType.capital:
+        return 'Capital City';
+      case TriTargetType.country:
+        return 'Country';
+    }
+  }
+}
+
 /// Label types that can accompany a clue marker on the compass.
 enum TriLabel { country, capital, leader, language }
 
@@ -46,8 +63,8 @@ class TriangulationClue {
   /// Capital coordinates as (lng, lat) degrees.
   final Vector2 capitalLngLat;
 
-  /// Compass bearing (0 = N, clockwise) from the hidden target's capital
-  /// to this clue's capital.
+  /// Rhumb-line compass bearing (0 = N, clockwise) from the hidden
+  /// target's capital to this clue's capital — the flat-map direction.
   final double bearingFromTargetDeg;
 
   /// Great-circle distance from the hidden target's capital, in km.
@@ -164,8 +181,10 @@ class TriangulationRound {
     for (final c in anchors) {
       if (clues.length >= markerCount) break;
       final capital = CountryData.getCapital(c.code)!;
-      final bearing =
-          initialBearingDeg(targetCapital.location, capital.location);
+      // Rhumb-line bearing: the flat-map direction players expect (a
+      // great-circle initial bearing to a far anchor can point over the
+      // pole — Colombo→Mexico City would read "north").
+      final bearing = rhumbBearingDeg(targetCapital.location, capital.location);
       final clue = TriangulationClue(
         countryCode: c.code,
         countryName: c.name,

--- a/test/unit/game/triangulation/triangulation_test.dart
+++ b/test/unit/game/triangulation/triangulation_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flit/core/services/game_settings.dart';
 import 'package:flit/core/utils/math_utils.dart';
+import 'package:flit/game/clues/clue_types.dart';
 import 'package:flit/game/map/country_data.dart';
 import 'package:flit/game/triangulation/daily_triangulation.dart';
 import 'package:flit/game/triangulation/triangulation_scoring.dart';
@@ -58,15 +59,82 @@ void main() {
       final paris = Vector2(2.3522, 48.8566);
       expect(greatCircleKm(london, paris), closeTo(343, 15));
     });
+
+    test('rhumb bearing matches cardinal directions', () {
+      expect(rhumbBearingDeg(Vector2(0, 0), Vector2(0, 10)), closeTo(0, 0.01));
+      expect(rhumbBearingDeg(Vector2(0, 0), Vector2(10, 0)), closeTo(90, 0.01));
+      expect(
+        rhumbBearingDeg(Vector2(0, 10), Vector2(0, 0)),
+        closeTo(180, 0.01),
+      );
+      expect(
+        rhumbBearingDeg(Vector2(10, 0), Vector2(0, 0)),
+        closeTo(270, 0.01),
+      );
+    });
+
+    test('Colombo→Mexico City rhumb bearing reads west, not north', () {
+      // Great-circle initial bearing here crosses near the pole (~N),
+      // which broke map intuition in-game; the rhumb bearing is the
+      // flat-map direction players expect.
+      final colombo = Vector2(79.86, 6.93);
+      final mexicoCity = Vector2(-99.13, 19.43);
+      final rhumb = rhumbBearingDeg(colombo, mexicoCity);
+      expect(rhumb, greaterThan(250));
+      expect(rhumb, lessThan(300));
+      // Sanity: the great-circle bearing really is the unintuitive one.
+      final greatCircle = initialBearingDeg(colombo, mexicoCity);
+      expect(greatCircle < 45 || greatCircle > 315, isTrue);
+    });
   });
 
   group('daily determinism', () {
-    test('same date yields identical seed and theme', () {
+    test('same date yields identical seed, theme, target, difficulty', () {
       final a = DailyTriangulation.forDate(DateTime.utc(2026, 7, 4));
       final b = DailyTriangulation.forDate(DateTime.utc(2026, 7, 4));
       expect(a.seed, b.seed);
       expect(a.seed, 20260704);
       expect(a.theme.title, b.theme.title);
+      expect(a.theme.targetType, b.theme.targetType);
+      expect(a.difficulty, b.difficulty);
+      expect(a.difficultyPercent, b.difficultyPercent);
+      expect(a.difficultyPercent, inInclusiveRange(0, 100));
+      expect(a.difficultyLabelText, isNotEmpty);
+    });
+
+    test('label-free (expert) themes report higher difficulty', () {
+      final date = DateTime.utc(2026, 7, 4);
+      final base = DailyTriangulation.forDate(date);
+      const labelled = DailyTriangulationTheme(
+        title: 'T',
+        description: 'd',
+        targetType: TriTargetType.capital,
+        clueTypes: {ClueType.flag},
+        labelTypes: {TriLabel.capital},
+      );
+      const expert = DailyTriangulationTheme(
+        title: 'T',
+        description: 'd',
+        targetType: TriTargetType.capital,
+        clueTypes: {ClueType.flag},
+        labelTypes: {},
+      );
+      final withLabels = DailyTriangulation(
+        date: date,
+        seed: base.seed,
+        theme: labelled,
+        difficulty: GameDifficulty.normal,
+      );
+      final withoutLabels = DailyTriangulation(
+        date: date,
+        seed: base.seed,
+        theme: expert,
+        difficulty: GameDifficulty.normal,
+      );
+      expect(
+        withoutLabels.difficultyPercent,
+        greaterThan(withLabels.difficultyPercent),
+      );
     });
 
     test('same seed yields identical targets, clues, and bearings', () {
@@ -116,6 +184,14 @@ void main() {
         expect(clue.countryCode, isNot(round.targetCountryCode));
         expect(clue.bearingFromTargetDeg, inInclusiveRange(0, 360));
         expect(clue.distanceFromTargetKm, greaterThan(0));
+        // Arrows use flat-map (rhumb) bearings, not great-circle.
+        expect(
+          clue.bearingFromTargetDeg,
+          closeTo(
+            rhumbBearingDeg(round.targetCapitalLngLat, clue.capitalLngLat),
+            1e-9,
+          ),
+        );
       }
       expect(
         round.clues.map((c) => c.countryCode).toSet().length,
@@ -226,6 +302,34 @@ void main() {
       expect(session.currentRound.solved, isTrue);
       expect(session.currentRound.score, greaterThan(0));
       expect(session.isFinished, isTrue);
+    });
+
+    test('country-target days score full marks for the country name', () {
+      // Same seed, same timing: solving a capital-target game via the
+      // capital must equal solving a country-target game via the country
+      // (no ×0.7 discount on country days).
+      final capitalGame = TriangulationSession(
+        const TriangulationConfig(seed: 99, rounds: 1),
+      );
+      final countryGame = TriangulationSession(
+        const TriangulationConfig(
+          seed: 99,
+          rounds: 1,
+          targetType: TriTargetType.country,
+        ),
+      );
+      capitalGame.submitGuess(
+        capitalGame.currentRound.round.targetCountryCode,
+        viaCapital: true,
+        elapsedMs: 4000,
+      );
+      countryGame.submitGuess(
+        countryGame.currentRound.round.targetCountryCode,
+        viaCapital: false,
+        elapsedMs: 4000,
+      );
+      expect(countryGame.currentRound.score, capitalGame.currentRound.score);
+      expect(countryGame.currentRound.score, greaterThan(0));
     });
 
     test('wrong guesses add compass markers and expire after 5', () {


### PR DESCRIPTION
## Summary

Playtest feedback round for Triangulation (follow-up to #433–#435):

### Bearing intuition fix ("Mexico north of Sri Lanka")
Compass arrows (clues **and** red guess markers) now use **rhumb-line bearings** — the constant flat-map heading — instead of great-circle initial bearings, which can cross near the pole for far anchors (Colombo→Mexico City genuinely reads "north" on a great circle). Distances/scoring and the flying game's steering remain great-circle. Regression-tested: Colombo→Mexico City rhumb ≈ west, and the test asserts the great-circle value really was the unintuitive one.

### Target-type rotation
- Daily themes now declare what you hunt: **Capital City** or **Country** (bearings stay capital-anchored either way).
- **Country days accept country names only** — capital entries aren't answer candidates (no suggestions, no matcher). Capital days unchanged: capital = full, country = ×0.7 (the discount is disabled on country days).
- Daily **difficulty pool rotates** deterministically (¼ easy, ½ normal, ¼ hard).
- Two **expert label-free themes** join the rotation: *Silent Compass* (bare flags) and *Ghost Shapes* (bare outlines).
- Free play gains a TARGET selector (Capital City / Country).

### Scramble-style daily brief
The lobby now shows exactly what to expect today:
- Theme title + description
- **TARGET** pill + the day's answer rule
- **ACTIVE CLUES** chips — visual types in accent, label types in gold, or "No labels — expert!" in warning
- **Difficulty pill** (`Turbulence 62%`-style) computed from the day's actual 3 targets via the same `difficultyLabel`/`difficultyBandIndex` scale the Scramble uses, nudged up for expert/outline-only configs

### Reveal shows the full picture
The round-result map now draws the original 5 clue anchors (accent ringed dots with faint lines to the target) alongside the gold answer star and red guess dots, with a legend row.

## Testing
- 29 unit tests (4 new): rhumb cardinal directions, Colombo→Mexico City regression, clue arrows verified rhumb, daily determinism incl. targetType/difficulty/percent, expert-theme difficulty bump, country-day full-marks scoring parity
- Full suite **838/838 green**; `flutter analyze` 0 errors; both compass goldens regenerated and visually verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_