### PR TITLE
fix(triangulation): lock bearings to the flat map — no antimeridian shortcut

### DIFF
--- a/lib/core/utils/math_utils.dart
+++ b/lib/core/utils/math_utils.dart
@@ -53,19 +53,21 @@ double initialBearingDeg(Vector2 from, Vector2 to) {
   return (deg % 360 + 360) % 360;
 }
 
-/// Rhumb-line (loxodrome) bearing from [from] to [to], in compass degrees
-/// normalised to [0, 360).
+/// Flat-map bearing from [from] to [to], in compass degrees normalised
+/// to [0, 360).
 ///
-/// This is the constant heading you'd follow on a Mercator map — the
-/// direction players intuitively expect (a great-circle initial bearing to
-/// a far-away point can cross near a pole, e.g. Colombo→Mexico City reads
-/// "north", which is technically right but violates map sense).
-double rhumbBearingDeg(Vector2 from, Vector2 to) {
+/// This is the direction as drawn on a standard Greenwich-centred world
+/// map (Mercator vertical scale), with NO antimeridian shortcut: Russia
+/// reads east of the USA and Japan east of California even when crossing
+/// the ±180° line would be shorter. Players reason on the flat map, so
+/// game bearings must match it — a great-circle initial bearing can cross
+/// near a pole (Colombo→Mexico City reads "north"), and a true rhumb line
+/// takes the short way around the antimeridian; both violate map sense.
+double flatMapBearingDeg(Vector2 from, Vector2 to) {
   final lat1 = from.y * deg2rad;
   final lat2 = to.y * deg2rad;
-  var dLng = (to.x - from.x) * deg2rad;
-  // Take the shorter way around the antimeridian.
-  if (dLng.abs() > pi) dLng -= dLng.sign * 2 * pi;
+  // Raw longitude difference — the on-map horizontal direction.
+  final dLng = (to.x - from.x) * deg2rad;
 
   final dPsi = log(tan(pi / 4 + lat2 / 2) / tan(pi / 4 + lat1 / 2));
   final deg = atan2(dLng, dPsi) * rad2deg;

--- a/lib/game/triangulation/triangulation_session.dart
+++ b/lib/game/triangulation/triangulation_session.dart
@@ -179,9 +179,9 @@ class TriangulationSession {
       viaCapital: viaCapital,
       isCorrect: isCorrect,
       distanceKm: distanceKm,
-      // Rhumb bearing, matching the clue arrows' flat-map convention.
+      // Flat-map bearing, matching the clue arrows' convention.
       bearingFromTargetDeg:
-          rhumbBearingDeg(round.targetCapitalLngLat, capitalLngLat),
+          flatMapBearingDeg(round.targetCapitalLngLat, capitalLngLat),
       penalty: isCorrect
           ? 0
           : triProximityPenalty(distanceKm, isNeighbor: isNeighbor),

--- a/lib/game/triangulation/triangulation_target.dart
+++ b/lib/game/triangulation/triangulation_target.dart
@@ -63,8 +63,9 @@ class TriangulationClue {
   /// Capital coordinates as (lng, lat) degrees.
   final Vector2 capitalLngLat;
 
-  /// Rhumb-line compass bearing (0 = N, clockwise) from the hidden
-  /// target's capital to this clue's capital — the flat-map direction.
+  /// Flat-map compass bearing (0 = N, clockwise) from the hidden
+  /// target's capital to this clue's capital — the direction as drawn
+  /// on a standard world map, never shortcutting the antimeridian.
   final double bearingFromTargetDeg;
 
   /// Great-circle distance from the hidden target's capital, in km.
@@ -188,10 +189,12 @@ class TriangulationRound {
     for (final c in anchors) {
       if (clues.length >= markerCount) break;
       final capital = CountryData.getCapital(c.code)!;
-      // Rhumb-line bearing: the flat-map direction players expect (a
-      // great-circle initial bearing to a far anchor can point over the
-      // pole — Colombo→Mexico City would read "north").
-      final bearing = rhumbBearingDeg(targetCapital.location, capital.location);
+      // Flat-map bearing: the direction as drawn on a world map. No
+      // polar great-circle shortcuts (Colombo→Mexico City would read
+      // "north") and no antimeridian shortcuts (Russia stays east of
+      // the USA even when crossing ±180° is shorter).
+      final bearing =
+          flatMapBearingDeg(targetCapital.location, capital.location);
       final clue = TriangulationClue(
         countryCode: c.code,
         countryName: c.name,

--- a/test/unit/game/triangulation/triangulation_test.dart
+++ b/test/unit/game/triangulation/triangulation_test.dart
@@ -60,31 +60,56 @@ void main() {
       expect(greatCircleKm(london, paris), closeTo(343, 15));
     });
 
-    test('rhumb bearing matches cardinal directions', () {
-      expect(rhumbBearingDeg(Vector2(0, 0), Vector2(0, 10)), closeTo(0, 0.01));
-      expect(rhumbBearingDeg(Vector2(0, 0), Vector2(10, 0)), closeTo(90, 0.01));
+    test('flat-map bearing matches cardinal directions', () {
       expect(
-        rhumbBearingDeg(Vector2(0, 10), Vector2(0, 0)),
+          flatMapBearingDeg(Vector2(0, 0), Vector2(0, 10)), closeTo(0, 0.01));
+      expect(
+          flatMapBearingDeg(Vector2(0, 0), Vector2(10, 0)), closeTo(90, 0.01));
+      expect(
+        flatMapBearingDeg(Vector2(0, 10), Vector2(0, 0)),
         closeTo(180, 0.01),
       );
       expect(
-        rhumbBearingDeg(Vector2(10, 0), Vector2(0, 0)),
+        flatMapBearingDeg(Vector2(10, 0), Vector2(0, 0)),
         closeTo(270, 0.01),
       );
     });
 
-    test('Colombo→Mexico City rhumb bearing reads west, not north', () {
+    test('Colombo→Mexico City flat-map bearing reads west, not north', () {
       // Great-circle initial bearing here crosses near the pole (~N),
-      // which broke map intuition in-game; the rhumb bearing is the
-      // flat-map direction players expect.
+      // which broke map intuition in-game; the flat-map bearing is the
+      // direction players expect.
       final colombo = Vector2(79.86, 6.93);
       final mexicoCity = Vector2(-99.13, 19.43);
-      final rhumb = rhumbBearingDeg(colombo, mexicoCity);
-      expect(rhumb, greaterThan(250));
-      expect(rhumb, lessThan(300));
+      final flatMap = flatMapBearingDeg(colombo, mexicoCity);
+      expect(flatMap, greaterThan(250));
+      expect(flatMap, lessThan(300));
       // Sanity: the great-circle bearing really is the unintuitive one.
       final greatCircle = initialBearingDeg(colombo, mexicoCity);
       expect(greatCircle < 45 || greatCircle > 315, isTrue);
+    });
+
+    test('no antimeridian shortcut: bearings match the flat map', () {
+      final washington = Vector2(-77.0, 38.9);
+      final losAngeles = Vector2(-118.2, 34.1);
+      final tokyo = Vector2(139.7, 35.7);
+      final moscow = Vector2(37.6, 55.8);
+
+      // Russia is east of the USA on the map.
+      final usaToRussia = flatMapBearingDeg(washington, moscow);
+      expect(usaToRussia, greaterThan(0));
+      expect(usaToRussia, lessThan(90));
+
+      // Tokyo is east of Los Angeles on the map, even though flying west
+      // across the Pacific is shorter.
+      final laToTokyo = flatMapBearingDeg(losAngeles, tokyo);
+      expect(laToTokyo, greaterThan(45));
+      expect(laToTokyo, lessThan(135));
+
+      // And the USA is west of Tokyo on the map.
+      final tokyoToDc = flatMapBearingDeg(tokyo, washington);
+      expect(tokyoToDc, greaterThan(225));
+      expect(tokyoToDc, lessThan(315));
     });
   });
 
@@ -204,7 +229,7 @@ void main() {
         expect(
           clue.bearingFromTargetDeg,
           closeTo(
-            rhumbBearingDeg(round.targetCapitalLngLat, clue.capitalLngLat),
+            flatMapBearingDeg(round.targetCapitalLngLat, clue.capitalLngLat),
             1e-9,
           ),
         );


### PR DESCRIPTION
## Summary

Compass arrows previously took the shorter way around the ±180° line, so with a target across the Pacific, a clue like the USA could point WEST of a Japanese target. Players read the compass against a standard flat world map, where **Russia is east of the USA** and **Tokyo is east of Los Angeles** — regardless of which crossing is shorter.

- `rhumbBearingDeg` → `flatMapBearingDeg`: same Mercator vertical scale, but the longitude difference is now taken **raw** (as drawn on a Greenwich-centred map) with no antimeridian wrap
- Applies consistently to clue arrows and red wrong-guess markers
- Great-circle math unchanged for distances/proximity scoring and the flying game's steering

## Testing
- New regression test pinning the exact complaint: USA→Russia reads east, LA→Tokyo reads east (despite the shorter westward Pacific hop), Tokyo→Washington reads west
- All triangulation + content suites pass (62 tests); goldens regenerated (unchanged for the fixture seed — no antimeridian pairs in it); `flutter analyze` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_