### PR TITLE
fix: resolve full-codebase audit findings — broken flows, dead wiring, infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,8 +330,8 @@ jobs:
           # Update version in pubspec.yaml (keep build number as PR count)
           sed -i "s/^version: .*/version: 1.0.${PR_COUNT}+${PR_COUNT}/" pubspec.yaml
 
-          # Update version in error_service.dart
-          sed -i "s/static const String appVersion = '.*'/static const String appVersion = '${CURRENT_VERSION}'/" lib/core/services/error_service.dart
+          # (error_service.dart now reads its version from app_version.dart,
+          # so it no longer needs a sed of its own.)
 
           # Update version in index.html JS error handler
           sed -i "s/appVersion: '.*'/appVersion: '${CURRENT_VERSION}'/" web/index.html
@@ -342,7 +342,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add lib/core/app_version.dart pubspec.yaml lib/core/services/error_service.dart web/index.html
+          git add lib/core/app_version.dart pubspec.yaml web/index.html
           # Only commit if there are changes
           git diff --cached --quiet || {
             git commit -m "chore: bump version to $(grep "const String appVersion" lib/core/app_version.dart | grep -oP "v1\.\d+") [skip ci]"

--- a/.github/workflows/fetch-errors.yml
+++ b/.github/workflows/fetch-errors.yml
@@ -27,6 +27,8 @@ jobs:
           # Create labels if they do not already exist (--force updates existing ones).
           gh label create "bug"         --color "d73a4a" --description "Something isn't working"    --force
           gh label create "critical"    --color "b60205" --description "Critical severity issue"    --force
+          gh label create "error"       --color "d93f0b" --description "Error severity issue"       --force
+          gh label create "warning"     --color "fbca04" --description "Warning severity issue"     --force
           gh label create "auto-triage" --color "e4e669" --description "Auto-created by CI pipeline" --force
 
       - name: Fetch critical errors and create/update GitHub issues
@@ -41,12 +43,15 @@ jobs:
           mkdir -p logs
 
           # ---------------------------------------------------------------
-          # 1. Fetch critical errors from Vercel endpoint
+          # 1. Fetch ALL severities from the Vercel endpoint. The log is
+          #    purged at the end of this workflow, so anything not fetched
+          #    here is permanently discarded — filtering to critical-only
+          #    was silently destroying error/warning telemetry.
           # ---------------------------------------------------------------
           HTTP_CODE=$(curl -s -o /tmp/errors_response.json -w "%{http_code}" \
             --max-time 30 --connect-timeout 10 \
             -H "X-API-Key: ${VERCEL_ERRORS_API_KEY}" \
-            "${ERRORS_ENDPOINT}?severity=critical&limit=100" \
+            "${ERRORS_ENDPOINT}?limit=250" \
           ) || {
             echo "::warning::curl failed to connect to errors endpoint"
             exit 0
@@ -164,7 +169,7 @@ jobs:
               gh issue create \
                 --title "$ISSUE_TITLE" \
                 --body-file /tmp/issue_body.md \
-                --label "bug,critical,auto-triage"
+                --label "bug,${SEVERITY},auto-triage"
 
               echo "Created new issue: ${ISSUE_TITLE}"
               ISSUES_CREATED=$((ISSUES_CREATED + 1))

--- a/api/admin/stats.js
+++ b/api/admin/stats.js
@@ -5,8 +5,13 @@
 // Queries Supabase directly for player counts, activity windows,
 // game volume, and matchmaking pool status.
 
-const SUPABASE_URL = 'https://zrffgpkscdaybfhujioc.supabase.co';
-const SUPABASE_ANON_KEY = 'sb_publishable_AnlV4Gngx7a5z3KwqV7F9w_-4rQYEJs';
+// Publishable values — env vars take precedence so rotation only needs a
+// Vercel config change; the literals are last-resort fallbacks.
+const SUPABASE_URL =
+  process.env.SUPABASE_URL || 'https://zrffgpkscdaybfhujioc.supabase.co';
+const SUPABASE_ANON_KEY =
+  process.env.SUPABASE_ANON_KEY ||
+  'sb_publishable_AnlV4Gngx7a5z3KwqV7F9w_-4rQYEJs';
 
 const HEADERS = {
   apikey: SUPABASE_ANON_KEY,
@@ -112,11 +117,12 @@ module.exports = async (req, res) => {
     query('scores?select=score,time_ms,region,rounds_completed,created_at,user_id&order=created_at.desc&limit=20'),
   ]);
 
-  // Compute active players (distinct users who played in each window)
-  // We approximate this from scores data — a player who submitted a score was active
+  // Compute active players (distinct users who played in each window).
+  // Approximated from the recent-scores sample — a player who submitted a
+  // score was active. (A 7d distinct-count needs a wider query than the
+  // 20-row sample supports, so no 7d active metric is reported.)
   let activePlayers1h = 0;
   let activePlayers24h = 0;
-  let activePlayers7d = 0;
   if (recentScores) {
     const uniqueUsers1h = new Set();
     const uniqueUsers24h = new Set();

--- a/api/health/index.js
+++ b/api/health/index.js
@@ -5,9 +5,13 @@
 // (Supabase pauses after 7 days of inactivity). Vercel cron hits
 // this endpoint every 3 days via the "crons" config in vercel.json.
 
-// Supabase project details (public/client-side values — safe to embed).
-const SUPABASE_URL = 'https://zrffgpkscdaybfhujioc.supabase.co';
-const SUPABASE_ANON_KEY = 'sb_publishable_AnlV4Gngx7a5z3KwqV7F9w_-4rQYEJs';
+// Supabase project details (publishable values — env vars take precedence
+// so rotation only needs a Vercel config change).
+const SUPABASE_URL =
+  process.env.SUPABASE_URL || 'https://zrffgpkscdaybfhujioc.supabase.co';
+const SUPABASE_ANON_KEY =
+  process.env.SUPABASE_ANON_KEY ||
+  'sb_publishable_AnlV4Gngx7a5z3KwqV7F9w_-4rQYEJs';
 
 /**
  * Lightweight Supabase ping — hits the PostgREST health endpoint.

--- a/lib/core/services/audio_manager.dart
+++ b/lib/core/services/audio_manager.dart
@@ -23,9 +23,6 @@ enum SfxType {
 
   /// Whoosh for altitude toggle.
   altitudeChange,
-
-  /// Speed boost activation.
-  boostStart,
 }
 
 /// Manages all game audio: background music and one-shot SFX.
@@ -149,8 +146,8 @@ class AudioManager {
         return 'audio/sfx/ui_click.mp3';
       case SfxType.altitudeChange:
         return 'audio/sfx/altitude_change.mp3';
-      case SfxType.boostStart:
-        return 'audio/sfx/boost_start.mp3';
+      // No boost mechanic exists — boost_start.mp3 stays in assets for
+      // when one does, but the enum only lists playable effects.
     }
   }
 

--- a/lib/core/services/error_service.dart
+++ b/lib/core/services/error_service.dart
@@ -261,7 +261,7 @@ class ErrorService {
     String errorString;
     try {
       final dynamic e = error;
-      errorString = e == null ? 'Unknown error (null)' : e.toString() as String;
+      errorString = e == null ? 'Unknown error (null)' : e.toString();
     } catch (_) {
       errorString = 'Error (toString failed)';
     }
@@ -422,8 +422,12 @@ class ErrorService {
           );
 
           if (success) {
-            // Remove only the errors we successfully sent.
-            _queue.removeWhere((e) => batch.contains(e));
+            // Remove only the errors we successfully sent. The batch is a
+            // snapshot of the queue's head, so drop that prefix by count —
+            // identity-based removeWhere would silently stop clearing if
+            // CapturedError ever gained value equality or the queue were
+            // rebuilt.
+            _queue.removeRange(0, batch.length.clamp(0, _queue.length));
             if (kDebugMode) {
               debugPrint(
                 '[ErrorService] flush() SUCCESS: ${batch.length} errors sent',

--- a/lib/core/utils/haptics.dart
+++ b/lib/core/utils/haptics.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/services.dart';
+
+import '../services/game_settings.dart';
+
+/// Haptic feedback helpers gated by the user's "Haptic Feedback" setting.
+///
+/// These are the only sanctioned entry points for vibration — calling
+/// [HapticFeedback] directly would bypass the settings toggle. Safe on
+/// web/desktop where the engine treats haptics as a no-op.
+void hapticLight() {
+  if (GameSettings.instance.hapticEnabled) HapticFeedback.lightImpact();
+}
+
+void hapticMedium() {
+  if (GameSettings.instance.hapticEnabled) HapticFeedback.mediumImpact();
+}
+
+void hapticSuccess() {
+  if (GameSettings.instance.hapticEnabled) HapticFeedback.heavyImpact();
+}

--- a/lib/core/widgets/settings_sheet.dart
+++ b/lib/core/widgets/settings_sheet.dart
@@ -113,19 +113,10 @@ class _SettingsSheetContentState extends State<_SettingsSheetContent> {
                   }
                 : null,
           ),
-          // Notifications — profile settings only (not during gameplay)
-          if (!widget.inGame) ...[
-            const Divider(color: FlitColors.cardBorder, height: 1),
-            _SettingsToggle(
-              label: 'Notifications',
-              icon: Icons.notifications_outlined,
-              value: GameSettings.instance.notificationsEnabled,
-              onChanged: (value) {
-                GameSettings.instance.notificationsEnabled = value;
-                setState(() {});
-              },
-            ),
-          ],
+          // NOTE: the Notifications toggle was removed — no notification
+          // service exists yet, so the switch controlled nothing. Restore
+          // it (GameSettings.notificationsEnabled is still persisted) when
+          // push/local notifications ship.
           const Divider(color: FlitColors.cardBorder, height: 1),
           _SettingsToggle(
             label: 'Haptic Feedback',

--- a/lib/data/models/economy_config.dart
+++ b/lib/data/models/economy_config.dart
@@ -121,6 +121,9 @@ class EarningsConfig {
   /// Base gold reward for completing a daily scramble puzzle.
   final int dailyScrambleBaseReward;
 
+  /// Base gold reward for completing the daily triangulation puzzle.
+  final int dailyTriangulationBaseReward;
+
   /// Gold earned per clue discovered during free flight mode.
   final int freeFlightPerClueReward;
 
@@ -138,6 +141,7 @@ class EarningsConfig {
 
   const EarningsConfig({
     this.dailyScrambleBaseReward = 150,
+    this.dailyTriangulationBaseReward = 150,
     this.freeFlightPerClueReward = 15,
     this.freeFlightDailyCap = 150,
     this.campaignMissionReward = 100,
@@ -149,6 +153,8 @@ class EarningsConfig {
     if (json == null) return const EarningsConfig();
     return EarningsConfig(
       dailyScrambleBaseReward: json['dailyScrambleBaseReward'] as int? ?? 150,
+      dailyTriangulationBaseReward:
+          json['dailyTriangulationBaseReward'] as int? ?? 150,
       freeFlightPerClueReward: json['freeFlightPerClueReward'] as int? ?? 15,
       freeFlightDailyCap: json['freeFlightDailyCap'] as int? ?? 150,
       campaignMissionReward: json['campaignMissionReward'] as int? ?? 100,
@@ -160,6 +166,7 @@ class EarningsConfig {
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'dailyScrambleBaseReward': dailyScrambleBaseReward,
+      'dailyTriangulationBaseReward': dailyTriangulationBaseReward,
       'freeFlightPerClueReward': freeFlightPerClueReward,
       'freeFlightDailyCap': freeFlightDailyCap,
       'campaignMissionReward': campaignMissionReward,

--- a/lib/data/providers/account_provider.dart
+++ b/lib/data/providers/account_provider.dart
@@ -648,6 +648,17 @@ class AccountNotifier extends StateNotifier<AccountState> {
     _userId = null;
     _supabaseLoaded = false;
     _prefs.clear();
+    // Reset in-memory state too: without this, widgets keep showing the
+    // previous user's coins/avatar/license until the next login loads.
+    state = AccountState(
+      currentPlayer: const Player(
+        id: '',
+        username: '',
+        level: 1,
+        xp: 0,
+        coins: 0,
+      ),
+    );
   }
 
   @override

--- a/lib/data/services/account_management_service.dart
+++ b/lib/data/services/account_management_service.dart
@@ -261,6 +261,19 @@ class AccountManagementService {
       await _client.from('user_settings').delete().eq('user_id', userId);
       logStep('user_settings');
 
+      // 5b. IAP receipts — best-effort: the schema now cascades on auth
+      // deletion, but live databases created before that change would hit
+      // an FK violation at step 7 without this. RLS may deny the delete
+      // for older rows; that's fine once the cascade exists.
+      try {
+        await _client.from('iap_receipts').delete().eq('user_id', userId);
+        logStep('iap_receipts');
+      } catch (e) {
+        debugPrint(
+          '[AccountManagementService] iap_receipts delete skipped: $e',
+        );
+      }
+
       // 6. Profile (last, since other tables may reference it).
       await _client.from('profiles').delete().eq('id', userId);
       logStep('profiles');

--- a/lib/data/services/feature_flag_service.dart
+++ b/lib/data/services/feature_flag_service.dart
@@ -15,10 +15,24 @@ class FeatureFlagService {
   Map<String, bool>? _cache;
   DateTime? _cacheTime;
 
-  /// Whether a flag is enabled. Defaults to `false` if unknown (fail-closed).
+  /// Server-side defaults (mirrors the seeded `feature_flags` rows). Used
+  /// when a flag can't be fetched AND has no local cache — e.g. the very
+  /// first launch offline. Failing closed there would silently hide Shop,
+  /// Leaderboard, Matchmaking, and Daily Scramble on a fresh install.
+  static const Map<String, bool> _defaults = {
+    'shop_enabled': true,
+    'leaderboard_enabled': true,
+    'matchmaking_enabled': true,
+    'daily_scramble_enabled': true,
+    'gifting_enabled': true,
+  };
+
+  /// Whether a flag is enabled. Falls back to the known server default
+  /// (or `false` for unknown flags) when neither the server nor a local
+  /// cache has an answer.
   Future<bool> isEnabled(String flagKey) async {
     final flags = await fetchAll();
-    return flags[flagKey] ?? false;
+    return flags[flagKey] ?? _defaults[flagKey] ?? false;
   }
 
   /// Fetch all flags as a key→bool map.

--- a/lib/data/services/leaderboard_service.dart
+++ b/lib/data/services/leaderboard_service.dart
@@ -561,7 +561,13 @@ class LeaderboardService {
       case LeaderboardMode.flightBriefing:
         return query.eq('region', 'briefing');
       case LeaderboardMode.trainingFlight:
-        return query.neq('region', 'daily').neq('region', 'briefing');
+        // Exclude every daily/quiz region so those runs don't pollute the
+        // flight boards ('daily_triangulation' rows are recorded for
+        // history/anti-cheat; they get their own board when one ships).
+        return query
+            .neq('region', 'daily')
+            .neq('region', 'briefing')
+            .neq('region', 'daily_triangulation');
     }
   }
 
@@ -602,7 +608,10 @@ class LeaderboardService {
           filtered = query.eq('region', 'briefing');
           break;
         case LeaderboardMode.trainingFlight:
-          filtered = query.neq('region', 'daily').neq('region', 'briefing');
+          filtered = query
+              .neq('region', 'daily')
+              .neq('region', 'briefing')
+              .neq('region', 'daily_triangulation');
           break;
       }
 

--- a/lib/data/services/user_preferences_service.dart
+++ b/lib/data/services/user_preferences_service.dart
@@ -5,6 +5,8 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../../core/services/error_service.dart';
+
 import '../../game/quiz/flight_school_level.dart';
 import '../../game/quiz/uncharted_progress.dart';
 import '../../game/tutorial/campaign_mission.dart';
@@ -111,20 +113,29 @@ class _PendingWriteQueue {
 
   /// Increment the retry counter on the oldest entry and re-persist.
   ///
-  /// If the entry has reached [_kMaxRetries] it is dropped instead.
+  /// If the entry has reached [_kMaxRetries] it is dropped instead —
+  /// with telemetry, because a dropped entry is silently lost data (a
+  /// game score, a coin-audit row). Retried entries rotate to the back
+  /// of the queue so one poisoned write can't head-block every other
+  /// queued write across drain cycles.
   Future<void> incrementRetryOrDrop() async {
     final entries = _loadAll();
     if (entries.isEmpty) return;
-    final head = entries.first;
+    final head = entries.removeAt(0);
     final retries = (head['retries'] as int? ?? 0) + 1;
     if (retries >= _kMaxRetries) {
-      entries.removeAt(0);
       debugPrint(
         '[PendingWriteQueue] dropped entry after $_kMaxRetries '
         'retries: table=${head['table']}',
       );
+      ErrorService.instance.reportWarning(
+        'Pending write dropped after $_kMaxRetries retries '
+        '(table=${head['table']}, op=${head['op']}) — data lost',
+        StackTrace.current,
+        context: {'source': 'PendingWriteQueue'},
+      );
     } else {
-      entries[0] = {...head, 'retries': retries};
+      entries.add({...head, 'retries': retries});
     }
     await _persist(entries);
   }

--- a/lib/features/admin/admin_screen.dart
+++ b/lib/features/admin/admin_screen.dart
@@ -1042,10 +1042,14 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
                         final username = usernameCtl.text.trim();
                         if (username.isNotEmpty) {
                           Navigator.of(dialogCtx).pop();
-                          // TODO: Send via backend API when cosmetics table exists
+                          // No admin grant RPC exists yet (gift_cosmetic
+                          // charges the gifter, which is wrong for an admin
+                          // grant) — say so instead of faking success.
                           _snack(
                             context,
-                            '${items[selectedItemId]} gifted to @$username',
+                            'Cosmetic gifting is not wired to the backend '
+                            'yet — nothing was granted.',
+                            isError: true,
                           );
                         }
                       },
@@ -1063,7 +1067,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
           ),
         ),
       ),
-    );
+    ).then((_) => usernameCtl.dispose());
   }
 
   // ── Manage Moderators ──
@@ -1761,6 +1765,9 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
     final scrambleCtl = TextEditingController(
       text: '${config.earnings.dailyScrambleBaseReward}',
     );
+    final triangulationCtl = TextEditingController(
+      text: '${config.earnings.dailyTriangulationBaseReward}',
+    );
     final perClueCtl = TextEditingController(
       text: '${config.earnings.freeFlightPerClueReward}',
     );
@@ -1793,6 +1800,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
           onCancel: () => Navigator.of(dialogCtx).pop(),
           onAction: () async {
             final scramble = int.tryParse(scrambleCtl.text.trim());
+            final triangulation = int.tryParse(triangulationCtl.text.trim());
             final perClue = int.tryParse(perClueCtl.text.trim());
             final cap = int.tryParse(dailyCapCtl.text.trim());
             final campaign = int.tryParse(campaignCtl.text.trim());
@@ -1804,6 +1812,12 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
             if (scramble == null || scramble < 0) {
               setDialogState(
                 () => error = 'Daily Scramble Reward must be >= 0',
+              );
+              return;
+            }
+            if (triangulation == null || triangulation < 0) {
+              setDialogState(
+                () => error = 'Daily Triangulation Reward must be >= 0',
               );
               return;
             }
@@ -1842,6 +1856,7 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
               final updated = EconomyConfig(
                 earnings: EarningsConfig(
                   dailyScrambleBaseReward: scramble,
+                  dailyTriangulationBaseReward: triangulation,
                   freeFlightPerClueReward: perClue,
                   freeFlightDailyCap: cap,
                   campaignMissionReward: campaign,
@@ -1869,6 +1884,11 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
             ),
             const SizedBox(height: 10),
             _AdminTextField(
+              controller: triangulationCtl,
+              label: 'Daily Triangulation Base Reward',
+            ),
+            const SizedBox(height: 10),
+            _AdminTextField(
               controller: perClueCtl,
               label: 'Free Flight Per-Clue Reward',
             ),
@@ -1880,19 +1900,23 @@ class _AdminScreenState extends ConsumerState<AdminScreen> {
             const SizedBox(height: 16),
             const Divider(color: FlitColors.cardBorder),
             const SizedBox(height: 8),
+            // These three are stored but not yet read by gameplay
+            // (campaign uses per-mission rewards; regular flights and
+            // Flight School compute rewards internally). Labelled so
+            // admins aren't editing dead knobs unknowingly.
             _AdminTextField(
               controller: campaignCtl,
-              label: 'Campaign Mission Reward',
+              label: 'Campaign Mission Reward (not wired yet)',
             ),
             const SizedBox(height: 10),
             _AdminTextField(
               controller: gameCompCtl,
-              label: 'Game Completion Base Reward',
+              label: 'Game Completion Base Reward (not wired yet)',
             ),
             const SizedBox(height: 10),
             _AdminTextField(
               controller: flightSchoolCtl,
-              label: 'Flight School Reward',
+              label: 'Flight School Reward (not wired yet)',
             ),
           ],
         ),
@@ -4335,13 +4359,11 @@ class _AdminTextField extends StatelessWidget {
     required this.controller,
     required this.label,
     this.keyboardType = TextInputType.number,
-    this.hintText,
   });
 
   final TextEditingController controller;
   final String label;
   final TextInputType keyboardType;
-  final String? hintText;
 
   @override
   Widget build(BuildContext context) => Column(
@@ -4361,7 +4383,6 @@ class _AdminTextField extends StatelessWidget {
             keyboardType: keyboardType,
             style: const TextStyle(color: FlitColors.textPrimary),
             decoration: InputDecoration(
-              hintText: hintText,
               hintStyle: const TextStyle(color: FlitColors.textMuted),
               filled: true,
               fillColor: FlitColors.backgroundMid,

--- a/lib/features/admin/alias_admin_screen.dart
+++ b/lib/features/admin/alias_admin_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
-import '../../game/data/country_aliases.dart';
 import '../../game/map/country_data.dart';
 import '../../game/map/region.dart';
 import '../../game/quiz/alias_service.dart';
@@ -177,13 +176,13 @@ class _AliasAdminScreenState extends State<AliasAdminScreen> {
 
   Future<void> _removeAlias(_AliasEntry entry, String alias) async {
     await AliasService.instance.removeAlias(entry.normalizedName, alias);
-    setState(() {});
+    if (mounted) setState(() {});
   }
 
   Future<void> _restoreBaselineAlias(_AliasEntry entry, String alias) async {
     await AliasService.instance
         .restoreBaselineAlias(entry.normalizedName, alias);
-    setState(() {});
+    if (mounted) setState(() {});
   }
 
   @override

--- a/lib/features/admin/gold_management_screen.dart
+++ b/lib/features/admin/gold_management_screen.dart
@@ -309,11 +309,19 @@ class _GoldManagementScreenState extends State<GoldManagementScreen> {
 
     if (_economyConfig == null) return;
 
+    // Preserve the fields this screen doesn't edit — constructing a fresh
+    // EarningsConfig with only three values silently reset every other
+    // reward to its default on save.
+    final current = _economyConfig!.earnings;
     final updated = EconomyConfig(
       earnings: EarningsConfig(
         dailyScrambleBaseReward: daily,
         freeFlightPerClueReward: perClue,
         freeFlightDailyCap: cap,
+        dailyTriangulationBaseReward: current.dailyTriangulationBaseReward,
+        campaignMissionReward: current.campaignMissionReward,
+        gameCompletionBaseReward: current.gameCompletionBaseReward,
+        flightSchoolReward: current.flightSchoolReward,
       ),
       shopPriceOverrides: _economyConfig!.shopPriceOverrides,
       promotions: _economyConfig!.promotions,

--- a/lib/features/campaign/coach_overlay.dart
+++ b/lib/features/campaign/coach_overlay.dart
@@ -142,6 +142,14 @@ class CoachOverlayState extends State<CoachOverlay>
     if (!mounted) return;
     _lostHintCount++;
 
+    // First trip: play the mission's authored 'lost' tip if one exists —
+    // the coach's scripted encouragement. Later trips escalate to the
+    // hint-forcing nudges below.
+    if (_lostHintCount == 1 && showTip('lost')) {
+      startLostTimer();
+      return;
+    }
+
     // Always suggest using a hint and force them to press it.
     final coach = widget.mission.coach;
     final message = _lostSuggestion(coach);

--- a/lib/features/friends/friends_screen.dart
+++ b/lib/features/friends/friends_screen.dart
@@ -674,7 +674,7 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
           ),
         ),
       ),
-    );
+    ).then((_) => controller.dispose());
   }
 
   // ---------------------------------------------------------------------------
@@ -749,17 +749,20 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 20),
+              // Flit+ gifting has no purchase backend yet — never fake a
+              // successful purchase. Both options are honest placeholders
+              // until IAP + a subscription service exist.
               _GiftOption(
                 label: '1 Month',
                 price: '\$2.99',
                 onTap: () {
                   Navigator.of(dialogContext).pop();
                   ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
+                    const SnackBar(
                       content: Text(
-                        'Gifted 1 month of Flit+ to ${friend.name}!',
+                        'Flit+ gifting is coming soon — no purchase was made.',
                       ),
-                      backgroundColor: FlitColors.success,
+                      backgroundColor: FlitColors.warning,
                     ),
                   );
                 },
@@ -772,11 +775,11 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
                 onTap: () {
                   Navigator.of(dialogContext).pop();
                   ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
+                    const SnackBar(
                       content: Text(
-                        'Gifted 1 year of Flit+ to ${friend.name}!',
+                        'Flit+ gifting is coming soon — no purchase was made.',
                       ),
-                      backgroundColor: FlitColors.success,
+                      backgroundColor: FlitColors.warning,
                     ),
                   );
                 },

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/app_version.dart';
+import '../../core/services/audio_manager.dart';
+import '../../core/utils/haptics.dart';
 import '../../data/providers/account_provider.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../core/theme/flit_theme.dart';
@@ -379,6 +381,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   /// Close the bottom sheet and navigate to [destination].
   void _closeSheetAndNavigate(BuildContext sheetContext, Widget destination) {
+    AudioManager.instance.playSfx(SfxType.uiClick);
+    hapticLight();
     try {
       Navigator.of(sheetContext)
         ..pop()

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/services/audio_manager.dart';
+import '../../core/utils/haptics.dart';
 import '../../core/services/error_service.dart';
 import '../../core/services/game_settings.dart';
 import '../../core/theme/flit_colors.dart';
@@ -402,6 +403,11 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
         _isHighAltitude = isHigh;
         if (!isHigh) _descentMapMounted = true;
       });
+      // Descending far from the target is the "wrong region" moment —
+      // fire the mission-authored coach tip (campaign only; one-shot).
+      if (!isHigh && !_game.isNearTarget()) {
+        _coachOverlayKey.currentState?.showTip('wrongRegion');
+      }
     }
   }
 
@@ -413,6 +419,7 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
     // Deduct fuel for using a hint. If tank is empty, abort.
     if (!_game.useHintFuel()) return;
 
+    hapticLight();
     // Fire coach tip for first hint usage (campaign missions only).
     _coachOverlayKey.currentState?.showTip('firstHint');
     // Notify coach overlay that a hint was used (explains what it does).
@@ -1039,6 +1046,7 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
         );
     if (earned > 0) {
       _freeFlightCoinsEarned += earned;
+      AudioManager.instance.playSfx(SfxType.coinCollect);
     }
   }
 
@@ -1066,6 +1074,7 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
     }
     _cumulativeTime += _elapsed;
     AudioManager.instance.playSfx(SfxType.landingSuccess);
+    hapticSuccess();
 
     // Fire ink-burst success animation from the clue card area.
     final mq = MediaQuery.of(context);

--- a/lib/features/play/practice_screen.dart
+++ b/lib/features/play/practice_screen.dart
@@ -163,13 +163,18 @@ class _PracticeScreenState extends ConsumerState<PracticeScreen> {
     for (final type in _worldClueTypes) type: true,
   };
 
-  /// Correct-answer counts per clue type, sourced from player progress data.
-  ///
-  // TODO(progress): populate from real player progress provider once the
-  // clue-progress persistence layer is wired up (see account_provider).
-  final Map<ClueType, int> _clueProgress = {
-    for (final type in _worldClueTypes) type: 0,
-  };
+  /// Correct-answer counts per clue type, from the player's lifetime
+  /// stats (the same per-type counters that drive social titles).
+  Map<ClueType, int> get _clueProgress {
+    final p = ref.watch(accountProvider).currentPlayer;
+    return {
+      ClueType.flag: p.flagsCorrect,
+      ClueType.outline: p.outlinesCorrect,
+      ClueType.borders: p.bordersCorrect,
+      ClueType.capital: p.capitalsCorrect,
+      ClueType.stats: p.statsCorrect,
+    };
+  }
 
   // ---------------------------------------------------------------------------
   // Derived state

--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -191,10 +191,9 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
               ),
             ),
             TextButton(
-              onPressed: () {
+              onPressed: () async {
                 final filter = ProfanityFilter.instance;
                 final username = usernameController.text.trim();
-                var hasError = false;
 
                 // Validate username for profanity and format.
                 if (username.isNotEmpty &&
@@ -204,10 +203,38 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                         'Username contains inappropriate content or '
                         'invalid characters';
                   });
-                  hasError = true;
+                  return;
                 }
 
-                if (hasError) return;
+                // Check uniqueness before committing (same check as
+                // signup). Without this, the debounced profile upsert hits
+                // the UNIQUE index, retries forever, and the client shows
+                // a name the server never accepted.
+                if (username.isNotEmpty && username != currentPlayer.username) {
+                  setDialogState(() => usernameError = null);
+                  try {
+                    final existing = await Supabase.instance.client
+                        .from('profiles')
+                        .select('id')
+                        .eq('username', username)
+                        .neq('id', currentPlayer.id)
+                        .maybeSingle();
+                    if (existing != null) {
+                      setDialogState(() {
+                        usernameError = 'Username @$username is already taken';
+                      });
+                      return;
+                    }
+                  } catch (_) {
+                    setDialogState(() {
+                      usernameError =
+                          'Could not verify availability — check your '
+                          'connection and try again';
+                    });
+                    return;
+                  }
+                }
+                if (!dialogContext.mounted || !context.mounted) return;
 
                 // Update player via AccountProvider
                 ref.read(accountProvider.notifier).switchAccount(
@@ -237,7 +264,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           ],
         ),
       ),
-    );
+    ).then((_) => usernameController.dispose());
   }
 
   void _showNationalityPicker() {
@@ -468,7 +495,10 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           ],
         ),
       ),
-    );
+    ).then((_) {
+      newPasswordController.dispose();
+      confirmPasswordController.dispose();
+    });
   }
 
   void _signOut() {
@@ -524,11 +554,12 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
 
   void _exportData() {
     final player = ref.read(accountProvider).currentPlayer;
-    if (player.id.isEmpty || player.id == 'guest') {
+    // Guest mode no longer exists — an empty id means "not signed in".
+    if (player.id.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: const Text(
-            'Data export is not available for guest accounts',
+            'Sign in to export your data',
           ),
           backgroundColor: FlitColors.warning,
           behavior: SnackBarBehavior.floating,
@@ -551,11 +582,12 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
 
   void _deleteAccount() {
     final player = ref.read(accountProvider).currentPlayer;
-    if (player.id.isEmpty || player.id == 'guest') {
+    // Guest mode no longer exists — an empty id means "not signed in".
+    if (player.id.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: const Text(
-            'Account deletion is not available for guest accounts',
+            'Sign in to delete your account',
           ),
           backgroundColor: FlitColors.warning,
           behavior: SnackBarBehavior.floating,

--- a/lib/features/quiz/quiz_game_screen.dart
+++ b/lib/features/quiz/quiz_game_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/utils/haptics.dart';
 import '../../data/services/challenge_service.dart';
 import '../../game/quiz/quiz_category.dart';
 import '../../game/quiz/quiz_difficulty.dart';
@@ -79,7 +80,6 @@ class _QuizGameScreenState extends State<QuizGameScreen>
   late bool _showLabels;
 
   // Animation state
-  String? _lastWrongCode;
   String? _highlightCode;
   int? _lastPoints;
   bool _showPointsPopup = false;
@@ -174,13 +174,17 @@ class _QuizGameScreenState extends State<QuizGameScreen>
     final result = _session.submitAnswer(code);
     if (result == null) return;
 
+    if (result.correct) {
+      hapticMedium();
+    } else {
+      hapticLight();
+    }
     setState(() {
       if (result.correct) {
         _stateVisuals[code]?.status = StateVisualStatus.correct;
         _lastPoints = result.points;
         _showPointsPopup = true;
         _highlightCode = null;
-        _lastWrongCode = null;
 
         _pointsAnimController.forward(from: 0).then((_) {
           if (mounted) {
@@ -202,7 +206,6 @@ class _QuizGameScreenState extends State<QuizGameScreen>
         });
       } else {
         _stateVisuals[code]?.status = StateVisualStatus.wrong;
-        _lastWrongCode = code;
         _lastPoints = result.points;
         _showPointsPopup = true;
 

--- a/lib/features/quiz/quiz_setup_screen.dart
+++ b/lib/features/quiz/quiz_setup_screen.dart
@@ -568,7 +568,8 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      '${diff.maxHints} hints',
+                      // Hints are unlimited at every tier; each costs score.
+                      'Hints cost score',
                       style: TextStyle(
                         color: isSelected
                             ? FlitColors.textSecondary

--- a/lib/features/quiz/type_in_game_screen.dart
+++ b/lib/features/quiz/type_in_game_screen.dart
@@ -39,7 +39,6 @@ class _TypeInGameScreenState extends State<TypeInGameScreen>
     with TickerProviderStateMixin {
   late QuizSession _session;
   late List<String> _allAreaNames;
-  late Map<String, String> _nameToCode;
   Timer? _timer;
 
   final TextEditingController _textController = TextEditingController();
@@ -114,7 +113,6 @@ class _TypeInGameScreenState extends State<TypeInGameScreen>
 
     // Build area name lookup
     final areas = RegionalData.getAreas(widget.region);
-    _nameToCode = {for (final area in areas) area.name: area.code};
     _allAreaNames = areas.map((a) => a.name).toList()..sort();
 
     _session.start();

--- a/lib/features/shop/shop_screen.dart
+++ b/lib/features/shop/shop_screen.dart
@@ -2662,7 +2662,6 @@ class _CompanionPreviewPainter extends CustomPainter {
   void _paintCharizard(Canvas canvas, double flapOffset) {
     const s = 22.0;
     const deepOrange = Color(0xFFD85A10);
-    const brightOrange = Color(0xFFFF8833);
     const paleYellow = Color(0xFFFFE8A0);
     const tealWing = Color(0xFF1B8B7A);
     const darkTeal = Color(0xFF0E5E52);

--- a/lib/features/triangulation/daily_triangulation_screen.dart
+++ b/lib/features/triangulation/daily_triangulation_screen.dart
@@ -5,6 +5,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/daily_result.dart';
+import '../../data/models/economy_config.dart';
+import '../../data/services/economy_config_service.dart';
 import '../../game/clues/clue_types.dart';
 import '../../game/data/country_difficulty.dart';
 import '../../game/triangulation/daily_triangulation.dart';
@@ -26,12 +28,32 @@ class _DailyTriangulationScreenState extends State<DailyTriangulationScreen> {
   String? _completedShareText;
   int? _completedScore;
   bool _loading = true;
+  EconomyConfig? _economyConfig;
 
   @override
   void initState() {
     super.initState();
     _daily = DailyTriangulation.forToday();
     _loadResult();
+    _loadEconomyConfig();
+  }
+
+  Future<void> _loadEconomyConfig() async {
+    try {
+      final config = await EconomyConfigService.instance.getConfig();
+      if (!mounted) return;
+      setState(() => _economyConfig = config);
+    } catch (_) {
+      // Defaults apply — the reward pill just shows the default value.
+    }
+  }
+
+  /// Today's completion reward (base x promo multiplier).
+  int get _coinReward {
+    final config = _economyConfig ?? EconomyConfig.defaults();
+    return (config.earnings.dailyTriangulationBaseReward *
+            config.earningsMultiplier)
+        .round();
   }
 
   Future<void> _loadResult() async {
@@ -52,6 +74,7 @@ class _DailyTriangulationScreenState extends State<DailyTriangulationScreen> {
         builder: (_) => TriangulationGameScreen(
           config: _daily.toConfig(),
           daily: _daily,
+          coinReward: _coinReward,
         ),
       ),
     );
@@ -161,9 +184,20 @@ class _DailyTriangulationScreenState extends State<DailyTriangulationScreen> {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 10),
-            _DifficultyIndicator(
-              percent: _daily.difficultyPercent,
-              label: _daily.difficultyLabelText,
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _DifficultyIndicator(
+                  percent: _daily.difficultyPercent,
+                  label: _daily.difficultyLabelText,
+                ),
+                const SizedBox(width: 8),
+                _BriefChip(
+                  icon: Icons.monetization_on_rounded,
+                  label: '$_coinReward coins',
+                  color: FlitColors.gold,
+                ),
+              ],
             ),
             const SizedBox(height: 8),
             const Text(

--- a/lib/features/triangulation/triangulation_game_screen.dart
+++ b/lib/features/triangulation/triangulation_game_screen.dart
@@ -5,11 +5,14 @@ import 'package:flag/flag.dart';
 import 'package:flame/components.dart' show Vector2;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/utils/haptics.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/daily_result.dart';
+import '../../data/providers/account_provider.dart';
 import '../../game/map/country_data.dart';
 import '../../game/quiz/fuzzy_match.dart';
 import '../../game/triangulation/daily_triangulation.dart';
@@ -20,11 +23,12 @@ import 'widgets/triangulation_compass.dart';
 
 /// The Triangulation gameplay screen: compass + guess input, round results
 /// on a map, and a final summary with spoiler-free share text.
-class TriangulationGameScreen extends StatefulWidget {
+class TriangulationGameScreen extends ConsumerStatefulWidget {
   const TriangulationGameScreen({
     super.key,
     required this.config,
     this.daily,
+    this.coinReward = 0,
   });
 
   final TriangulationConfig config;
@@ -33,8 +37,11 @@ class TriangulationGameScreen extends StatefulWidget {
   /// header and records completion so the puzzle can't be replayed.
   final DailyTriangulation? daily;
 
+  /// Coins awarded for completing the daily (0 for free play).
+  final int coinReward;
+
   @override
-  State<TriangulationGameScreen> createState() =>
+  ConsumerState<TriangulationGameScreen> createState() =>
       _TriangulationGameScreenState();
 }
 
@@ -51,7 +58,8 @@ class _GuessCandidate {
   final bool viaCapital;
 }
 
-class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
+class _TriangulationGameScreenState
+    extends ConsumerState<TriangulationGameScreen> {
   late final TriangulationSession _session;
   late final FuzzyMatcher _countryMatcher;
   FuzzyMatcher? _capitalMatcher;
@@ -177,6 +185,11 @@ class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
       elapsedMs: _stopwatch.elapsedMilliseconds,
     );
     _inputController.clear();
+    if (guess.isCorrect) {
+      hapticSuccess();
+    } else {
+      hapticLight();
+    }
     setState(() {
       _feedback = guess.isCorrect
           ? null
@@ -219,6 +232,25 @@ class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
       'daily_triangulation_score_${daily.dateKey}',
       _session.totalScore,
     );
+    // Server-side parity with the other dailies: persist the score row
+    // (region 'daily_triangulation') and award the completion coins.
+    // Solving at least one round counts as completing the daily.
+    await ref.read(accountProvider.notifier).recordGameCompletion(
+          elapsed: Duration(milliseconds: _session.totalTimeMs),
+          score: _session.totalScore,
+          roundsCompleted: _session.solvedRounds,
+          coinReward: _session.solvedRounds > 0 ? widget.coinReward : 0,
+          region: 'daily_triangulation',
+          roundEmojis: _session.rounds
+              .map(
+                (r) =>
+                    r.wrongGuesses
+                        .map((g) => proximityEmoji(g.distanceKm))
+                        .join() +
+                    (r.solved ? '✅' : '❌'),
+              )
+              .join(' '),
+        );
   }
 
   String get _shareText => buildTriangulationShareText(
@@ -235,6 +267,7 @@ class _TriangulationGameScreenState extends State<TriangulationGameScreen> {
         shareText: _shareText,
         isDaily: widget.daily != null,
         isCapitalTarget: _isCapitalTarget,
+        coinsEarned: _session.solvedRounds > 0 ? widget.coinReward : 0,
       );
     } else if (_showingRoundResult) {
       body = _RoundResultView(
@@ -840,12 +873,14 @@ class _SummaryView extends StatelessWidget {
     required this.shareText,
     required this.isDaily,
     required this.isCapitalTarget,
+    this.coinsEarned = 0,
   });
 
   final TriangulationSession session;
   final String shareText;
   final bool isDaily;
   final bool isCapitalTarget;
+  final int coinsEarned;
 
   @override
   Widget build(BuildContext context) {
@@ -887,6 +922,28 @@ class _SummaryView extends StatelessWidget {
                     fontSize: 13,
                   ),
                 ),
+                if (coinsEarned > 0) ...[
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(
+                        Icons.monetization_on_rounded,
+                        color: FlitColors.gold,
+                        size: 18,
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        '+$coinsEarned coins',
+                        style: const TextStyle(
+                          color: FlitColors.gold,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
               ],
             ),
           ),

--- a/lib/game/data/country_difficulty.dart
+++ b/lib/game/data/country_difficulty.dart
@@ -441,10 +441,12 @@ const Map<String, double> _defaultCountryDifficulty = {
   'PW': 0.92, // Palau — Pacific (confusable)
   'KM': 0.92, // Comoros — Indian Ocean
   'ST': 0.93, // São Tomé and Príncipe — Gulf of Guinea
-  // Non-playable excluded: AI, AQ, AS, MS, NF, NU, PM, PN, SH, UM, VG, WF
+  'YE': 0.48, // Yemen — Arabian peninsula, often in the news
+  'AQ': 0.95, // Antarctica — playable oddity (McMurdo), maximum obscurity
+  // Non-playable excluded: AI, AS, MS, NF, NU, PM, PN, SH, UM, VG, WF
 
   // ── Regional / special codes ───────────────────────────────────────
-  'XC': 0.80, // Cocos (Keeling) Islands
+  'XC': 0.80, // Northern Cyprus — de facto state
   'XS': 0.85, // Somaliland
 };
 

--- a/lib/game/map/region.dart
+++ b/lib/game/map/region.dart
@@ -227,8 +227,13 @@ abstract class RegionalData {
   }
 
   static List<RegionalArea> _countriesForCodes(Set<String> codes) {
+    // Honour the global exclusion list: territories the world modes filter
+    // out (too obscure / flag renders as the parent country's) must not
+    // resurface as playable areas in regional quizzes either.
     return CountryData.countries
-        .where((c) => codes.contains(c.code))
+        .where((c) =>
+            codes.contains(c.code) &&
+            !CountryData.excludedTerritories.contains(c.code))
         .map(
           (c) => RegionalArea(
             code: c.code,

--- a/lib/game/quiz/quiz_difficulty.dart
+++ b/lib/game/quiz/quiz_difficulty.dart
@@ -19,13 +19,15 @@ extension QuizDifficultyExtension on QuizDifficulty {
   }
 
   String get description {
+    // Hints are unlimited at every tier (using one costs score), so the
+    // copy must not promise hint limits that don't exist.
     switch (this) {
       case QuizDifficulty.easy:
-        return 'Labels shown, easier clues, hints available';
+        return 'Labels shown, easier clues';
       case QuizDifficulty.medium:
-        return 'No labels, all clue types, fewer hints';
+        return 'No labels, all clue types';
       case QuizDifficulty.hard:
-        return 'No labels, hardest clues only, no hints';
+        return 'No labels, hardest clues only';
     }
   }
 
@@ -37,19 +39,6 @@ extension QuizDifficultyExtension on QuizDifficulty {
       case QuizDifficulty.medium:
       case QuizDifficulty.hard:
         return false;
-    }
-  }
-
-  /// Maximum hints allowed per quiz session.
-  /// All difficulties now allow unlimited hints (score penalty increases).
-  int get maxHints {
-    switch (this) {
-      case QuizDifficulty.easy:
-        return 999;
-      case QuizDifficulty.medium:
-        return 999;
-      case QuizDifficulty.hard:
-        return 999;
     }
   }
 

--- a/lib/game/quiz/uncharted_session.dart
+++ b/lib/game/quiz/uncharted_session.dart
@@ -200,11 +200,11 @@ class UnchartedSession {
     // Only score areas the player actually guessed, not force-revealed ones.
     final basePoints = _guessedCodes.length * 100;
 
-    // Time bonus: up to 1.5x for under 2 minutes, decays to 1.0x over 10 min.
+    // Time bonus: 1.5x at 0s decaying linearly to 1.0x at 10 minutes.
+    // One continuous curve — the old flat-1.5x-under-2-minutes rule
+    // created a score cliff (1.5x → 1.4x) at exactly 120s.
     final seconds = elapsedMs / 1000.0;
-    final timeMult = seconds < 120.0
-        ? 1.5
-        : (1.0 + 0.5 * (1.0 - (seconds / 600.0)).clamp(0, 1));
+    final timeMult = 1.0 + 0.5 * (1.0 - (seconds / 600.0)).clamp(0, 1);
 
     // Completion bonus: 2000 extra points for completing all areas.
     final completionBonus =

--- a/lib/game/rendering/plane_renderer.dart
+++ b/lib/game/rendering/plane_renderer.dart
@@ -83,8 +83,6 @@ class PlaneRenderer {
     Canvas canvas,
     Color baseColor, {
     double strokeWidth = 1.1,
-    double offsetX = 0.3,
-    double offsetY = 0.3,
     double opacity = 0.55,
   }) {
     WatercolorStyle.wetEdge(
@@ -141,11 +139,6 @@ class PlaneRenderer {
     String seed = '',
   }) {
     WatercolorStyle.washFill(canvas, path, color, seed: seed);
-  }
-
-  /// Draw a soft watercolour shadow under a shape.
-  static void _softShadow(Canvas canvas, Path path) {
-    WatercolorStyle.softShadow(canvas, path);
   }
 
   /// Draws a soft ambient-occlusion shadow where a wing meets the fuselage.

--- a/lib/game/session/game_session.dart
+++ b/lib/game/session/game_session.dart
@@ -93,7 +93,9 @@ class GameSession {
       hintPenalty += hintTierPenalties[i];
     }
     final int timeDeduction = _useTimeScoring ? timePenalty : 0;
-    return max(0, base + fuelBonus - hintPenalty - timeDeduction);
+    // Enforce the documented [0, 10000] invariant explicitly so a future
+    // constant change (e.g. a bigger fuel bonus) can't silently break it.
+    return (base + fuelBonus - hintPenalty - timeDeduction).clamp(0, 10000);
   }
 
   /// Final score for this round, with difficulty multiplier applied.

--- a/lib/game/triangulation/triangulation_target.dart
+++ b/lib/game/triangulation/triangulation_target.dart
@@ -155,6 +155,15 @@ class TriangulationRound {
     var targetPool = _targetPool(difficulty)
         .where((c) => !excludedTargetCodes.contains(c.code))
         .toList();
+    if (targetPool.isEmpty) {
+      // Difficulty pool exhausted: widen to all eligible countries but
+      // keep honouring the exclusion set — targets must never repeat
+      // within a game. Only if even that is empty (absurdly long games)
+      // does reuse become allowed.
+      targetPool = _eligibleCountries()
+          .where((c) => !excludedTargetCodes.contains(c.code))
+          .toList();
+    }
     if (targetPool.isEmpty) targetPool = _eligibleCountries();
     final target = targetPool[rng.nextInt(targetPool.length)];
     final targetCapital = CountryData.getCapital(target.code)!;

--- a/lib/game/tutorial/campaign_mission.dart
+++ b/lib/game/tutorial/campaign_mission.dart
@@ -10,7 +10,8 @@ class CoachTip {
 
   /// When this tip should appear.
   /// Supported triggers: 'firstClue', 'firstHint', 'fuelLow', 'fuelEmpty',
-  /// 'halfwayDone', 'correctAnswer', 'wrongRegion'.
+  /// 'halfwayDone', 'correctAnswer', 'wrongRegion' (descending far from
+  /// the target), 'lost' (first idle/lost-timer trip).
   final String trigger;
 
   /// The coach's dialogue text.

--- a/lib/game/ui/game_hud.dart
+++ b/lib/game/ui/game_hud.dart
@@ -5,6 +5,7 @@ import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/country_outline_painter.dart';
 import '../clues/clue_types.dart';
 import '../flit_game.dart';
 import '../session/game_session.dart';
@@ -867,82 +868,23 @@ class _CountryOutline extends StatelessWidget {
     if (polygons.isEmpty) {
       return const Text('🗺️', style: TextStyle(fontSize: 48));
     }
+    // Shared painter: its shouldRepaint compares polygon data, so the
+    // silhouette updates when the clue changes (the old private copy
+    // returned false unconditionally and could show a stale country).
     return SizedBox(
       height: 80,
       width: double.infinity,
-      child: CustomPaint(painter: _CountryOutlinePainter(polygons)),
+      child: CustomPaint(
+        painter: CountryOutlinePainter(
+          polygons,
+          fillColor: FlitColors.landMass.withOpacity(0.5),
+          strokeColor: FlitColors.accent,
+          strokeWidth: 1.5,
+          padding: 4.0,
+        ),
+      ),
     );
   }
-}
-
-class _CountryOutlinePainter extends CustomPainter {
-  _CountryOutlinePainter(this.polygons);
-
-  final List<List<Vector2>> polygons;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    if (polygons.isEmpty || size.isEmpty) return;
-
-    // Find bounding box across ALL polygons
-    final firstPt = polygons.first.first;
-    var minX = firstPt.x;
-    var maxX = firstPt.x;
-    var minY = firstPt.y;
-    var maxY = firstPt.y;
-    for (final poly in polygons) {
-      for (final p in poly) {
-        minX = math.min(minX, p.x);
-        maxX = math.max(maxX, p.x);
-        minY = math.min(minY, p.y);
-        maxY = math.max(maxY, p.y);
-      }
-    }
-
-    final rangeX = maxX - minX;
-    final rangeY = maxY - minY;
-    if (rangeX == 0 || rangeY == 0) return;
-
-    // Scale to fit within the available size with padding
-    const padding = 4.0;
-    final drawW = size.width - padding * 2;
-    final drawH = size.height - padding * 2;
-    final scale = math.min(drawW / rangeX, drawH / rangeY);
-    final offsetX = padding + (drawW - rangeX * scale) / 2;
-    final offsetY = padding + (drawH - rangeY * scale) / 2;
-
-    final path = Path();
-    for (final poly in polygons) {
-      for (var i = 0; i < poly.length; i++) {
-        final x = offsetX + (poly[i].x - minX) * scale;
-        // Flip Y: higher latitude = higher on screen
-        final y = offsetY + (maxY - poly[i].y) * scale;
-        if (i == 0) {
-          path.moveTo(x, y);
-        } else {
-          path.lineTo(x, y);
-        }
-      }
-      path.close();
-    }
-
-    // Filled silhouette
-    canvas.drawPath(
-      path,
-      Paint()..color = FlitColors.landMass.withOpacity(0.5),
-    );
-    // Border stroke
-    canvas.drawPath(
-      path,
-      Paint()
-        ..color = FlitColors.accent
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 1.5,
-    );
-  }
-
-  @override
-  bool shouldRepaint(covariant _CountryOutlinePainter oldDelegate) => false;
 }
 
 /// Horizontal fuel gauge bar displayed above the bottom controls.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,7 @@ bool _isNonFatalError(Object error) {
   // 'e.toString')".
   final dynamic e = error;
   if (e == null) return false;
-  final msg = e.toString() as String;
+  final msg = e.toString();
   return msg.contains('Invalid SVG') ||
       msg.contains('invalid svg') ||
       msg.contains('SVG data') ||
@@ -50,7 +50,7 @@ String _safeErrorString(Object error) {
   final dynamic e = error;
   if (e == null) return 'Unknown error (null)';
   try {
-    return e.toString() as String;
+    return e.toString();
   } catch (_) {
     return 'Error (toString failed)';
   }

--- a/supabase/rebuild.sql
+++ b/supabase/rebuild.sql
@@ -2495,7 +2495,9 @@ $$;
 
 CREATE TABLE IF NOT EXISTS public.iap_receipts (
   id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-  user_id UUID NOT NULL REFERENCES auth.users(id),
+  -- ON DELETE CASCADE so GDPR account deletion can remove auth.users
+  -- without an FK violation once IAP starts writing receipts.
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   product_id TEXT NOT NULL,
   platform TEXT NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
   receipt_data TEXT,

--- a/test/unit/core/services/audio_manager_test.dart
+++ b/test/unit/core/services/audio_manager_test.dart
@@ -69,8 +69,10 @@ void main() {
   });
 
   group('SfxType', () {
-    test('has 6 values', () {
-      expect(SfxType.values, hasLength(6));
+    test(
+        'lists only playable effects (boostStart removed with no boost '
+        'mechanic)', () {
+      expect(SfxType.values, hasLength(5));
     });
   });
 }

--- a/test/unit/data/models/app_remote_config_test.dart
+++ b/test/unit/data/models/app_remote_config_test.dart
@@ -20,13 +20,6 @@ Map<String, dynamic> _maintenanceConfigJson() => {
       'maintenance_message': 'Back soon — deploying hotfix.',
     };
 
-Map<String, dynamic> _gatedConfigJson() => {
-      'min_app_version': 'v1.50',
-      'recommended_version': 'v1.200',
-      'maintenance_mode': false,
-      'maintenance_message': null,
-    };
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes everything actionable from the deep functionality/coherence audit (3 parallel audit agents + mechanical sweep). 42 files changed.

### 🔴 Broken flows fixed
- **Fake gift flows**: "Gift Flit+" (friends) and admin "Gift Cosmetic" showed success toasts while doing nothing. Both now honestly report the backend isn't wired — no false purchase/grant confirmations. (Real wiring needs IAP/subscriptions and an admin-grant RPC — the existing `gift_cosmetic` RPC charges the gifter, wrong semantics for admin grants.)
- **Username collision desync**: profile edits now check uniqueness server-side (same check as signup) before committing; collisions show an inline error instead of an optimistic success + forever-failing queued upsert.
- **Stale outline clue**: the HUD's private painter had `shouldRepaint => false`; replaced with the shared `CountryOutlinePainter` (repaints on data change).
- **Sign-out**: `clearPreferences` now resets in-memory account state, closing the stale-coins/avatar window.
- **Offline first launch**: feature flags fall back to known server defaults when there's no cache — Shop/Leaderboard/Matchmaking/Daily Scramble no longer vanish.
- **"999 hints"** on quiz difficulty removed; copy now reflects the real rule (hints unlimited, each costs score). `maxHints` deleted.
- **Triangulation** target fallback keeps honouring exclusions when a difficulty pool runs dry.

### 🟡 Unfinished features wired
- **Daily Triangulation economy/leaderboard parity**: new admin-editable `dailyTriangulationBaseReward` (default 150), coins awarded on completion (any round solved), score rows persisted server-side with region `daily_triangulation` (excluded from flight leaderboards), reward shown in lobby and summary.
- **Campaign coach tips**: `lost` fires on the first lost-timer trip and `wrongRegion` when descending far from the target — ~26 authored dialogue lines are now reachable.
- **Haptics** exist now (`core/utils/haptics.dart`, gated by the existing toggle): landing success, hint use, triangulation guesses, quiz answers.
- **SFX**: `coinCollect` and `uiClick` wired; `boostStart` removed (no boost mechanic exists; the asset stays for when one does).
- **Practice screen** progress cards read real per-clue-type lifetime stats instead of hardcoded zeros.
- **Notifications toggle removed** (nothing consumed it); setting stays persisted for when notifications ship.
- **Admin economy dialog**: the three knobs gameplay doesn't read are labelled "(not wired yet)"; **Gold Management save no longer silently resets unedited earnings fields to defaults** (bonus bug found during wiring).

### 🟠 Coherence / infra
- `fetch-errors.yml` fetches **all severities** before purging the log (was permanently destroying error/warning telemetry) and labels issues by actual severity.
- Removed the dead CI version-bump sed (targeted a refactored-away string).
- Offline write queue: dropped entries now report to telemetry; failing entries rotate to the back (no head-of-line blocking).
- `ErrorService.flush` removes the sent batch by prefix count, not object identity.
- `iap_receipts` gains `ON DELETE CASCADE` in the schema + a best-effort delete in the GDPR flow (pre-empts undeletable accounts once IAP ships). *Note: existing live DBs need the one-line `ALTER TABLE` migration.*
- Serverless functions read `SUPABASE_URL`/`SUPABASE_ANON_KEY` from env first; dead `activePlayers7d` removed.
- Regional quizzes honour `excludedTerritories`; YE/AQ get curated difficulty ratings (and the mislabelled XC comment fixed); Uncharted's time bonus is one continuous curve (no 120s cliff); `rawScore` enforces its documented clamp; vestigial guest-mode checks removed; dialog `TextEditingController`s disposed; `mounted` guards added in admin paths.
- **All 12 analyzer warnings cleared** — the tree is now 0 errors / 0 warnings.

### Deliberately NOT changed (product decisions, called out in the audit)
- Region unlocks ("Coming Soon") and the Gold Shop IAP stub — both are honest placeholders requiring store/product work.
- `ShaderLODManager` remains unwired — connecting it changes visual quality dynamics and needs on-device profiling.
- The hardcoded owner email in the DB signup trigger (needs a config-table migration).

## Testing
- Full suite **844/844 green** (audio enum test updated; goldens regenerated after the difficulty-rating change shifted the fixture's anchor pool)
- `flutter analyze`: **0 errors, 0 warnings**
- `dart format` applied repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_