### PR TITLE
Triangulation: distance hint button + free distances on every guess

### DIFF
--- a/lib/features/triangulation/triangulation_game_screen.dart
+++ b/lib/features/triangulation/triangulation_game_screen.dart
@@ -17,6 +17,7 @@ import '../../game/map/country_data.dart';
 import '../../game/quiz/fuzzy_match.dart';
 import '../../game/triangulation/daily_triangulation.dart';
 import '../../game/triangulation/triangulation_session.dart';
+import '../../game/triangulation/triangulation_scoring.dart';
 import '../../game/triangulation/triangulation_share.dart';
 import '../../game/triangulation/triangulation_target.dart';
 import 'widgets/triangulation_compass.dart';
@@ -177,6 +178,14 @@ class _TriangulationGameScreenState
     _submitCandidate(chosen);
   }
 
+  void _useDistanceHint() {
+    if (_session.currentRound.isOver || _session.currentRound.hintUsed) {
+      return;
+    }
+    hapticLight();
+    setState(() => _session.useDistanceHint());
+  }
+
   void _submitCandidate(_GuessCandidate candidate) {
     if (_session.currentRound.isOver) return;
     final guess = _session.submitGuess(
@@ -320,6 +329,7 @@ class _TriangulationGameScreenState
                   clueTypes: widget.config.clueTypes,
                   labelTypes: widget.config.labelTypes,
                   centerLabel: _isCapitalTarget ? 'CAPITAL' : 'COUNTRY',
+                  showClueDistances: state.hintUsed,
                 ),
                 const SizedBox(height: 4),
                 Text(
@@ -331,6 +341,36 @@ class _TriangulationGameScreenState
                     fontSize: 11,
                   ),
                 ),
+                const SizedBox(height: 8),
+                if (!state.hintUsed)
+                  OutlinedButton.icon(
+                    onPressed: _useDistanceHint,
+                    icon: const Icon(
+                      Icons.straighten_rounded,
+                      size: 16,
+                      color: FlitColors.gold,
+                    ),
+                    label: Text(
+                      'Reveal clue distances  −${triDistanceHintPenalty} pts',
+                      style: const TextStyle(
+                        color: FlitColors.gold,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    style: OutlinedButton.styleFrom(
+                      side: BorderSide(
+                        color: FlitColors.gold.withOpacity(0.5),
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 6,
+                      ),
+                    ),
+                  ),
               ],
             ),
           ),
@@ -710,6 +750,17 @@ class _RoundResultView extends StatelessWidget {
                     child: Text(
                       'Solved by country name (×0.7)',
                       style: TextStyle(
+                        color: FlitColors.textMuted,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                if (state.hintUsed)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      'Distance hint used (−$triDistanceHintPenalty)',
+                      style: const TextStyle(
                         color: FlitColors.textMuted,
                         fontSize: 12,
                       ),

--- a/lib/features/triangulation/widgets/triangulation_compass.dart
+++ b/lib/features/triangulation/widgets/triangulation_compass.dart
@@ -30,6 +30,7 @@ class TriangulationCompass extends StatelessWidget {
     required this.clueTypes,
     required this.labelTypes,
     this.centerLabel = 'CAPITAL',
+    this.showClueDistances = false,
   });
 
   final List<TriangulationClue> clues;
@@ -37,6 +38,11 @@ class TriangulationCompass extends StatelessWidget {
   final Set<ClueType> clueTypes;
   final Set<TriLabel> labelTypes;
   final String centerLabel;
+
+  /// When true (the distance hint was bought), each starting clue's box
+  /// also shows its distance from the hidden target. Wrong-guess markers
+  /// always show their distance — that feedback is free.
+  final bool showClueDistances;
 
   static const double _circleFraction = 0.15;
   static const double _arrowEndFraction = 0.28;
@@ -221,6 +227,9 @@ class TriangulationCompass extends StatelessWidget {
         );
       }
     }
+    if (showClueDistances) {
+      lines.add(formatKmAway(clue.distanceFromTargetKm));
+    }
 
     return _MarkerContent(
       bearingDeg: clue.bearingFromTargetDeg,
@@ -232,8 +241,7 @@ class TriangulationCompass extends StatelessWidget {
     );
   }
 
-  /// Wrong guess: red-tinted, flag + guessed name only (no distance —
-  /// bearing plus distance would give the answer away).
+  /// Wrong guess: red-tinted, flag + guessed name + free distance.
   _MarkerContent _guessContent(TriangulationGuess guess) => _MarkerContent(
         bearingDeg: guess.bearingFromTargetDeg,
         isGuess: true,
@@ -245,6 +253,9 @@ class TriangulationCompass extends StatelessWidget {
             guess.capitalName
           else
             guess.countryName,
+          // Distance feedback is free on every guess — combined with the
+          // bearing it's the core triangulation feedback loop.
+          formatKmAway(guess.distanceKm),
         ],
       );
 
@@ -514,4 +525,16 @@ class _MarkerFlag extends StatelessWidget {
         : code;
     return Text(emoji, style: const TextStyle(fontSize: 16));
   }
+}
+
+/// '1,234 km away' formatting shared by clue and guess markers.
+String formatKmAway(double km) {
+  final rounded = km.round().toString();
+  final buf = StringBuffer();
+  for (var i = 0; i < rounded.length; i++) {
+    final fromEnd = rounded.length - i;
+    buf.write(rounded[i]);
+    if (fromEnd > 1 && fromEnd % 3 == 1) buf.write(',');
+  }
+  return '$buf km away';
 }

--- a/lib/game/triangulation/triangulation_scoring.dart
+++ b/lib/game/triangulation/triangulation_scoring.dart
@@ -29,6 +29,11 @@ const int triWrongGuessDistanceMax = 2300;
 /// instead of the capital.
 const double triCountryAnswerMultiplier = 0.7;
 
+/// Cost of the one distance hint per round (reveals how far each starting
+/// clue is from the hidden target). Wrong-guess distances are always shown
+/// free — only the up-front reveal of the original clues costs score.
+const int triDistanceHintPenalty = 1000;
+
 /// Penalty for one wrong guess, based on how far the guessed capital is
 /// from the target capital. Direct neighbours are softened by half.
 int triProximityPenalty(double distanceKm, {bool isNeighbor = false}) {
@@ -50,7 +55,7 @@ int triTimePenalty(int timeMs) {
 /// Final round score.
 ///
 /// Expired (unsolved) rounds score 0. Otherwise:
-///   raw   = base − timePenalty − Σ proximityPenalties
+///   raw   = base − timePenalty − Σ proximityPenalties − hint
 ///   score = raw × difficultyMultiplier(target) × (0.7 if solved by country)
 int computeTriangulationScore({
   required bool solved,
@@ -58,10 +63,13 @@ int computeTriangulationScore({
   required int timeMs,
   required List<int> wrongGuessPenalties,
   required String targetCountryCode,
+  bool hintUsed = false,
 }) {
   if (!solved) return 0;
   final proximityTotal = wrongGuessPenalties.fold<int>(0, (sum, p) => sum + p);
-  final raw = triBaseScore - triTimePenalty(timeMs) - proximityTotal;
+  final hintPenalty = hintUsed ? triDistanceHintPenalty : 0;
+  final raw =
+      triBaseScore - triTimePenalty(timeMs) - proximityTotal - hintPenalty;
   if (raw <= 0) return 0;
   var score = raw * difficultyMultiplier(targetCountryCode);
   if (solvedAsCountry) score *= triCountryAnswerMultiplier;

--- a/lib/game/triangulation/triangulation_session.dart
+++ b/lib/game/triangulation/triangulation_session.dart
@@ -93,6 +93,10 @@ class TriangulationRoundState {
   final List<TriangulationGuess> guesses = [];
   bool solved = false;
   bool expired = false;
+
+  /// Whether the distance hint (reveal clue distances) was bought this
+  /// round. Costs [triDistanceHintPenalty] at scoring time.
+  bool hintUsed = false;
   int elapsedMs = 0;
   int score = 0;
 
@@ -142,6 +146,14 @@ class TriangulationSession {
 
   int get guessesRemaining =>
       config.guessesPerRound - currentRound.guesses.length;
+
+  /// Buy the distance hint for the current round: the compass reveals how
+  /// far each starting clue is from the hidden target. One per round;
+  /// charged in scoring. Wrong-guess distances are always free.
+  void useDistanceHint() {
+    if (currentRound.isOver) return;
+    currentRound.hintUsed = true;
+  }
 
   /// Submit a guess for the current round. [countryCode] must be an ISO
   /// code resolved by the input matcher; [viaCapital] records whether the
@@ -204,6 +216,7 @@ class TriangulationSession {
         timeMs: state.elapsedMs,
         wrongGuessPenalties: state.wrongGuesses.map((g) => g.penalty).toList(),
         targetCountryCode: round.targetCountryCode,
+        hintUsed: state.hintUsed,
       );
     }
     return guess;

--- a/test/unit/game/triangulation/triangulation_test.dart
+++ b/test/unit/game/triangulation/triangulation_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flit/core/services/game_settings.dart';
 import 'package:flit/core/utils/math_utils.dart';
 import 'package:flit/game/clues/clue_types.dart';
+import 'package:flit/game/data/country_difficulty.dart';
 import 'package:flit/game/map/country_data.dart';
 import 'package:flit/game/triangulation/daily_triangulation.dart';
 import 'package:flit/game/triangulation/triangulation_scoring.dart';
@@ -303,6 +304,29 @@ void main() {
       expect(viaCountry, (viaCapital * 0.7).round());
     });
 
+    test('distance hint costs exactly its penalty', () {
+      final without = computeTriangulationScore(
+        solved: true,
+        solvedAsCountry: false,
+        timeMs: 5000,
+        wrongGuessPenalties: const [],
+        targetCountryCode: 'FR',
+      );
+      final withHint = computeTriangulationScore(
+        solved: true,
+        solvedAsCountry: false,
+        timeMs: 5000,
+        wrongGuessPenalties: const [],
+        targetCountryCode: 'FR',
+        hintUsed: true,
+      );
+      expect(withHint, lessThan(without));
+      expect(
+        without - withHint,
+        (triDistanceHintPenalty * difficultyMultiplier('FR')).round(),
+      );
+    });
+
     test('expired round scores 0', () {
       final score = computeTriangulationScore(
         solved: false,
@@ -371,6 +395,32 @@ void main() {
       );
       expect(countryGame.currentRound.score, capitalGame.currentRound.score);
       expect(countryGame.currentRound.score, greaterThan(0));
+    });
+
+    test('distance hint is per-round state and charged in scoring', () {
+      final session = TriangulationSession(
+        const TriangulationConfig(seed: 99, rounds: 1),
+      );
+      expect(session.currentRound.hintUsed, isFalse);
+      session.useDistanceHint();
+      expect(session.currentRound.hintUsed, isTrue);
+      session.submitGuess(
+        session.currentRound.round.targetCountryCode,
+        viaCapital: true,
+        elapsedMs: 4000,
+      );
+      final noHint = TriangulationSession(
+        const TriangulationConfig(seed: 99, rounds: 1),
+      );
+      noHint.submitGuess(
+        noHint.currentRound.round.targetCountryCode,
+        viaCapital: true,
+        elapsedMs: 4000,
+      );
+      expect(
+        session.currentRound.score,
+        lessThan(noHint.currentRound.score),
+      );
     });
 
     test('wrong guesses add compass markers and expire after 5', () {


### PR DESCRIPTION
## Summary
- Every wrong guess now shows its distance from the hidden target on its red compass marker, free of charge — instant feedback on how close you are.
- New in-round hint button ("Reveal clue distances — −1000 pts") shows how far each of the 5 original clues is from the target. One per round, charged once at scoring time (scaled by the target's difficulty multiplier like every other component).
- Round results note when the hint was used; hint state resets each round.
- Frameless clue markers stay frameless until the hint is bought (a distance line needs a box); wrong-guess markers always carry a box for the distance text.

## Changes
- `triangulation_scoring.dart` — `triDistanceHintPenalty` (1000) + `hintUsed` param in `computeTriangulationScore`
- `triangulation_session.dart` — per-round `hintUsed` state, `useDistanceHint()`, scoring pass-through
- `triangulation_compass.dart` — `showClueDistances` param; guess boxes always render "N,NNN km away"; shared `formatKmAway` helper
- `triangulation_game_screen.dart` — gold hint button under the compass (hidden once used or round over); "Distance hint used" note in round results
- Tests: hint costs exactly its difficulty-scaled penalty; per-round session state charged in scoring

## Verification
- 846/846 tests pass (2 new)
- `flutter analyze`: 0 errors, 0 warnings
- Goldens regenerated and visually verified (no overlaps, distances legible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_