### PR TITLE
Triangulation: declutter dense compass markers + zoomable reveal map

### DIFF
--- a/lib/features/triangulation/triangulation_game_screen.dart
+++ b/lib/features/triangulation/triangulation_game_screen.dart
@@ -13,6 +13,7 @@ import '../../core/utils/haptics.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
 import '../../data/models/daily_result.dart';
 import '../../data/providers/account_provider.dart';
+import '../../game/clues/clue_types.dart';
 import '../../game/map/country_data.dart';
 import '../../game/quiz/fuzzy_match.dart';
 import '../../game/triangulation/daily_triangulation.dart';
@@ -69,6 +70,20 @@ class _TriangulationGameScreenState
   bool get _isCapitalTarget =>
       widget.config.targetType == TriTargetType.capital;
 
+  /// Whether this config produces markers with tap-to-open detail cards
+  /// (collapsed dense boxes, or borders lists that may be truncated).
+  bool get _hasInspectableMarkers {
+    final types = widget.config.clueTypes;
+    final labels = widget.config.labelTypes;
+    var lines = labels.length;
+    if (types.contains(ClueType.capital) &&
+        !labels.contains(TriLabel.capital)) {
+      lines++;
+    }
+    if (types.contains(ClueType.borders)) lines++;
+    return lines > 2 || types.contains(ClueType.borders);
+  }
+
   final Stopwatch _stopwatch = Stopwatch();
   Timer? _ticker;
   final TextEditingController _inputController = TextEditingController();
@@ -77,6 +92,9 @@ class _TriangulationGameScreenState
   bool _showingRoundResult = false;
   bool _finished = false;
   String? _feedback;
+
+  /// Clue marker currently expanded into the detail card, if any.
+  int? _inspectedClueIndex;
 
   @override
   void initState() {
@@ -226,7 +244,10 @@ class _TriangulationGameScreenState
     _stopwatch
       ..reset()
       ..start();
-    setState(() => _showingRoundResult = false);
+    setState(() {
+      _showingRoundResult = false;
+      _inspectedClueIndex = null;
+    });
   }
 
   Future<void> _recordDailyResult() async {
@@ -330,17 +351,35 @@ class _TriangulationGameScreenState
                   labelTypes: widget.config.labelTypes,
                   centerLabel: _isCapitalTarget ? 'CAPITAL' : 'COUNTRY',
                   showClueDistances: state.hintUsed,
+                  selectedClueIndex: _inspectedClueIndex,
+                  onClueTap: (i) => setState(
+                    () => _inspectedClueIndex =
+                        _inspectedClueIndex == i ? null : i,
+                  ),
                 ),
                 const SizedBox(height: 4),
                 Text(
                   'Arrows point from the hidden '
                   '${_isCapitalTarget ? 'capital' : 'country'} '
-                  'toward each place',
+                  'toward each place'
+                  '${_hasInspectableMarkers ? ' · tap a marker for details' : ''}',
+                  textAlign: TextAlign.center,
                   style: TextStyle(
                     color: FlitColors.textMuted.withOpacity(0.8),
                     fontSize: 11,
                   ),
                 ),
+                if (_inspectedClueIndex != null &&
+                    _inspectedClueIndex! < state.round.clues.length) ...[
+                  const SizedBox(height: 8),
+                  TriangulationClueDetailCard(
+                    clue: state.round.clues[_inspectedClueIndex!],
+                    clueTypes: widget.config.clueTypes,
+                    labelTypes: widget.config.labelTypes,
+                    showDistance: state.hintUsed,
+                    onClose: () => setState(() => _inspectedClueIndex = null),
+                  ),
+                ],
                 const SizedBox(height: 8),
                 if (!state.hintUsed)
                   OutlinedButton.icon(
@@ -566,7 +605,7 @@ class _StatusBar extends StatelessWidget {
 // Round result: answer revealed on a map
 // ─────────────────────────────────────────────────────────────────────────
 
-class _RoundResultView extends StatelessWidget {
+class _RoundResultView extends StatefulWidget {
   const _RoundResultView({
     required this.state,
     required this.isLastRound,
@@ -580,7 +619,38 @@ class _RoundResultView extends StatelessWidget {
   final VoidCallback onContinue;
 
   @override
+  State<_RoundResultView> createState() => _RoundResultViewState();
+}
+
+class _RoundResultViewState extends State<_RoundResultView> {
+  /// Drives the reveal map's pinch-zoom/pan; the current zoom feeds back
+  /// into the painter so markers keep a constant on-screen size.
+  final TransformationController _mapController = TransformationController();
+  double _mapZoom = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _mapController.addListener(_onMapTransform);
+  }
+
+  void _onMapTransform() {
+    final zoom = _mapController.value.getMaxScaleOnAxis();
+    if ((zoom - _mapZoom).abs() > 0.01) setState(() => _mapZoom = zoom);
+  }
+
+  @override
+  void dispose() {
+    _mapController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final state = widget.state;
+    final isLastRound = widget.isLastRound;
+    final isCapitalTarget = widget.isCapitalTarget;
+    final onContinue = widget.onContinue;
     final round = state.round;
     return Column(
       children: [
@@ -644,17 +714,24 @@ class _RoundResultView extends StatelessWidget {
                 ),
                 const SizedBox(height: 16),
                 // The reveal: world map with the target and every guess.
+                // Pinch to zoom / drag to pan for a closer look at
+                // clustered markers.
                 ClipRRect(
                   borderRadius: BorderRadius.circular(12),
                   child: Container(
                     color: FlitColors.backgroundMid,
                     child: AspectRatio(
                       aspectRatio: 2,
-                      child: CustomPaint(
-                        painter: _ResultMapPainter(
-                          targetLngLat: round.targetCapitalLngLat,
-                          guesses: state.wrongGuesses,
-                          clues: round.clues,
+                      child: InteractiveViewer(
+                        transformationController: _mapController,
+                        maxScale: 12,
+                        child: CustomPaint(
+                          painter: _ResultMapPainter(
+                            targetLngLat: round.targetCapitalLngLat,
+                            guesses: state.wrongGuesses,
+                            clues: round.clues,
+                            zoom: _mapZoom,
+                          ),
                         ),
                       ),
                     ),
@@ -705,6 +782,14 @@ class _RoundResultView extends StatelessWidget {
                       ),
                     ],
                   ],
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'pinch to zoom · drag to pan',
+                  style: TextStyle(
+                    color: FlitColors.textMuted.withOpacity(0.7),
+                    fontSize: 10,
+                  ),
                 ),
                 const SizedBox(height: 8),
                 if (state.wrongGuesses.isNotEmpty)
@@ -803,24 +888,31 @@ class _RoundResultView extends StatelessWidget {
 /// Equirectangular world map with the target capital (gold star), each
 /// wrong guess (red dot), and the round's original clue anchors (accent
 /// ringed dots) so the reveal shows the full triangulation picture.
+///
+/// [zoom] is the InteractiveViewer's current scale; markers and line
+/// widths are divided by it so they keep a constant on-screen size while
+/// the map itself zooms.
 class _ResultMapPainter extends CustomPainter {
   _ResultMapPainter({
     required this.targetLngLat,
     required this.guesses,
     required this.clues,
+    this.zoom = 1,
   });
 
   final Vector2 targetLngLat;
   final List<TriangulationGuess> guesses;
   final List<TriangulationClue> clues;
+  final double zoom;
 
   @override
   void paint(Canvas canvas, Size size) {
+    final z = zoom.clamp(1.0, 100.0);
     final landPaint = Paint()..color = FlitColors.landMass.withOpacity(0.45);
     final borderPaint = Paint()
       ..color = FlitColors.border.withOpacity(0.6)
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 0.6;
+      ..strokeWidth = 0.6 / z;
 
     Offset project(double lng, double lat) => Offset(
           (lng + 180) / 360 * size.width,
@@ -856,20 +948,20 @@ class _ResultMapPainter extends CustomPainter {
         target,
         Paint()
           ..color = FlitColors.textSecondary.withOpacity(0.3)
-          ..strokeWidth = 0.8,
+          ..strokeWidth = 0.8 / z,
       );
       canvas.drawCircle(
         pos,
-        3,
+        3 / z,
         Paint()..color = FlitColors.backgroundDark,
       );
       canvas.drawCircle(
         pos,
-        3,
+        3 / z,
         Paint()
           ..color = FlitColors.accent
           ..style = PaintingStyle.stroke
-          ..strokeWidth = 1.6,
+          ..strokeWidth = 1.6 / z,
       );
     }
 
@@ -881,13 +973,13 @@ class _ResultMapPainter extends CustomPainter {
         target,
         Paint()
           ..color = FlitColors.error.withOpacity(0.5)
-          ..strokeWidth = 1,
+          ..strokeWidth = 1 / z,
       );
-      canvas.drawCircle(pos, 3.5, Paint()..color = FlitColors.error);
+      canvas.drawCircle(pos, 3.5 / z, Paint()..color = FlitColors.error);
     }
 
     // Target star.
-    _drawStar(canvas, target, 7, Paint()..color = FlitColors.gold);
+    _drawStar(canvas, target, 7 / z, Paint()..color = FlitColors.gold);
   }
 
   void _drawStar(Canvas canvas, Offset center, double r, Paint paint) {
@@ -911,7 +1003,8 @@ class _ResultMapPainter extends CustomPainter {
   bool shouldRepaint(_ResultMapPainter old) =>
       targetLngLat != old.targetLngLat ||
       guesses.length != old.guesses.length ||
-      clues.length != old.clues.length;
+      clues.length != old.clues.length ||
+      zoom != old.zoom;
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/lib/features/triangulation/widgets/triangulation_compass.dart
+++ b/lib/features/triangulation/widgets/triangulation_compass.dart
@@ -22,6 +22,11 @@ import 'compass_painter.dart';
 /// box back to its arrow tip. Sized by its parent; always renders square
 /// via [AspectRatio]. All placement is fractional (no absolute positioning)
 /// so it scales across phone/tablet/web.
+///
+/// Dense configs (3+ text lines per marker) collapse each box to its
+/// primary label; the full, untruncated content moves to a tap-to-open
+/// [TriangulationClueDetailCard] hosted by the parent screen via
+/// [onClueTap] / [selectedClueIndex].
 class TriangulationCompass extends StatelessWidget {
   const TriangulationCompass({
     super.key,
@@ -31,6 +36,8 @@ class TriangulationCompass extends StatelessWidget {
     required this.labelTypes,
     this.centerLabel = 'CAPITAL',
     this.showClueDistances = false,
+    this.selectedClueIndex,
+    this.onClueTap,
   });
 
   final List<TriangulationClue> clues;
@@ -38,6 +45,13 @@ class TriangulationCompass extends StatelessWidget {
   final Set<ClueType> clueTypes;
   final Set<TriLabel> labelTypes;
   final String centerLabel;
+
+  /// Which clue marker is currently inspected (gold highlight), if any.
+  final int? selectedClueIndex;
+
+  /// Called with the clue index when a marker with collapsed or truncated
+  /// content is tapped. Null disables tap handling entirely.
+  final ValueChanged<int>? onClueTap;
 
   /// When true (the distance hint was bought), each starting clue's box
   /// also shows its distance from the hidden target. Wrong-guess markers
@@ -152,30 +166,46 @@ class TriangulationCompass extends StatelessWidget {
                   left: positions[i].dx - sizes[i].width / 2,
                   top: positions[i].dy - sizes[i].height / 2,
                   width: sizes[i].width,
-                  // No text to hold → no card: just the bare visual(s) at
-                  // the arrow tip (e.g. flags-only expert mode).
-                  child: markers[i].lines.isEmpty
-                      ? Wrap(
-                          spacing: 4,
-                          alignment: WrapAlignment.center,
-                          crossAxisAlignment: WrapCrossAlignment.center,
-                          children: markers[i].visuals,
-                        )
-                      : _InfoBoxFrame(
-                          borderColor: markers[i].isGuess
-                              ? FlitColors.error
-                              : FlitColors.cardBorder,
-                          textColor: markers[i].isGuess
-                              ? FlitColors.error
-                              : FlitColors.textPrimary,
-                          visuals: markers[i].visuals,
-                          lines: markers[i].lines,
-                        ),
+                  child: _markerChild(markers[i], clueIndex: i),
                 ),
             ],
           );
         },
       ),
+    );
+  }
+
+  /// The rendered widget for one marker: bare visuals when frameless, a
+  /// framed info box otherwise, wrapped in a tap target when the marker
+  /// has more content than its box shows.
+  Widget _markerChild(_MarkerContent marker, {required int clueIndex}) {
+    final selected = !marker.isGuess && clueIndex == selectedClueIndex;
+    // No text to hold → no card: just the bare visual(s) at the arrow
+    // tip (e.g. flags-only expert mode).
+    final Widget child = marker.displayLines.isEmpty
+        ? Wrap(
+            spacing: 4,
+            alignment: WrapAlignment.center,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: marker.visuals,
+          )
+        : _InfoBoxFrame(
+            borderColor: marker.isGuess
+                ? FlitColors.error
+                : selected
+                    ? FlitColors.gold
+                    : FlitColors.cardBorder,
+            textColor:
+                marker.isGuess ? FlitColors.error : FlitColors.textPrimary,
+            visuals: marker.visuals,
+            lines: marker.displayLines,
+            showMore: marker.hasMore,
+          );
+    if (marker.isGuess || !marker.hasMore || onClueTap == null) return child;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => onClueTap!(clueIndex),
+      child: child,
     );
   }
 
@@ -218,17 +248,23 @@ class TriangulationCompass extends StatelessWidget {
         !labelTypes.contains(TriLabel.capital)) {
       lines.add(clue.capitalName);
     }
+    var bordersTruncated = false;
     if (clueTypes.contains(ClueType.borders)) {
       final neighbors = Clue.getNeighbors(clue.countryCode);
       if (neighbors.isNotEmpty) {
+        bordersTruncated = neighbors.length > 3;
         final shown = neighbors.take(3).join(', ');
-        lines.add(
-          neighbors.length > 3 ? 'Borders: $shown…' : 'Borders: $shown',
-        );
+        lines.add(bordersTruncated ? 'Borders: $shown…' : 'Borders: $shown');
       }
     }
+
+    // Dense configs collapse to the primary label so the compass stays
+    // readable — the rest moves to the tap-to-open detail card. The bought
+    // distance line always stays visible.
+    final compact = lines.length > 2;
+    final displayLines = compact ? [lines.first] : List.of(lines);
     if (showClueDistances) {
-      lines.add(formatKmAway(clue.distanceFromTargetKm));
+      displayLines.add(formatKmAway(clue.distanceFromTargetKm));
     }
 
     return _MarkerContent(
@@ -237,7 +273,8 @@ class TriangulationCompass extends StatelessWidget {
       visuals: visuals,
       hasFlag: clueTypes.contains(ClueType.flag),
       hasOutline: hasOutline,
-      lines: lines,
+      displayLines: displayLines,
+      hasMore: compact || bordersTruncated,
     );
   }
 
@@ -248,7 +285,7 @@ class TriangulationCompass extends StatelessWidget {
         visuals: [_MarkerFlag(code: guess.countryCode)],
         hasFlag: true,
         hasOutline: false,
-        lines: [
+        displayLines: [
           if (guess.viaCapital && guess.capitalName.isNotEmpty)
             guess.capitalName
           else
@@ -257,6 +294,7 @@ class TriangulationCompass extends StatelessWidget {
           // bearing it's the core triangulation feedback loop.
           formatKmAway(guess.distanceKm),
         ],
+        hasMore: false,
       );
 
   // ── Layout ─────────────────────────────────────────────────────────────
@@ -268,7 +306,7 @@ class TriangulationCompass extends StatelessWidget {
     // Markers with no text render frameless (bare visuals), so their size
     // is just the visuals' footprint — the collision layout then packs
     // them much tighter.
-    if (marker.lines.isEmpty) {
+    if (marker.displayLines.isEmpty) {
       var width = 0.0;
       if (marker.hasFlag) width += 33;
       if (marker.hasOutline) width += 40 + (marker.hasFlag ? 4 : 0);
@@ -283,11 +321,12 @@ class TriangulationCompass extends StatelessWidget {
         height += 24;
       }
     }
-    for (final line in marker.lines) {
+    for (final line in marker.displayLines) {
       const charWidth = 6.2; // ~10.5px semi-bold
       final rows = ((line.length * charWidth) / innerWidth).ceil().clamp(1, 2);
       height += rows * 13.0 + 2;
     }
+    if (marker.hasMore) height += 12; // "more" dots row
     return Size(boxWidth, height);
   }
 
@@ -359,9 +398,10 @@ class TriangulationCompass extends StatelessWidget {
           positions[i] += outward * (minRadius - dist + 1);
         }
 
-        // Soft bounds: prefer staying inside the square, but allow a small
+        // Soft bounds: prefer staying inside the square, but allow a tiny
         // overflow (the Stack doesn't clip) rather than re-overlapping.
-        final slack = side * 0.05;
+        // Kept tight so boxes never get clipped by the screen edge.
+        final slack = side * 0.02;
         final minX = halfW - slack;
         final maxX = side - halfW + slack;
         final minY = halfH - slack;
@@ -390,7 +430,8 @@ class _MarkerContent {
     required this.visuals,
     required this.hasFlag,
     required this.hasOutline,
-    required this.lines,
+    required this.displayLines,
+    required this.hasMore,
   });
 
   final double bearingDeg;
@@ -398,7 +439,14 @@ class _MarkerContent {
   final List<Widget> visuals;
   final bool hasFlag;
   final bool hasOutline;
-  final List<String> lines;
+
+  /// Text lines actually shown in the on-compass box (collapsed for
+  /// dense configs).
+  final List<String> displayLines;
+
+  /// True when tapping opens the detail card (content was collapsed or
+  /// a borders list was truncated).
+  final bool hasMore;
 }
 
 /// Thin lines tying each arrow tip to its info box (drawn beneath the
@@ -445,12 +493,16 @@ class _InfoBoxFrame extends StatelessWidget {
     required this.textColor,
     required this.visuals,
     required this.lines,
+    this.showMore = false,
   });
 
   final Color borderColor;
   final Color textColor;
   final List<Widget> visuals;
   final List<String> lines;
+
+  /// Renders a muted "more" dots row — the tap-for-details affordance.
+  final bool showMore;
 
   @override
   Widget build(BuildContext context) {
@@ -488,6 +540,12 @@ class _InfoBoxFrame extends StatelessWidget {
                 ),
               ),
             ),
+          if (showMore)
+            Icon(
+              Icons.more_horiz_rounded,
+              size: 12,
+              color: FlitColors.textMuted.withOpacity(0.8),
+            ),
         ],
       ),
     );
@@ -524,6 +582,156 @@ class _MarkerFlag extends StatelessWidget {
           )
         : code;
     return Text(emoji, style: const TextStyle(fontSize: 16));
+  }
+}
+
+/// Full, untruncated info for one tapped clue marker, shown beneath the
+/// compass. Only reveals content the round's clue/label config already
+/// enables — inspecting a marker never leaks extra information (e.g. no
+/// country name on label-free expert themes).
+class TriangulationClueDetailCard extends StatelessWidget {
+  const TriangulationClueDetailCard({
+    super.key,
+    required this.clue,
+    required this.clueTypes,
+    required this.labelTypes,
+    this.showDistance = false,
+    this.onClose,
+  });
+
+  final TriangulationClue clue;
+  final Set<ClueType> clueTypes;
+  final Set<TriLabel> labelTypes;
+  final bool showDistance;
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = <(String, String)>[];
+    for (final label in TriLabel.values) {
+      if (label == TriLabel.country) continue; // shown as the title
+      if (!labelTypes.contains(label)) continue;
+      final text = clue.labelText(label);
+      if (text != null) rows.add((label.displayName, text));
+    }
+    if (clueTypes.contains(ClueType.capital) &&
+        !labelTypes.contains(TriLabel.capital)) {
+      rows.add((TriLabel.capital.displayName, clue.capitalName));
+    }
+    if (clueTypes.contains(ClueType.borders)) {
+      final neighbors = Clue.getNeighbors(clue.countryCode);
+      if (neighbors.isNotEmpty) rows.add(('Borders', neighbors.join(', ')));
+    }
+    final title =
+        labelTypes.contains(TriLabel.country) ? clue.countryName : null;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(12, 10, 8, 10),
+      decoration: BoxDecoration(
+        color: FlitColors.cardBackground.withOpacity(0.95),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FlitColors.gold.withOpacity(0.6)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    if (clueTypes.contains(ClueType.flag)) ...[
+                      _MarkerFlag(code: clue.countryCode),
+                      const SizedBox(width: 8),
+                    ],
+                    if (clueTypes.contains(ClueType.outline)) ...[
+                      SizedBox(
+                        width: 40,
+                        height: 30,
+                        child: CustomPaint(
+                          painter: CountryOutlinePainter(
+                            CountryData.getCountry(clue.countryCode)
+                                    ?.polygons ??
+                                const [],
+                            fillColor: FlitColors.landMass.withOpacity(0.5),
+                            strokeColor: FlitColors.textPrimary,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                    ],
+                    if (title != null)
+                      Expanded(
+                        child: Text(
+                          title,
+                          style: const TextStyle(
+                            color: FlitColors.textPrimary,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                for (final (label, value) in rows)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text.rich(
+                      TextSpan(
+                        children: [
+                          TextSpan(
+                            text: '$label  ',
+                            style: const TextStyle(
+                              color: FlitColors.textMuted,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          TextSpan(
+                            text: value,
+                            style: const TextStyle(
+                              color: FlitColors.textPrimary,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                if (showDistance)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      formatKmAway(clue.distanceFromTargetKm),
+                      style: const TextStyle(
+                        color: FlitColors.gold,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (onClose != null)
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: onClose,
+              child: Padding(
+                padding: const EdgeInsets.all(4),
+                child: Icon(
+                  Icons.close_rounded,
+                  size: 16,
+                  color: FlitColors.textMuted.withOpacity(0.9),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- **Compact markers when the config is dense.** With lots of clue/label options enabled, each compass box was carrying 5+ lines of truncated, clipped text. Markers with 3+ text lines now collapse to flag/outline + primary label with a subtle "⋯" affordance.
- **Tap a marker to read everything cleanly.** Tapping opens a full-width detail card below the compass with labelled rows — Capital, Leader, Language, and the *full* borders list (no more "Belgium, Germa…"). The tapped marker gets a gold highlight; tap again or ✕ to close. The card only shows content the round's clue/label config enables, so inspecting never leaks extra information on expert themes.
- **No more off-screen boxes.** Layout bounds tightened so boxes can't hang past the compass edge.
- **Reveal map is now zoomable/pannable.** The round-result world map supports pinch-zoom (up to 12×) and drag-pan via InteractiveViewer; marker dots, the target star, and line widths compensate for zoom so they stay a constant on-screen size instead of blowing up.

## Changes
- `triangulation_compass.dart` — collapsed `displayLines` + `hasMore` per marker, tap handling, `selectedClueIndex`/`onClueTap` params, new public `TriangulationClueDetailCard`, tighter layout slack
- `triangulation_game_screen.dart` — inspection state + detail card wiring, caption tap hint, `InteractiveViewer` + zoom-compensated `_ResultMapPainter`, "pinch to zoom · drag to pan" legend hint
- Goldens (local-only): new dense-config golden verifying compact boxes + detail card; MaterialIcons font loaded so icons render as real glyphs

## Verification
- 847/847 tests pass
- `flutter analyze`: 0 errors, 0 warnings
- All three compass goldens regenerated and visually verified (compact collapse, gold selection highlight, untruncated detail rows, no clipped boxes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_