### PR TITLE
CI: document the skip-marker-in-PR-body footgun + retrigger lost deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI & Deploy
 
+# FOOTGUN: GitHub natively skips push-triggered workflows when the skip
+# marker ('[skip ci]' and friends) appears ANYWHERE in the head commit
+# message — body included. A squash-merge whose PR description merely
+# *mentions* the marker will silently skip the whole deploy. Never quote
+# the literal marker in PR titles or bodies.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- PR #444's squash commit quoted the CI skip marker in its body, and GitHub's native skip handling matches the marker anywhere in the head commit message — so the merge never triggered CI & Deploy at all. This adds a warning comment at the top of `ci.yml` so nobody (human or agent) quotes the literal marker in a PR title/body again.
- The run before that (d71973d) passed all tests but lost the Pages deploy to a transient "Deployment failed, try again later" error. Merging this PR retriggers CI & Deploy, which will ship the pending changes: the Triangulation scoring rebalance (#443) and the telemetry skip-ci fix (#444).

## Verification
- Comment-only workflow change; no behavior modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_