### PR TITLE
CI: note the transient Pages deploy flake + retrigger lost deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ name: CI & Deploy
 # message — body included. A squash-merge whose PR description merely
 # *mentions* the marker will silently skip the whole deploy. Never quote
 # the literal marker in PR titles or bodies.
+#
+# Pages deploys occasionally fail with a transient "Deployment failed,
+# try again later" — tests stay green; just re-run by pushing to main.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- GitHub Pages rejected two consecutive green builds (runs 28715533027 and 28716766563) with its transient "Deployment failed, try again later" error — tests passed both times; only the Pages upload step failed. This documents the flake in `ci.yml` so the failure mode is recognisable at a glance.
- Merging this PR retriggers CI & Deploy on `main`, shipping the pending Triangulation scoring rebalance (#443) and telemetry CI fix (#444) — the live site is still v1.385 until this lands.

## Verification
- Comment-only workflow change; no behavior modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_