### PR TITLE
Fix: keyboard dismissed after first keystroke (feedback banner reconciliation)

### DIFF
--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -326,8 +326,12 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              // Keyed (with the fields below) because typing clears the
+              // banner — unkeyed, its removal would re-inflate the focused
+              // TextField and dismiss the keyboard.
               if (error != null) ...[
                 Container(
+                  key: const ValueKey('pw-error'),
                   padding: const EdgeInsets.all(10),
                   decoration: BoxDecoration(
                     color: FlitColors.error.withOpacity(0.15),
@@ -356,6 +360,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                 const SizedBox(height: 12),
               ],
               TextField(
+                key: const ValueKey('pw-new'),
                 controller: newPasswordController,
                 obscureText: obscureNew,
                 style: const TextStyle(color: FlitColors.textPrimary),
@@ -388,6 +393,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
               ),
               const SizedBox(height: 16),
               TextField(
+                key: const ValueKey('pw-confirm'),
                 controller: confirmPasswordController,
                 obscureText: obscureConfirm,
                 style: const TextStyle(color: FlitColors.textPrimary),

--- a/lib/features/quiz/type_in_game_screen.dart
+++ b/lib/features/quiz/type_in_game_screen.dart
@@ -420,11 +420,21 @@ class _TypeInGameScreenState extends State<TypeInGameScreen>
 
                         const SizedBox(height: 16),
 
-                        // Feedback animation
-                        if (_showFeedback) _buildFeedback(),
+                        // Feedback animation. Keyed (with the input below)
+                        // because it toggles while the answer field is
+                        // focused — unkeyed, its removal would re-inflate
+                        // the TextField and dismiss the keyboard.
+                        if (_showFeedback)
+                          KeyedSubtree(
+                            key: const ValueKey('quiz-feedback'),
+                            child: _buildFeedback(),
+                          ),
 
                         // Text input
-                        _buildTextInput(),
+                        KeyedSubtree(
+                          key: const ValueKey('quiz-answer-input'),
+                          child: _buildTextInput(),
+                        ),
                         const SizedBox(height: 8),
 
                         // Action buttons

--- a/lib/features/triangulation/triangulation_game_screen.dart
+++ b/lib/features/triangulation/triangulation_game_screen.dart
@@ -414,8 +414,14 @@ class _TriangulationGameScreenState
             ),
           ),
         ),
+        // These trailing children are keyed because the feedback banner and
+        // suggestion strip appear/disappear WHILE the player is typing.
+        // Without keys, positional reconciliation re-inflates the TextField
+        // when an earlier sibling vanishes (first keystroke clears the
+        // feedback banner), which closes the keyboard on iOS/Android.
         if (_feedback != null)
           Padding(
+            key: const ValueKey('tri-feedback'),
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Text(
               _feedback!,
@@ -428,6 +434,7 @@ class _TriangulationGameScreenState
           ),
         if (suggestions.isNotEmpty)
           Container(
+            key: const ValueKey('tri-suggestions'),
             height: 44,
             padding: const EdgeInsets.symmetric(horizontal: 12),
             child: ListView(
@@ -457,6 +464,7 @@ class _TriangulationGameScreenState
             ),
           ),
         Padding(
+          key: const ValueKey('tri-guess-input'),
           padding: const EdgeInsets.fromLTRB(12, 6, 12, 12),
           child: Row(
             children: [


### PR DESCRIPTION
## Summary
On iOS, typing the first letter into the Triangulation guess box minimised the keyboard, forcing a re-tap. Root cause: the wrong-guess feedback banner ("🔥 France — not it") is a conditional sibling rendered *above* the input in the same unkeyed `Column`, and the first keystroke clears it via `onChanged`. Flutter's positional reconciliation then matched the input's `Padding` against the departed banner's slot, re-inflated the `TextField` element, and disposing the old `EditableText` closed the keyboard connection. Later keystrokes don't change the child list — which is exactly why only the first letter was affected.

## Fix
Key the volatile trailing children (feedback banner, suggestions strip, input row) so the field keeps its element identity across banner toggles.

Per the apply-fixes-generically rule, all 17 files with `TextField`s were audited for the same shape; two more had it and are fixed the same way:
- **Type-in quiz mode** — `if (_showFeedback) _buildFeedback()` toggles directly above the answer field while it holds focus
- **Change-password dialog** — the error banner above the password fields is cleared by `onChanged`

The remaining inputs are structurally safe (conditional siblings come after the field, or their conditions can't change while typing).

## Verification
- 848/848 tests pass; analyzer 0 errors / 0 warnings
- Key-based reconciliation preserves the focused element when a preceding sibling disappears — the standard Flutter fix for this class of bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_