### PR TITLE
CI: auto-retry the Pages deploy step on transient failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,10 +245,24 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
     steps:
+      # Pages intermittently rejects healthy deployments with a transient
+      # "Deployment failed, try again later" (three green builds lost to it
+      # on 2026-07-04 alone). Retry twice in-job with a pause so a flake
+      # never requires a manual retrigger commit.
       - name: Deploy to GitHub Pages
         id: deployment
+        uses: actions/deploy-pages@v4
+        continue-on-error: true
+
+      - name: Pause before retry
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 90
+
+      - name: Deploy to GitHub Pages (retry)
+        id: deployment_retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@v4
 
   # ── Smoke Test ──


### PR DESCRIPTION
## Summary
- GitHub Pages rejected **three** healthy deployments today with its transient "Deployment failed, try again later" error, each needing a manual retrigger commit. The Deploy job now absorbs one flake automatically: the first `deploy-pages` attempt is `continue-on-error`, and on failure a second attempt runs after a 90-second pause. The environment URL falls back to whichever attempt succeeded.
- A genuine Pages outage still fails the job — both attempts must fail.
- Merging this also retriggers the deploy of the keyboard-dismiss fix (#447) that the third flake dropped.

## Verification
- Workflow-only change; tests unaffected (848/848 green on the same tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_