### PR TITLE
CI: note runner-shutdown flake + retrigger outline/flag deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ name: CI & Deploy
 #
 # Pages deploys occasionally fail with a transient "Deployment failed,
 # try again later" — tests stay green; just re-run by pushing to main.
+# Hosted runners can also be reclaimed mid-job (exit 143 / "runner has
+# received a shutdown signal"); that's infra churn, not code — re-run.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- The outline/flag deploy (run 28729654252) failed with exit 143 mid-dart2js: the hosted runner was reclaimed ("runner has received a shutdown signal"). Infra churn, not code — all tests passed. Documented alongside the other known CI flakes.
- Merging retriggers CI & Deploy, shipping PR #449 (152 upgraded outlines + XC/XS flags).

## Verification
- Comment-only workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_