### PR TITLE
Bring the Triangulation reveal map to quiz results and flight modes

### DIFF
--- a/lib/core/widgets/reveal_map.dart
+++ b/lib/core/widgets/reveal_map.dart
@@ -1,0 +1,248 @@
+import 'dart:math' as math;
+
+import 'package:flame/components.dart' show Vector2;
+import 'package:flutter/material.dart';
+
+import '../theme/flit_colors.dart';
+import '../../game/map/country_data.dart';
+
+/// Post-round reveal map shared by all game modes: an equirectangular
+/// world map with the answer (gold star), optional clue anchors
+/// (accent-ringed dots), and the player's wrong guesses (red dots with
+/// connector lines back to the answer).
+///
+/// Pinch-zoomable and pannable; marker and line sizes counter-scale with
+/// zoom so they keep a constant on-screen size. Includes the legend and
+/// gesture hint so every mode presents results identically.
+class RevealMap extends StatefulWidget {
+  const RevealMap({
+    super.key,
+    required this.targetLngLat,
+    this.clueLngLats = const [],
+    this.guessLngLats = const [],
+    this.showLegend = true,
+  });
+
+  /// The answer location as (lng, lat) degrees.
+  final Vector2 targetLngLat;
+
+  /// Original clue anchor locations, if the mode has them.
+  final List<Vector2> clueLngLats;
+
+  /// Wrong-guess locations.
+  final List<Vector2> guessLngLats;
+
+  final bool showLegend;
+
+  @override
+  State<RevealMap> createState() => _RevealMapState();
+}
+
+class _RevealMapState extends State<RevealMap> {
+  /// Drives pinch-zoom/pan; the current zoom feeds back into the painter
+  /// so markers keep a constant on-screen size.
+  final TransformationController _controller = TransformationController();
+  double _zoom = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onTransform);
+  }
+
+  void _onTransform() {
+    final zoom = _controller.value.getMaxScaleOnAxis();
+    if ((zoom - _zoom).abs() > 0.01) setState(() => _zoom = zoom);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            color: FlitColors.backgroundMid,
+            child: AspectRatio(
+              aspectRatio: 2,
+              child: InteractiveViewer(
+                transformationController: _controller,
+                maxScale: 12,
+                child: CustomPaint(
+                  painter: _RevealMapPainter(
+                    targetLngLat: widget.targetLngLat,
+                    clueLngLats: widget.clueLngLats,
+                    guessLngLats: widget.guessLngLats,
+                    zoom: _zoom,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (widget.showLegend) ...[
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.star, color: FlitColors.gold, size: 13),
+              const SizedBox(width: 3),
+              const Text(
+                'answer',
+                style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
+              ),
+              if (widget.clueLngLats.isNotEmpty) ...[
+                const SizedBox(width: 12),
+                const Icon(
+                  Icons.circle_outlined,
+                  color: FlitColors.accent,
+                  size: 11,
+                ),
+                const SizedBox(width: 3),
+                const Text(
+                  'clues',
+                  style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
+                ),
+              ],
+              if (widget.guessLngLats.isNotEmpty) ...[
+                const SizedBox(width: 12),
+                const Icon(Icons.circle, color: FlitColors.error, size: 11),
+                const SizedBox(width: 3),
+                const Text(
+                  'your guesses',
+                  style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
+                ),
+              ],
+            ],
+          ),
+          const SizedBox(height: 2),
+          Text(
+            'pinch to zoom · drag to pan',
+            style: TextStyle(
+              color: FlitColors.textMuted.withOpacity(0.7),
+              fontSize: 10,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// Equirectangular world map painter behind [RevealMap]. [zoom] is the
+/// InteractiveViewer's current scale; markers and line widths are divided
+/// by it so they keep a constant on-screen size while the map zooms.
+class _RevealMapPainter extends CustomPainter {
+  _RevealMapPainter({
+    required this.targetLngLat,
+    required this.clueLngLats,
+    required this.guessLngLats,
+    this.zoom = 1,
+  });
+
+  final Vector2 targetLngLat;
+  final List<Vector2> clueLngLats;
+  final List<Vector2> guessLngLats;
+  final double zoom;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final z = zoom.clamp(1.0, 100.0);
+    final landPaint = Paint()..color = FlitColors.landMass.withOpacity(0.45);
+    final borderPaint = Paint()
+      ..color = FlitColors.border.withOpacity(0.6)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.6 / z;
+
+    Offset project(double lng, double lat) => Offset(
+          (lng + 180) / 360 * size.width,
+          (90 - lat) / 180 * size.height,
+        );
+
+    for (final country in CountryData.countries) {
+      for (final poly in country.polygons) {
+        if (poly.length < 3) continue;
+        final path = Path();
+        for (var i = 0; i < poly.length; i++) {
+          final pt = project(poly[i].x, poly[i].y);
+          if (i == 0) {
+            path.moveTo(pt.dx, pt.dy);
+          } else {
+            path.lineTo(pt.dx, pt.dy);
+          }
+        }
+        path.close();
+        canvas.drawPath(path, landPaint);
+        canvas.drawPath(path, borderPaint);
+      }
+    }
+
+    final target = project(targetLngLat.x, targetLngLat.y);
+
+    // Clue anchors: accent-ringed dots with a faint line to the answer.
+    for (final clue in clueLngLats) {
+      final pos = project(clue.x, clue.y);
+      canvas.drawLine(
+        pos,
+        target,
+        Paint()
+          ..color = FlitColors.textSecondary.withOpacity(0.3)
+          ..strokeWidth = 0.8 / z,
+      );
+      canvas.drawCircle(pos, 3 / z, Paint()..color = FlitColors.backgroundDark);
+      canvas.drawCircle(
+        pos,
+        3 / z,
+        Paint()
+          ..color = FlitColors.accent
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1.6 / z,
+      );
+    }
+
+    // Guess dots + connector lines toward the answer.
+    for (final g in guessLngLats) {
+      final pos = project(g.x, g.y);
+      canvas.drawLine(
+        pos,
+        target,
+        Paint()
+          ..color = FlitColors.error.withOpacity(0.5)
+          ..strokeWidth = 1 / z,
+      );
+      canvas.drawCircle(pos, 3.5 / z, Paint()..color = FlitColors.error);
+    }
+
+    _drawStar(canvas, target, 7 / z, Paint()..color = FlitColors.gold);
+  }
+
+  void _drawStar(Canvas canvas, Offset center, double r, Paint paint) {
+    final path = Path();
+    for (var i = 0; i < 10; i++) {
+      final radius = i.isEven ? r : r * 0.45;
+      final angle = -math.pi / 2 + i * math.pi / 5;
+      final pt =
+          center + Offset(radius * math.cos(angle), radius * math.sin(angle));
+      if (i == 0) {
+        path.moveTo(pt.dx, pt.dy);
+      } else {
+        path.lineTo(pt.dx, pt.dy);
+      }
+    }
+    path.close();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_RevealMapPainter old) =>
+      targetLngLat != old.targetLngLat ||
+      guessLngLats.length != old.guessLngLats.length ||
+      clueLngLats.length != old.clueLngLats.length ||
+      zoom != old.zoom;
+}

--- a/lib/core/widgets/reveal_map.dart
+++ b/lib/core/widgets/reveal_map.dart
@@ -14,23 +14,77 @@ import '../../game/map/country_data.dart';
 /// Pinch-zoomable and pannable; marker and line sizes counter-scale with
 /// zoom so they keep a constant on-screen size. Includes the legend and
 /// gesture hint so every mode presents results identically.
+/// One star marker on the reveal map — an answer/target location.
+class RevealStar {
+  const RevealStar(this.lngLat, {this.color = FlitColors.gold});
+
+  final Vector2 lngLat;
+  final Color color;
+}
+
+/// One dot marker, optionally tied by a connector line to a location
+/// (e.g. a wrong guess pointing at its own question's answer).
+class RevealDot {
+  const RevealDot(this.lngLat, {this.color = FlitColors.error, this.lineTo});
+
+  final Vector2 lngLat;
+  final Color color;
+  final Vector2? lineTo;
+}
+
+/// A polyline layer (e.g. the flown path in the flight modes).
+class RevealPath {
+  const RevealPath(this.points, {this.color = FlitColors.accent});
+
+  final List<Vector2> points;
+  final Color color;
+}
+
+/// One legend entry below the map.
+class RevealLegendItem {
+  const RevealLegendItem(this.icon, this.color, this.label);
+
+  final IconData icon;
+  final Color color;
+  final String label;
+}
+
 class RevealMap extends StatefulWidget {
   const RevealMap({
     super.key,
-    required this.targetLngLat,
+    this.targetLngLat,
     this.clueLngLats = const [],
     this.guessLngLats = const [],
+    this.stars = const [],
+    this.dots = const [],
+    this.paths = const [],
+    this.legendItems,
     this.showLegend = true,
   });
 
-  /// The answer location as (lng, lat) degrees.
-  final Vector2 targetLngLat;
+  /// The single answer location as (lng, lat) degrees — Triangulation's
+  /// classic shape. [guessLngLats] connect to it. Modes with several
+  /// targets use [stars]/[dots] instead.
+  final Vector2? targetLngLat;
 
   /// Original clue anchor locations, if the mode has them.
   final List<Vector2> clueLngLats;
 
-  /// Wrong-guess locations.
+  /// Wrong-guess locations (connected to [targetLngLat]).
   final List<Vector2> guessLngLats;
+
+  /// Additional star markers (multi-target modes).
+  final List<RevealStar> stars;
+
+  /// Additional dot markers with optional per-dot connector lines.
+  final List<RevealDot> dots;
+
+  /// Polyline layers, drawn beneath the markers.
+  final List<RevealPath> paths;
+
+  /// Custom legend; when null the classic answer/clues/guesses legend is
+  /// derived from whichever of the simple layers are present.
+  final List<RevealLegendItem>? legendItems;
 
   final bool showLegend;
 
@@ -61,6 +115,23 @@ class _RevealMapState extends State<RevealMap> {
     super.dispose();
   }
 
+  List<RevealLegendItem> _defaultLegend() => [
+        if (widget.targetLngLat != null || widget.stars.isNotEmpty)
+          const RevealLegendItem(Icons.star, FlitColors.gold, 'answer'),
+        if (widget.clueLngLats.isNotEmpty)
+          const RevealLegendItem(
+            Icons.circle_outlined,
+            FlitColors.accent,
+            'clues',
+          ),
+        if (widget.guessLngLats.isNotEmpty || widget.dots.isNotEmpty)
+          const RevealLegendItem(
+            Icons.circle,
+            FlitColors.error,
+            'your guesses',
+          ),
+      ];
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -79,6 +150,9 @@ class _RevealMapState extends State<RevealMap> {
                     targetLngLat: widget.targetLngLat,
                     clueLngLats: widget.clueLngLats,
                     guessLngLats: widget.guessLngLats,
+                    stars: widget.stars,
+                    dots: widget.dots,
+                    paths: widget.paths,
                     zoom: _zoom,
                   ),
                 ),
@@ -88,37 +162,26 @@ class _RevealMapState extends State<RevealMap> {
         ),
         if (widget.showLegend) ...[
           const SizedBox(height: 8),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
+          Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 12,
+            runSpacing: 2,
             children: [
-              const Icon(Icons.star, color: FlitColors.gold, size: 13),
-              const SizedBox(width: 3),
-              const Text(
-                'answer',
-                style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
-              ),
-              if (widget.clueLngLats.isNotEmpty) ...[
-                const SizedBox(width: 12),
-                const Icon(
-                  Icons.circle_outlined,
-                  color: FlitColors.accent,
-                  size: 11,
+              for (final item in widget.legendItems ?? _defaultLegend())
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(item.icon, color: item.color, size: 12),
+                    const SizedBox(width: 3),
+                    Text(
+                      item.label,
+                      style: const TextStyle(
+                        color: FlitColors.textMuted,
+                        fontSize: 11,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(width: 3),
-                const Text(
-                  'clues',
-                  style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
-                ),
-              ],
-              if (widget.guessLngLats.isNotEmpty) ...[
-                const SizedBox(width: 12),
-                const Icon(Icons.circle, color: FlitColors.error, size: 11),
-                const SizedBox(width: 3),
-                const Text(
-                  'your guesses',
-                  style: TextStyle(color: FlitColors.textMuted, fontSize: 11),
-                ),
-              ],
             ],
           ),
           const SizedBox(height: 2),
@@ -143,12 +206,18 @@ class _RevealMapPainter extends CustomPainter {
     required this.targetLngLat,
     required this.clueLngLats,
     required this.guessLngLats,
+    required this.stars,
+    required this.dots,
+    required this.paths,
     this.zoom = 1,
   });
 
-  final Vector2 targetLngLat;
+  final Vector2? targetLngLat;
   final List<Vector2> clueLngLats;
   final List<Vector2> guessLngLats;
+  final List<RevealStar> stars;
+  final List<RevealDot> dots;
+  final List<RevealPath> paths;
   final double zoom;
 
   @override
@@ -183,18 +252,43 @@ class _RevealMapPainter extends CustomPainter {
       }
     }
 
-    final target = project(targetLngLat.x, targetLngLat.y);
+    // Polyline layers (flight trails) beneath all markers.
+    for (final path in paths) {
+      if (path.points.length < 2) continue;
+      final p = Path();
+      for (var i = 0; i < path.points.length; i++) {
+        final pt = project(path.points[i].x, path.points[i].y);
+        if (i == 0) {
+          p.moveTo(pt.dx, pt.dy);
+        } else {
+          p.lineTo(pt.dx, pt.dy);
+        }
+      }
+      canvas.drawPath(
+        p,
+        Paint()
+          ..color = path.color.withOpacity(0.7)
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1.2 / z
+          ..strokeCap = StrokeCap.round,
+      );
+    }
+
+    final target =
+        targetLngLat == null ? null : project(targetLngLat!.x, targetLngLat!.y);
 
     // Clue anchors: accent-ringed dots with a faint line to the answer.
     for (final clue in clueLngLats) {
       final pos = project(clue.x, clue.y);
-      canvas.drawLine(
-        pos,
-        target,
-        Paint()
-          ..color = FlitColors.textSecondary.withOpacity(0.3)
-          ..strokeWidth = 0.8 / z,
-      );
+      if (target != null) {
+        canvas.drawLine(
+          pos,
+          target,
+          Paint()
+            ..color = FlitColors.textSecondary.withOpacity(0.3)
+            ..strokeWidth = 0.8 / z,
+        );
+      }
       canvas.drawCircle(pos, 3 / z, Paint()..color = FlitColors.backgroundDark);
       canvas.drawCircle(
         pos,
@@ -206,20 +300,47 @@ class _RevealMapPainter extends CustomPainter {
       );
     }
 
-    // Guess dots + connector lines toward the answer.
+    // Guess dots + connector lines toward the single answer.
     for (final g in guessLngLats) {
       final pos = project(g.x, g.y);
-      canvas.drawLine(
-        pos,
-        target,
-        Paint()
-          ..color = FlitColors.error.withOpacity(0.5)
-          ..strokeWidth = 1 / z,
-      );
+      if (target != null) {
+        canvas.drawLine(
+          pos,
+          target,
+          Paint()
+            ..color = FlitColors.error.withOpacity(0.5)
+            ..strokeWidth = 1 / z,
+        );
+      }
       canvas.drawCircle(pos, 3.5 / z, Paint()..color = FlitColors.error);
     }
 
-    _drawStar(canvas, target, 7 / z, Paint()..color = FlitColors.gold);
+    // Free-form dots (multi-target modes), each with its own connector.
+    for (final dot in dots) {
+      final pos = project(dot.lngLat.x, dot.lngLat.y);
+      if (dot.lineTo != null) {
+        canvas.drawLine(
+          pos,
+          project(dot.lineTo!.x, dot.lineTo!.y),
+          Paint()
+            ..color = dot.color.withOpacity(0.5)
+            ..strokeWidth = 1 / z,
+        );
+      }
+      canvas.drawCircle(pos, 3.5 / z, Paint()..color = dot.color);
+    }
+
+    for (final star in stars) {
+      _drawStar(
+        canvas,
+        project(star.lngLat.x, star.lngLat.y),
+        6 / z,
+        Paint()..color = star.color,
+      );
+    }
+    if (target != null) {
+      _drawStar(canvas, target, 7 / z, Paint()..color = FlitColors.gold);
+    }
   }
 
   void _drawStar(Canvas canvas, Offset center, double r, Paint paint) {
@@ -244,5 +365,8 @@ class _RevealMapPainter extends CustomPainter {
       targetLngLat != old.targetLngLat ||
       guessLngLats.length != old.guessLngLats.length ||
       clueLngLats.length != old.clueLngLats.length ||
+      stars.length != old.stars.length ||
+      dots.length != old.dots.length ||
+      paths.length != old.paths.length ||
       zoom != old.zoom;
 }

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -12,6 +12,7 @@ import '../../core/utils/haptics.dart';
 import '../../core/services/error_service.dart';
 import '../../core/services/game_settings.dart';
 import '../../core/theme/flit_colors.dart';
+import '../../core/widgets/reveal_map.dart';
 import '../../core/utils/game_log.dart';
 import '../../core/utils/web_error_bridge.dart';
 import '../../core/widgets/settings_sheet.dart';
@@ -26,6 +27,7 @@ import '../challenge/challenge_result_screen.dart';
 import '../../game/clues/clue_types.dart';
 import '../../game/data/country_difficulty.dart';
 import '../../game/flit_game.dart';
+import '../../game/map/country_data.dart';
 import '../../game/map/descent_map_view.dart';
 import '../../game/map/region.dart';
 import '../../game/session/game_session.dart';
@@ -223,6 +225,19 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
 
   /// Per-round results for the summary screen.
   final List<_RoundResult> _roundResults = [];
+
+  /// Snapshot of this round's flight trail, downsampled for the reveal
+  /// map (the session's full path can hold thousands of frames).
+  List<Vector2> _takeRoundPath() {
+    final full = _session?.flightPath ?? const <Vector2>[];
+    if (full.length <= 120) return List.of(full);
+    final stride = (full.length / 120).ceil();
+    return [
+      for (var i = 0; i < full.length; i += stride) full[i],
+      full.last,
+    ];
+  }
+
   late final Random _sessionSeedRandom;
 
   /// Country codes already used in this daily challenge (prevents duplicates).
@@ -889,6 +904,7 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
           fuelFraction: fuelFrac,
           useTimeScoring: true,
           timePenalty: _session!.timePenalty,
+          path: _takeRoundPath(),
         ),
       );
     }
@@ -1108,6 +1124,7 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
           fuelFraction: fuelFrac,
           useTimeScoring: true,
           timePenalty: _session!.timePenalty,
+          path: _takeRoundPath(),
         ),
       );
     }
@@ -1563,6 +1580,7 @@ class _PlayScreenState extends ConsumerState<PlayScreen> {
           rawScore: 0,
           hintsUsed: _hintTier,
           completed: false,
+          path: _takeRoundPath(),
         ),
       );
     }
@@ -2131,6 +2149,7 @@ class _RoundResult {
     this.fuelFraction = 1.0,
     this.useTimeScoring = false,
     this.timePenalty,
+    this.path = const <Vector2>[],
   });
 
   final String countryName;
@@ -2158,6 +2177,10 @@ class _RoundResult {
 
   /// Time penalty from [GameSession.timePenalty] (null if fuel-based).
   final int? timePenalty;
+
+  /// Downsampled flight trail flown during this round (lng/lat), for the
+  /// end-of-game reveal map.
+  final List<Vector2> path;
 
   /// Hint penalty computed from [hintsUsed] and tier penalties.
   int get hintPenalty {
@@ -2442,6 +2465,45 @@ class _ResultDialog extends ConsumerWidget {
   /// Coins earned from free flight per-clue rewards this session.
   final int freeFlightCoinsEarned;
 
+  /// World map of the whole run: a star per round's target (gold =
+  /// found, red = missed) and the flown trail per round. Skipped when no
+  /// target resolves (e.g. empty codes from unseen rounds only).
+  List<Widget> _buildRevealMap() {
+    final stars = <RevealStar>[];
+    final paths = <RevealPath>[];
+    for (final r in roundResults) {
+      final target = CountryData.getCapital(r.countryCode)?.location;
+      if (target != null) {
+        stars.add(
+          RevealStar(
+            target,
+            color: r.completed ? FlitColors.gold : FlitColors.error,
+          ),
+        );
+      }
+      if (r.path.length >= 2) paths.add(RevealPath(r.path));
+    }
+    if (stars.isEmpty) return const [];
+    return [
+      const SizedBox(height: 16),
+      RevealMap(
+        stars: stars,
+        paths: paths,
+        legendItems: [
+          const RevealLegendItem(Icons.star, FlitColors.gold, 'found'),
+          if (stars.any((s) => s.color == FlitColors.error))
+            const RevealLegendItem(Icons.star, FlitColors.error, 'missed'),
+          if (paths.isNotEmpty)
+            const RevealLegendItem(
+              Icons.timeline,
+              FlitColors.accent,
+              'your flight',
+            ),
+        ],
+      ),
+    ];
+  }
+
   static String _formatTime(Duration d) {
     final m = d.inMinutes;
     final s = d.inSeconds % 60;
@@ -2569,6 +2631,10 @@ class _ResultDialog extends ConsumerWidget {
                 const SizedBox(height: 8),
                 _ScoreBreakdown(result: roundResults.first),
               ],
+              // Flight reveal map: each round's target starred (gold =
+              // found, red = missed) with the flown trail — the same
+              // post-round reveal as Triangulation.
+              ..._buildRevealMap(),
               // Per-round summary table for multi-round modes.
               if (isMultiRound && roundResults.isNotEmpty) ...[
                 const SizedBox(height: 16),

--- a/lib/features/quiz/quiz_results_screen.dart
+++ b/lib/features/quiz/quiz_results_screen.dart
@@ -4,8 +4,10 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
+import '../../core/widgets/reveal_map.dart';
 import '../../data/providers/account_provider.dart';
 import '../../data/services/leaderboard_service.dart';
+import '../../game/map/country_data.dart';
 import '../../game/map/region.dart';
 import '../../game/quiz/flight_school_level.dart';
 import '../../game/quiz/quiz_category.dart';
@@ -280,6 +282,11 @@ class _QuizResultsScreenState extends ConsumerState<QuizResultsScreen>
                             _buildStatsGrid(summary),
                             const SizedBox(height: 16),
 
+                            // Reveal map: every question's answer starred,
+                            // wrong picks dotted — same reveal as
+                            // Triangulation.
+                            ..._buildRevealMap(summary),
+
                             // Detailed breakdown
                             _buildBreakdown(summary),
                             const SizedBox(height: 24),
@@ -302,6 +309,50 @@ class _QuizResultsScreenState extends ConsumerState<QuizResultsScreen>
         ),
       ),
     );
+  }
+
+  // ── Reveal map ──────────────────────────────────────────────────────────
+
+  /// World reveal map of the whole quiz: gold stars for answers found,
+  /// red stars for missed ones, red dots (with connector lines) where the
+  /// player's wrong tap landed. Only rendered for country-based regions —
+  /// US states / UK counties codes don't resolve to world capitals, and
+  /// type-in wrong answers carry no location, so absent data degrades
+  /// gracefully to stars only.
+  List<Widget> _buildRevealMap(QuizSummary summary) {
+    final stars = <RevealStar>[];
+    final dots = <RevealDot>[];
+    for (final r in summary.results) {
+      final target = CountryData.getCapital(r.correctCode)?.location;
+      if (target == null) continue; // non-country code (states, counties)
+      stars.add(
+        RevealStar(target,
+            color: r.correct ? FlitColors.gold : FlitColors.error),
+      );
+      if (!r.correct) {
+        final guess = CountryData.getCapital(r.answerCode)?.location;
+        if (guess != null) dots.add(RevealDot(guess, lineTo: target));
+      }
+    }
+    if (stars.isEmpty) return const [];
+    return [
+      RevealMap(
+        stars: stars,
+        dots: dots,
+        legendItems: [
+          const RevealLegendItem(Icons.star, FlitColors.gold, 'correct'),
+          if (stars.any((s) => s.color == FlitColors.error))
+            const RevealLegendItem(Icons.star, FlitColors.error, 'missed'),
+          if (dots.isNotEmpty)
+            const RevealLegendItem(
+              Icons.circle,
+              FlitColors.error,
+              'your pick',
+            ),
+        ],
+      ),
+      const SizedBox(height: 16),
+    ];
   }
 
   // ── Grade badge ─────────────────────────────────────────────────────────

--- a/lib/features/triangulation/triangulation_game_screen.dart
+++ b/lib/features/triangulation/triangulation_game_screen.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
-import 'dart:math' as math;
 
-import 'package:flame/components.dart' show Vector2;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +9,7 @@ import '../../core/theme/flit_colors.dart';
 import '../../core/utils/haptics.dart';
 import '../../core/widgets/country_flag.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
+import '../../core/widgets/reveal_map.dart';
 import '../../data/models/daily_result.dart';
 import '../../data/providers/account_provider.dart';
 import '../../game/clues/clue_types.dart';
@@ -614,7 +613,7 @@ class _StatusBar extends StatelessWidget {
 // Round result: answer revealed on a map
 // ─────────────────────────────────────────────────────────────────────────
 
-class _RoundResultView extends StatefulWidget {
+class _RoundResultView extends StatelessWidget {
   const _RoundResultView({
     required this.state,
     required this.isLastRound,
@@ -628,38 +627,7 @@ class _RoundResultView extends StatefulWidget {
   final VoidCallback onContinue;
 
   @override
-  State<_RoundResultView> createState() => _RoundResultViewState();
-}
-
-class _RoundResultViewState extends State<_RoundResultView> {
-  /// Drives the reveal map's pinch-zoom/pan; the current zoom feeds back
-  /// into the painter so markers keep a constant on-screen size.
-  final TransformationController _mapController = TransformationController();
-  double _mapZoom = 1;
-
-  @override
-  void initState() {
-    super.initState();
-    _mapController.addListener(_onMapTransform);
-  }
-
-  void _onMapTransform() {
-    final zoom = _mapController.value.getMaxScaleOnAxis();
-    if ((zoom - _mapZoom).abs() > 0.01) setState(() => _mapZoom = zoom);
-  }
-
-  @override
-  void dispose() {
-    _mapController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final state = widget.state;
-    final isLastRound = widget.isLastRound;
-    final isCapitalTarget = widget.isCapitalTarget;
-    final onContinue = widget.onContinue;
     final round = state.round;
     return Column(
       children: [
@@ -716,83 +684,16 @@ class _RoundResultViewState extends State<_RoundResultView> {
                   ],
                 ),
                 const SizedBox(height: 16),
-                // The reveal: world map with the target and every guess.
-                // Pinch to zoom / drag to pan for a closer look at
-                // clustered markers.
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(12),
-                  child: Container(
-                    color: FlitColors.backgroundMid,
-                    child: AspectRatio(
-                      aspectRatio: 2,
-                      child: InteractiveViewer(
-                        transformationController: _mapController,
-                        maxScale: 12,
-                        child: CustomPaint(
-                          painter: _ResultMapPainter(
-                            targetLngLat: round.targetCapitalLngLat,
-                            guesses: state.wrongGuesses,
-                            clues: round.clues,
-                            zoom: _mapZoom,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 8),
-                // Map legend.
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Icon(Icons.star, color: FlitColors.gold, size: 13),
-                    const SizedBox(width: 3),
-                    const Text(
-                      'answer',
-                      style: TextStyle(
-                        color: FlitColors.textMuted,
-                        fontSize: 11,
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    const Icon(
-                      Icons.circle_outlined,
-                      color: FlitColors.accent,
-                      size: 11,
-                    ),
-                    const SizedBox(width: 3),
-                    const Text(
-                      'clues',
-                      style: TextStyle(
-                        color: FlitColors.textMuted,
-                        fontSize: 11,
-                      ),
-                    ),
-                    if (state.wrongGuesses.isNotEmpty) ...[
-                      const SizedBox(width: 12),
-                      const Icon(
-                        Icons.circle,
-                        color: FlitColors.error,
-                        size: 11,
-                      ),
-                      const SizedBox(width: 3),
-                      const Text(
-                        'your guesses',
-                        style: TextStyle(
-                          color: FlitColors.textMuted,
-                          fontSize: 11,
-                        ),
-                      ),
-                    ],
+                // The reveal: shared world map with the target, the
+                // original clue anchors, and every wrong guess.
+                RevealMap(
+                  targetLngLat: round.targetCapitalLngLat,
+                  clueLngLats: [
+                    for (final c in round.clues) c.capitalLngLat,
                   ],
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  'pinch to zoom · drag to pan',
-                  style: TextStyle(
-                    color: FlitColors.textMuted.withOpacity(0.7),
-                    fontSize: 10,
-                  ),
+                  guessLngLats: [
+                    for (final g in state.wrongGuesses) g.capitalLngLat,
+                  ],
                 ),
                 const SizedBox(height: 8),
                 if (state.wrongGuesses.isNotEmpty)
@@ -886,128 +787,6 @@ class _RoundResultViewState extends State<_RoundResultView> {
       ],
     );
   }
-}
-
-/// Equirectangular world map with the target capital (gold star), each
-/// wrong guess (red dot), and the round's original clue anchors (accent
-/// ringed dots) so the reveal shows the full triangulation picture.
-///
-/// [zoom] is the InteractiveViewer's current scale; markers and line
-/// widths are divided by it so they keep a constant on-screen size while
-/// the map itself zooms.
-class _ResultMapPainter extends CustomPainter {
-  _ResultMapPainter({
-    required this.targetLngLat,
-    required this.guesses,
-    required this.clues,
-    this.zoom = 1,
-  });
-
-  final Vector2 targetLngLat;
-  final List<TriangulationGuess> guesses;
-  final List<TriangulationClue> clues;
-  final double zoom;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final z = zoom.clamp(1.0, 100.0);
-    final landPaint = Paint()..color = FlitColors.landMass.withOpacity(0.45);
-    final borderPaint = Paint()
-      ..color = FlitColors.border.withOpacity(0.6)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 0.6 / z;
-
-    Offset project(double lng, double lat) => Offset(
-          (lng + 180) / 360 * size.width,
-          (90 - lat) / 180 * size.height,
-        );
-
-    for (final country in CountryData.countries) {
-      for (final poly in country.polygons) {
-        if (poly.length < 3) continue;
-        final path = Path();
-        for (var i = 0; i < poly.length; i++) {
-          final pt = project(poly[i].x, poly[i].y);
-          if (i == 0) {
-            path.moveTo(pt.dx, pt.dy);
-          } else {
-            path.lineTo(pt.dx, pt.dy);
-          }
-        }
-        path.close();
-        canvas.drawPath(path, landPaint);
-        canvas.drawPath(path, borderPaint);
-      }
-    }
-
-    final target = project(targetLngLat.x, targetLngLat.y);
-
-    // Original clue anchors: accent ringed dots with a faint line to the
-    // target, so the reveal shows what the arrows were pointing at.
-    for (final clue in clues) {
-      final pos = project(clue.capitalLngLat.x, clue.capitalLngLat.y);
-      canvas.drawLine(
-        pos,
-        target,
-        Paint()
-          ..color = FlitColors.textSecondary.withOpacity(0.3)
-          ..strokeWidth = 0.8 / z,
-      );
-      canvas.drawCircle(
-        pos,
-        3 / z,
-        Paint()..color = FlitColors.backgroundDark,
-      );
-      canvas.drawCircle(
-        pos,
-        3 / z,
-        Paint()
-          ..color = FlitColors.accent
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 1.6 / z,
-      );
-    }
-
-    // Guess dots + connector lines toward the target.
-    for (final g in guesses) {
-      final pos = project(g.capitalLngLat.x, g.capitalLngLat.y);
-      canvas.drawLine(
-        pos,
-        target,
-        Paint()
-          ..color = FlitColors.error.withOpacity(0.5)
-          ..strokeWidth = 1 / z,
-      );
-      canvas.drawCircle(pos, 3.5 / z, Paint()..color = FlitColors.error);
-    }
-
-    // Target star.
-    _drawStar(canvas, target, 7 / z, Paint()..color = FlitColors.gold);
-  }
-
-  void _drawStar(Canvas canvas, Offset center, double r, Paint paint) {
-    final path = Path();
-    for (var i = 0; i < 10; i++) {
-      final radius = i.isEven ? r : r * 0.45;
-      final angle = -math.pi / 2 + i * math.pi / 5;
-      final pt =
-          center + Offset(math.cos(angle) * radius, math.sin(angle) * radius);
-      if (i == 0) {
-        path.moveTo(pt.dx, pt.dy);
-      } else {
-        path.lineTo(pt.dx, pt.dy);
-      }
-    }
-    path.close();
-    canvas.drawPath(path, paint);
-  }
-
-  @override
-  bool shouldRepaint(_ResultMapPainter old) =>
-      targetLngLat != old.targetLngLat ||
-      guesses.length != old.guesses.length ||
-      clues.length != old.clues.length ||
-      zoom != old.zoom;
 }
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
The post-round world-map reveal from Triangulation is now shared infrastructure (`core/widgets/reveal_map.dart`), and every mode with location data shows it:

- **Triangulation** — migrated to the shared widget first (identical behaviour, private painter deleted).
- **Flight School / Daily Briefing results** — new map section on the results screen: gold stars for answers found, red stars for missed ones, and red dots with connector lines showing where a wrong tap landed relative to the real answer. The per-question data already existed (`QuizAnswerResult.answerCode/correctCode`); it just was never rendered. Sub-country regions (US states, UK counties) and type-in wrong answers degrade gracefully — stars only, or no map when nothing resolves.
- **Daily Scramble / Free Flight / Training Sortie** — the end-of-game dialog now shows each round's target starred (gold = found, red = missed) **plus the actual flown trail per round**, captured at round end (downsampled to ~120 points) before the session resets.

`RevealMap` now supports generic layers — multi-target stars, dots with per-dot connectors, polyline paths, custom legends — while Triangulation's classic single-target/clues/guesses API is unchanged. Pinch-zoom with constant-size markers everywhere.

## Verification
- 850/850 tests pass; analyzer 0 errors / 0 warnings
- Both new map shapes (quiz stars+dots, flight stars+trails) rendered and visually verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_