### PR TITLE
Triangulation leaderboard tab + flight-path map hardening

### DIFF
--- a/lib/core/widgets/reveal_map.dart
+++ b/lib/core/widgets/reveal_map.dart
@@ -252,17 +252,29 @@ class _RevealMapPainter extends CustomPainter {
       }
     }
 
-    // Polyline layers (flight trails) beneath all markers.
+    // Longitudes from a live flight can drift outside [-180, 180).
+    double normLng(double lng) {
+      var v = (lng + 180) % 360;
+      if (v < 0) v += 360;
+      return v - 180;
+    }
+
+    // Polyline layers (flight trails) beneath all markers. Segments that
+    // cross the antimeridian break into a new subpath instead of drawing
+    // a streak across the whole map.
     for (final path in paths) {
       if (path.points.length < 2) continue;
       final p = Path();
+      double? prevLng;
       for (var i = 0; i < path.points.length; i++) {
-        final pt = project(path.points[i].x, path.points[i].y);
-        if (i == 0) {
+        final lng = normLng(path.points[i].x);
+        final pt = project(lng, path.points[i].y);
+        if (i == 0 || (lng - prevLng!).abs() > 180) {
           p.moveTo(pt.dx, pt.dy);
         } else {
           p.lineTo(pt.dx, pt.dy);
         }
+        prevLng = lng;
       }
       canvas.drawPath(
         p,
@@ -272,6 +284,9 @@ class _RevealMapPainter extends CustomPainter {
           ..strokeWidth = 1.2 / z
           ..strokeCap = StrokeCap.round,
       );
+      // Take-off dot so the trail's direction reads at a glance.
+      final start = project(normLng(path.points.first.x), path.points.first.y);
+      canvas.drawCircle(start, 2.5 / z, Paint()..color = path.color);
     }
 
     final target =

--- a/lib/data/models/leaderboard_entry.dart
+++ b/lib/data/models/leaderboard_entry.dart
@@ -130,7 +130,12 @@ extension GameModeTabExtension on GameModeTab {
 }
 
 /// Top-level leaderboard mode tab.
-enum LeaderboardMode { dailyScramble, trainingFlight, flightBriefing }
+enum LeaderboardMode {
+  dailyScramble,
+  trainingFlight,
+  flightBriefing,
+  dailyTriangulation,
+}
 
 extension LeaderboardModeExtension on LeaderboardMode {
   String get displayName {
@@ -141,6 +146,8 @@ extension LeaderboardModeExtension on LeaderboardMode {
         return 'TRAINING FLIGHT';
       case LeaderboardMode.flightBriefing:
         return 'FLIGHT BRIEFING';
+      case LeaderboardMode.dailyTriangulation:
+        return 'TRIANGULATION';
     }
   }
 
@@ -153,6 +160,8 @@ extension LeaderboardModeExtension on LeaderboardMode {
         return null; // neq 'daily' and neq 'briefing'
       case LeaderboardMode.flightBriefing:
         return 'briefing';
+      case LeaderboardMode.dailyTriangulation:
+        return 'daily_triangulation';
     }
   }
 }

--- a/lib/data/services/leaderboard_service.dart
+++ b/lib/data/services/leaderboard_service.dart
@@ -560,10 +560,11 @@ class LeaderboardService {
         return query.eq('region', 'daily');
       case LeaderboardMode.flightBriefing:
         return query.eq('region', 'briefing');
+      case LeaderboardMode.dailyTriangulation:
+        return query.eq('region', 'daily_triangulation');
       case LeaderboardMode.trainingFlight:
-        // Exclude every daily/quiz region so those runs don't pollute the
-        // flight boards ('daily_triangulation' rows are recorded for
-        // history/anti-cheat; they get their own board when one ships).
+        // Exclude every daily/quiz region so those runs don't pollute
+        // the flight boards.
         return query
             .neq('region', 'daily')
             .neq('region', 'briefing')
@@ -606,6 +607,9 @@ class LeaderboardService {
           break;
         case LeaderboardMode.flightBriefing:
           filtered = query.eq('region', 'briefing');
+          break;
+        case LeaderboardMode.dailyTriangulation:
+          filtered = query.eq('region', 'daily_triangulation');
           break;
         case LeaderboardMode.trainingFlight:
           filtered = query

--- a/lib/features/leaderboard/leaderboard_screen.dart
+++ b/lib/features/leaderboard/leaderboard_screen.dart
@@ -111,7 +111,10 @@ class _LeaderboardScreenState extends State<LeaderboardScreen>
   @override
   void initState() {
     super.initState();
-    _modeTabController = TabController(length: 3, vsync: this);
+    _modeTabController = TabController(
+      length: LeaderboardMode.values.length,
+      vsync: this,
+    );
     _modeTabController.addListener(_onModeChanged);
     _loadData();
   }
@@ -253,10 +256,13 @@ class _LeaderboardScreenState extends State<LeaderboardScreen>
               fontSize: 13,
               fontWeight: FontWeight.w500,
             ),
+            isScrollable: true,
+            tabAlignment: TabAlignment.center,
             tabs: const [
               Tab(text: 'SCRAMBLE'),
               Tab(text: 'TRAINING'),
               Tab(text: 'BRIEFING'),
+              Tab(text: 'TRIANGULATION'),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary

### Triangulation leaderboard
Daily Triangulation scores have been recorded under `region = 'daily_triangulation'` since the economy wiring — they now get their own board:
- New `LeaderboardMode.dailyTriangulation` (display name, region filter)
- Service query support (`eq('region', 'daily_triangulation')`); training-flight boards continue to exclude it
- Fourth **TRIANGULATION** tab in the leaderboard screen; the tab bar is now scrollable so all four fit on phones
- No spoiler embargo needed — Triangulation stores only proximity-colour emojis, never round details

### Flight path on the reveal map
The flight trail (shipped in #452) is hardened:
- Longitudes normalised into [-180, 180) — a live flight's longitude can drift outside the range, which would have projected the trail off the map
- Segments crossing the antimeridian split into separate subpaths instead of streaking across the whole map (Pacific crossings render correctly)
- Each trail gets a small take-off dot so its direction reads at a glance

## Verification
- 850/850 tests pass; analyzer 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_