### PR TITLE
Optimal-route overlay + per-clue performance rows on the mission report

### DIFF
--- a/lib/core/utils/math_utils.dart
+++ b/lib/core/utils/math_utils.dart
@@ -73,3 +73,33 @@ double flatMapBearingDeg(Vector2 from, Vector2 to) {
   final deg = atan2(dLng, dPsi) * rad2deg;
   return (deg % 360 + 360) % 360;
 }
+
+/// Points along the great-circle (shortest) route from [from] to [to],
+/// as (lng, lat) degrees — spherical linear interpolation on the unit
+/// sphere. Used to draw the "optimal route" overlay on reveal maps; the
+/// polyline may cross the antimeridian (renderers split it there).
+List<Vector2> greatCirclePoints(Vector2 from, Vector2 to, {int samples = 48}) {
+  Vector3 toXyz(Vector2 lngLat) {
+    final lng = lngLat.x * deg2rad;
+    final lat = lngLat.y * deg2rad;
+    return Vector3(cos(lat) * cos(lng), cos(lat) * sin(lng), sin(lat));
+  }
+
+  final a = toXyz(from);
+  final b = toXyz(to);
+  final angle = acos(a.dot(b).clamp(-1.0, 1.0));
+  if (angle < 1e-6) return [from.clone(), to.clone()];
+
+  final sinAngle = sin(angle);
+  return [
+    for (var i = 0; i <= samples; i++)
+      () {
+        final t = i / samples;
+        final w1 = sin((1 - t) * angle) / sinAngle;
+        final w2 = sin(t * angle) / sinAngle;
+        final p = a * w1 + b * w2;
+        return Vector2(
+            atan2(p.y, p.x) * rad2deg, asin(p.z.clamp(-1.0, 1.0)) * rad2deg);
+      }(),
+  ];
+}

--- a/lib/core/widgets/mission_report_card.dart
+++ b/lib/core/widgets/mission_report_card.dart
@@ -10,6 +10,16 @@ class ReportStat {
   final String value;
 }
 
+/// One per-round performance row: coloured emoji + label + value
+/// (e.g. 🟢  France  94%).
+class ReportRow {
+  const ReportRow(this.emoji, this.label, this.value);
+
+  final String emoji;
+  final String label;
+  final String value;
+}
+
 /// The downloadable end-of-game summary card — a branded, image-ready
 /// "mission report" that goes beyond the plain emoji share text.
 ///
@@ -25,6 +35,7 @@ class MissionReportCard extends StatelessWidget {
     this.subtitle,
     required this.score,
     this.emojiGrid,
+    this.rows = const [],
     this.stats = const [],
     this.map,
     this.footnote,
@@ -34,6 +45,12 @@ class MissionReportCard extends StatelessWidget {
   final String? subtitle;
   final int score;
   final String? emojiGrid;
+
+  /// Per-round performance rows (coloured emoji + label + value), the
+  /// classic per-clue breakdown players share. Long sessions are capped
+  /// with a "+N more" row.
+  final List<ReportRow> rows;
+
   final List<ReportStat> stats;
 
   /// Mini reveal map (e.g. [RevealMapThumbnail]); omit for daily modes.
@@ -144,6 +161,61 @@ class MissionReportCard extends StatelessWidget {
                 ),
             ],
           ),
+          if (rows.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: FlitColors.cardBackground.withOpacity(0.6),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Column(
+                children: [
+                  for (final row in rows.take(_maxRows))
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 1.5),
+                      child: Row(
+                        children: [
+                          Text(row.emoji, style: const TextStyle(fontSize: 11)),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              row.label,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                color: FlitColors.textSecondary,
+                                fontSize: 11,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                          Text(
+                            row.value,
+                            style: const TextStyle(
+                              color: FlitColors.textPrimary,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  if (rows.length > _maxRows)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(
+                        '+${rows.length - _maxRows} more',
+                        style: const TextStyle(
+                          color: FlitColors.textMuted,
+                          fontSize: 10,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
           if (map != null) ...[
             const SizedBox(height: 12),
             map!,
@@ -210,6 +282,10 @@ class MissionReportCard extends StatelessWidget {
       ),
     );
   }
+
+  /// Rows shown before collapsing to "+N more" (keeps long free-flight
+  /// sessions from producing a poster-sized card).
+  static const int _maxRows = 10;
 
   static String _formatScore(int score) {
     final s = score.toString();

--- a/lib/core/widgets/reveal_map.dart
+++ b/lib/core/widgets/reveal_map.dart
@@ -34,10 +34,19 @@ class RevealDot {
 
 /// A polyline layer (e.g. the flown path in the flight modes).
 class RevealPath {
-  const RevealPath(this.points, {this.color = FlitColors.accent});
+  const RevealPath(
+    this.points, {
+    this.color = FlitColors.accent,
+    this.dashed = false,
+  });
 
   final List<Vector2> points;
   final Color color;
+
+  /// Dashed rendering — used for the faint "optimal route" overlay so it
+  /// reads as a reference line, not a flown trail. Dashed paths also skip
+  /// the take-off dot.
+  final bool dashed;
 }
 
 /// One legend entry below the map.
@@ -303,7 +312,7 @@ class _RevealMapPainter extends CustomPainter {
     // a streak across the whole map.
     for (final path in paths) {
       if (path.points.length < 2) continue;
-      final p = Path();
+      var p = Path();
       double? prevLng;
       for (var i = 0; i < path.points.length; i++) {
         final lng = normLng(path.points[i].x);
@@ -315,17 +324,21 @@ class _RevealMapPainter extends CustomPainter {
         }
         prevLng = lng;
       }
+      if (path.dashed) p = _dashPath(p, dash: 4 / z, gap: 3.5 / z);
       canvas.drawPath(
         p,
         Paint()
-          ..color = path.color.withOpacity(0.7)
+          ..color = path.color.withOpacity(path.dashed ? 0.55 : 0.7)
           ..style = PaintingStyle.stroke
           ..strokeWidth = 1.2 / z
           ..strokeCap = StrokeCap.round,
       );
-      // Take-off dot so the trail's direction reads at a glance.
-      final start = project(normLng(path.points.first.x), path.points.first.y);
-      canvas.drawCircle(start, 2.5 / z, Paint()..color = path.color);
+      if (!path.dashed) {
+        // Take-off dot so the trail's direction reads at a glance.
+        final start =
+            project(normLng(path.points.first.x), path.points.first.y);
+        canvas.drawCircle(start, 2.5 / z, Paint()..color = path.color);
+      }
     }
 
     final target =
@@ -395,6 +408,21 @@ class _RevealMapPainter extends CustomPainter {
     if (target != null) {
       _drawStar(canvas, target, 7 / z, Paint()..color = FlitColors.gold);
     }
+  }
+
+  /// Converts [source] into a dashed copy by walking its metrics.
+  static Path _dashPath(Path source,
+      {required double dash, required double gap}) {
+    final dest = Path();
+    for (final metric in source.computeMetrics()) {
+      var distance = 0.0;
+      while (distance < metric.length) {
+        final end = (distance + dash).clamp(0.0, metric.length);
+        dest.addPath(metric.extractPath(distance, end), Offset.zero);
+        distance = end + gap;
+      }
+    }
+    return dest;
   }
 
   void _drawStar(Canvas canvas, Offset center, double r, Paint paint) {

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -2593,6 +2593,46 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
     }
   }
 
+  /// Round-performance emoji: the classic daily-share colours (hints
+  /// used → green/yellow/orange, failed → red).
+  static String _roundEmoji(_RoundResult r) {
+    if (!r.completed) return '\u{1F534}';
+    if (r.hintsUsed == 0) return '\u{1F7E2}';
+    if (r.hintsUsed <= 2) return '\u{1F7E1}';
+    if (r.hintsUsed <= 4) return '\u{1F7E0}';
+    return '\u{1F534}';
+  }
+
+  /// Difficulty-weighted max score for a round (proficiency denominator).
+  static int _roundMax(_RoundResult r) => r.countryCode.isEmpty
+      ? 10000
+      : (10000 * difficultyMultiplier(r.countryCode)).round();
+
+  /// Per-clue rows for the report card: emoji + country + efficiency.
+  /// The daily challenge hides country names (a shared card must not
+  /// spoil the day's answers) — rounds are numbered instead.
+  List<ReportRow> _reportRows() => [
+        for (final (i, r) in widget.roundResults.indexed)
+          ReportRow(
+            _roundEmoji(r),
+            widget.isDailyChallenge ? 'Round ${i + 1}' : r.countryName,
+            '${(r.score / _roundMax(r) * 100).clamp(0, 100).round()}%',
+          ),
+      ];
+
+  /// Overall efficiency: total score over difficulty-weighted maximum,
+  /// mirroring DailyResult.proficiencyPercent.
+  int get _overallEfficiency {
+    var max = 0;
+    var total = 0;
+    for (final r in widget.roundResults) {
+      max += _roundMax(r);
+      total += r.score;
+    }
+    if (max == 0) return 0;
+    return (total / max * 100).clamp(0, 100).round();
+  }
+
   Widget _buildReportCard() {
     final layers = _revealLayers();
     final displayTime =
@@ -2611,12 +2651,15 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
           if (!_isMultiRound) widget.session.targetName,
         ].join(' · '),
         score: _isMultiRound ? widget.totalScore : widget.session.score,
+        rows: _reportRows(),
         stats: [
           ReportStat(
             'ROUNDS',
             '$foundCount/'
                 '${widget.roundResults.isNotEmpty ? widget.roundResults.length : widget.totalRounds}',
           ),
+          if (widget.roundResults.isNotEmpty)
+            ReportStat('EFFICIENCY', '$_overallEfficiency%'),
           ReportStat('TIME', _formatTime(displayTime)),
           if (coins > 0) ReportStat('COINS', '+$coins'),
         ],

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -12,6 +12,7 @@ import '../../core/utils/haptics.dart';
 import '../../core/services/error_service.dart';
 import '../../core/services/game_settings.dart';
 import '../../core/theme/flit_colors.dart';
+import '../../core/utils/math_utils.dart';
 import '../../core/utils/report_capture.dart';
 import '../../core/widgets/mission_report_card.dart';
 import '../../core/widgets/reveal_map.dart';
@@ -2515,7 +2516,21 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
           ),
         );
       }
-      if (r.path.length >= 2) paths.add(RevealPath(r.path));
+      if (r.path.length >= 2) {
+        paths.add(RevealPath(r.path));
+        // Faint gold dashed reference line: the great-circle (shortest)
+        // route from where this round started to its target, so the
+        // player can compare their trail against the optimal course.
+        if (target != null) {
+          paths.add(
+            RevealPath(
+              greatCirclePoints(r.path.first, target),
+              color: FlitColors.gold,
+              dashed: true,
+            ),
+          );
+        }
+      }
     }
     return (stars: stars, paths: paths);
   }
@@ -2535,12 +2550,18 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
           const RevealLegendItem(Icons.star, FlitColors.gold, 'found'),
           if (layers.stars.any((s) => s.color == FlitColors.error))
             const RevealLegendItem(Icons.star, FlitColors.error, 'missed'),
-          if (layers.paths.isNotEmpty)
+          if (layers.paths.isNotEmpty) ...[
             const RevealLegendItem(
               Icons.timeline,
               FlitColors.accent,
               'your flight',
             ),
+            const RevealLegendItem(
+              Icons.linear_scale,
+              FlitColors.gold,
+              'shortest route',
+            ),
+          ],
         ],
       ),
     ];


### PR DESCRIPTION
## Summary

### Faint gold dashed optimal route (flight reveal maps)
Every flown round now also draws the **great-circle shortest route** from the round's start to its target as a faint gold dashed line — players can compare their trail against the ideal course, including the counterintuitive polar arcs (LA→Tokyo optimal sweeps up past Alaska). New `greatCirclePoints` spherical sampler in math_utils; `RevealPath.dashed` rendering via PathMetrics (zoom-scaled dashes, no take-off dot on reference lines); "shortest route" legend entry. The mission-report thumbnail inherits it automatically.

### Per-clue performance rows (mission report card)
The classic per-round breakdown from the old text share now features on the downloadable image: one row per country with the familiar coloured emoji (🟢 no hints / 🟡 ≤2 / 🟠 ≤4 / 🔴 missed), per-country efficiency %, plus **EFFICIENCY** (overall, difficulty-weighted like proficiency) and **TIME** stat tiles. Long free-flight sessions collapse to "+N more" after 10 rows.

### Spoiler guarantees
- The **classic emoji text share is untouched** — SHARE still copies the old spoiler-free format; SAVE IMAGE is additive.
- The daily-challenge card numbers rounds instead of naming countries and still carries no map.

## Verification
- 852/852 tests pass; analyzer 0 errors / 0 warnings
- Goldens regenerated and visually verified (flight card with rows + efficiency tiles; dateline-crossing dashed arc demo rendered and shared with the user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_