### PR TITLE
Enriched friend profile: avatar, rank, license, career stats, top scores

### DIFF
--- a/lib/core/utils/aviation_rank.dart
+++ b/lib/core/utils/aviation_rank.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+/// Aviation rank for a player level — the single source of truth used by
+/// the profile screen, license screen, and friend profile sheet.
+({String title, IconData icon}) aviationRank(int level) {
+  if (level >= 50) {
+    return (title: 'Air Marshal', icon: Icons.stars);
+  }
+  if (level >= 40) {
+    return (title: 'Wing Commander', icon: Icons.military_tech);
+  }
+  if (level >= 30) {
+    return (title: 'Squadron Leader', icon: Icons.shield);
+  }
+  if (level >= 20) {
+    return (title: 'Flight Lieutenant', icon: Icons.workspace_premium);
+  }
+  if (level >= 15) {
+    return (title: 'Captain', icon: Icons.anchor);
+  }
+  if (level >= 10) {
+    return (title: 'First Officer', icon: Icons.flight);
+  }
+  if (level >= 5) {
+    return (title: 'Pilot Officer', icon: Icons.flight_takeoff);
+  }
+  if (level >= 3) {
+    return (title: 'Cadet', icon: Icons.school);
+  }
+  return (title: 'Trainee', icon: Icons.person);
+}

--- a/lib/data/models/friend.dart
+++ b/lib/data/models/friend.dart
@@ -15,6 +15,11 @@ class Friend {
     this.status = FriendshipStatus.accepted,
     this.isOnline = false,
     this.lastSeen,
+    this.level = 1,
+    this.gamesPlayed = 0,
+    this.bestScore = 0,
+    this.bestStreak = 0,
+    this.licenseData,
   });
 
   final String id;
@@ -26,6 +31,17 @@ class Friend {
   final FriendshipStatus status;
   final bool isOnline;
   final DateTime? lastSeen;
+
+  /// Public profile stats (profiles table) for the enriched profile view.
+  final int level;
+  final int gamesPlayed;
+  final int bestScore;
+
+  /// Longest streak of consecutive correct answers ever achieved.
+  final int bestStreak;
+
+  /// Raw pilot-license JSON from account_state.license_data, if fetched.
+  final Map<String, dynamic>? licenseData;
 
   String get name => displayName ?? username;
 
@@ -39,6 +55,11 @@ class Friend {
         'status': status.name,
         'is_online': isOnline,
         'last_seen': lastSeen?.toIso8601String(),
+        'level': level,
+        'games_played': gamesPlayed,
+        'best_score': bestScore,
+        'best_streak': bestStreak,
+        if (licenseData != null) 'license_data': licenseData,
       };
 
   factory Friend.fromJson(Map<String, dynamic> json) => Friend(
@@ -59,6 +80,11 @@ class Friend {
         lastSeen: json['last_seen'] != null
             ? DateTime.parse(json['last_seen'] as String)
             : null,
+        level: json['level'] as int? ?? 1,
+        gamesPlayed: json['games_played'] as int? ?? 0,
+        bestScore: json['best_score'] as int? ?? 0,
+        bestStreak: json['best_streak'] as int? ?? 0,
+        licenseData: json['license_data'] as Map<String, dynamic>?,
       );
 }
 

--- a/lib/data/services/friends_service.dart
+++ b/lib/data/services/friends_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../models/avatar_config.dart';
 import '../models/friend.dart';
 import 'ttl_cache.dart';
 
@@ -251,18 +252,22 @@ class FriendsService {
     if (cached != null) return cached;
 
     try {
-      // Fetch friendships where current user is either party and status is accepted.
+      // Fetch friendships where current user is either party and status is
+      // accepted, with the public profile stats for the profile sheet.
+      const profileCols =
+          'id, username, display_name, avatar_url, level, games_played, '
+          'best_score, best_streak';
       final data = await _client
           .from('friendships')
           .select(
             'id, requester_id, addressee_id, status, created_at, '
-            'requester:profiles!fk_friendships_requester_profiles(id, username, display_name, avatar_url), '
-            'addressee:profiles!fk_friendships_addressee_profiles(id, username, display_name, avatar_url)',
+            'requester:profiles!fk_friendships_requester_profiles($profileCols), '
+            'addressee:profiles!fk_friendships_addressee_profiles($profileCols)',
           )
           .eq('status', 'accepted')
           .or('requester_id.eq.$_userId,addressee_id.eq.$_userId');
 
-      final result = data.map<Friend>((row) {
+      var result = data.map<Friend>((row) {
         // The "friend" is whichever party isn't the current user.
         final isRequester = row['requester_id'] == _userId;
         final profile = (isRequester ? row['addressee'] : row['requester'])
@@ -274,14 +279,68 @@ class FriendsService {
           displayName: profile['display_name'] as String?,
           avatarUrl: profile['avatar_url'] as String?,
           status: FriendshipStatus.accepted,
+          level: profile['level'] as int? ?? 1,
+          gamesPlayed: profile['games_played'] as int? ?? 0,
+          bestScore: profile['best_score'] as int? ?? 0,
+          bestStreak: profile['best_streak'] as int? ?? 0,
         );
       }).toList();
 
+      result = await _attachAccountState(result);
       _friendsCache.set(cacheKey, result);
       return result;
     } catch (e) {
       debugPrint('[FriendsService] fetchFriends failed: $e');
       return [];
+    }
+  }
+
+  /// Batch-fetch avatar configs and license data from account_state (both
+  /// publicly readable, same pattern the leaderboard uses) so friends show
+  /// their real composed avatar and pilot license instead of fallbacks.
+  Future<List<Friend>> _attachAccountState(List<Friend> friends) async {
+    if (friends.isEmpty) return friends;
+    try {
+      final ids = friends.map((f) => f.playerId).toSet().toList();
+      final rows = await _client
+          .from('account_state')
+          .select('user_id, avatar_config, license_data')
+          .inFilter('user_id', ids);
+      final byId = {
+        for (final row in rows) row['user_id'] as String: row,
+      };
+      return [
+        for (final f in friends)
+          () {
+            final row = byId[f.playerId];
+            if (row == null) return f;
+            final avatarJson = row['avatar_config'];
+            final licenseJson = row['license_data'];
+            return Friend(
+              id: f.id,
+              playerId: f.playerId,
+              username: f.username,
+              displayName: f.displayName,
+              avatarUrl: f.avatarUrl,
+              avatarConfig: avatarJson is Map<String, dynamic>
+                  ? AvatarConfig.fromJson(avatarJson)
+                  : null,
+              status: f.status,
+              isOnline: f.isOnline,
+              lastSeen: f.lastSeen,
+              level: f.level,
+              gamesPlayed: f.gamesPlayed,
+              bestScore: f.bestScore,
+              bestStreak: f.bestStreak,
+              licenseData:
+                  licenseJson is Map<String, dynamic> ? licenseJson : null,
+            );
+          }(),
+      ];
+    } catch (e) {
+      // Enrichment is best-effort — the base friend list still works.
+      debugPrint('[FriendsService] account_state enrichment failed: $e');
+      return friends;
     }
   }
 

--- a/lib/features/friends/friends_screen.dart
+++ b/lib/features/friends/friends_screen.dart
@@ -3,7 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../core/theme/flit_colors.dart';
+import '../../core/utils/aviation_rank.dart';
+import '../../core/widgets/country_flag.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
+import '../../data/models/pilot_license.dart';
+import '../../data/services/leaderboard_service.dart';
 import '../../data/models/challenge.dart';
 import '../../data/models/cosmetic.dart';
 import '../../data/models/seasonal_theme.dart';
@@ -2089,12 +2093,24 @@ class _FriendProfileSheetState extends State<_FriendProfileSheet> {
   bool _loadingHistory = false;
   int? _expandedMatchIndex;
 
+  /// Best scores per mode for this friend (daily / training), fetched
+  /// from the public scores table.
+  Map<String, Map<String, int>?>? _bestScores;
+
   @override
   void initState() {
     super.initState();
     if (widget.h2h != null && widget.h2h!.totalChallenges > 0) {
       _loadMatchHistory();
     }
+    _loadBestScores();
+  }
+
+  Future<void> _loadBestScores() async {
+    final scores = await LeaderboardService.instance
+        .fetchBestScoresByMode(widget.friend.playerId);
+    if (!mounted) return;
+    setState(() => _bestScores = scores);
   }
 
   Future<void> _loadMatchHistory() async {
@@ -2107,6 +2123,161 @@ class _FriendProfileSheetState extends State<_FriendProfileSheet> {
       _matchHistory = history;
       _loadingHistory = false;
     });
+  }
+
+  /// Rank + pilot-license chips under the friend's name.
+  Widget _buildRankAndLicense(Friend friend) {
+    final rank = aviationRank(friend.level);
+    PilotLicense? license;
+    if (friend.licenseData != null) {
+      try {
+        license = PilotLicense.fromJson(friend.licenseData!);
+      } catch (_) {
+        // Malformed license data — just skip the badge.
+      }
+    }
+    return Wrap(
+      spacing: 8,
+      runSpacing: 6,
+      alignment: WrapAlignment.center,
+      children: [
+        _profileChip(
+          icon: rank.icon,
+          color: FlitColors.gold,
+          label: '${rank.title} \u00b7 Lv.${friend.level}',
+        ),
+        if (license != null)
+          _profileChip(
+            icon: Icons.badge_outlined,
+            color: _licenseTierColor(license.rarityTier),
+            label: '${license.rarityTier} license',
+          ),
+        if (license?.nationality != null && license!.nationality!.isNotEmpty)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+            decoration: BoxDecoration(
+              color: FlitColors.cardBackground,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: FlitColors.cardBorder),
+            ),
+            child: CountryFlag(
+              code: license.nationality!,
+              height: 14,
+              width: 21,
+              borderRadius: 2,
+            ),
+          ),
+      ],
+    );
+  }
+
+  static Color _licenseTierColor(String tier) {
+    switch (tier) {
+      case 'Perfect':
+        return const Color(0xFFB388FF);
+      case 'Diamond':
+        return const Color(0xFF80DEEA);
+      case 'Gold':
+        return FlitColors.gold;
+      case 'Silver':
+        return const Color(0xFFB0BEC5);
+      default:
+        return const Color(0xFFCD7F32); // bronze
+    }
+  }
+
+  Widget _profileChip({
+    required IconData icon,
+    required Color color,
+    required String label,
+  }) =>
+      Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        decoration: BoxDecoration(
+          color: FlitColors.cardBackground,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: color.withOpacity(0.5)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: color, size: 13),
+            const SizedBox(width: 5),
+            Text(
+              label,
+              style: TextStyle(
+                color: color,
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      );
+
+  /// Career stats + per-mode best scores (public profile data).
+  Widget _buildProfileStats(Friend friend) {
+    String fmt(int v) => v > 0 ? _formatScore(v) : '\u2014';
+    final daily = _bestScores?['daily']?['score'];
+    final training = _bestScores?['training']?['score'];
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: FlitColors.backgroundMid,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              _MiniStat(
+                'Flights',
+                '${friend.gamesPlayed}',
+                FlitColors.textPrimary,
+              ),
+              _MiniStat(
+                'Best Score',
+                fmt(friend.bestScore),
+                FlitColors.gold,
+              ),
+              _MiniStat(
+                'Best Streak',
+                '${friend.bestStreak}',
+                FlitColors.accent,
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              _MiniStat(
+                'Daily Best',
+                daily != null ? _formatScore(daily) : '\u2014',
+                FlitColors.textSecondary,
+              ),
+              _MiniStat(
+                'Training Best',
+                training != null ? _formatScore(training) : '\u2014',
+                FlitColors.textSecondary,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _formatScore(int score) {
+    final s = score.toString();
+    final buf = StringBuffer();
+    for (var i = 0; i < s.length; i++) {
+      final fromEnd = s.length - i;
+      buf.write(s[i]);
+      if (fromEnd > 1 && fromEnd % 3 == 1) buf.write(',');
+    }
+    return buf.toString();
   }
 
   @override
@@ -2158,6 +2329,10 @@ class _FriendProfileSheetState extends State<_FriendProfileSheet> {
                 fontSize: 14,
               ),
             ),
+            const SizedBox(height: 8),
+            _buildRankAndLicense(friend),
+            const SizedBox(height: 16),
+            _buildProfileStats(friend),
             const SizedBox(height: 16),
             // ── Head-to-head summary stats ──
             if (h2h != null && h2h.totalChallenges > 0) ...[

--- a/lib/features/license/license_screen.dart
+++ b/lib/features/license/license_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/utils/aviation_rank.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../core/widgets/menu_content_wrapper.dart';
 import '../../core/theme/rarity_colors.dart';
@@ -36,17 +37,6 @@ Color _statColor(int value) {
 }
 
 /// Aviation rank title for player level (mirrors profile_screen).
-String _aviationRankTitle(int level) {
-  if (level >= 50) return 'Air Marshal';
-  if (level >= 40) return 'Wing Commander';
-  if (level >= 30) return 'Squadron Leader';
-  if (level >= 20) return 'Flight Lieutenant';
-  if (level >= 15) return 'Captain';
-  if (level >= 10) return 'First Officer';
-  if (level >= 5) return 'Pilot Officer';
-  if (level >= 3) return 'Cadet';
-  return 'Trainee';
-}
 
 // =============================================================================
 // LicenseScreen
@@ -328,7 +318,7 @@ class _LicenseScreenState extends ConsumerState<LicenseScreen>
     final avatarConfig = ref.watch(avatarProvider);
     final equippedPlaneId = ref.watch(equippedPlaneIdProvider);
     final equippedPlane = CosmeticCatalog.getById(equippedPlaneId);
-    final rank = _aviationRankTitle(player.level);
+    final rank = aviationRank(player.level).title;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/profile/profile_screen.dart
+++ b/lib/features/profile/profile_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../../core/utils/aviation_rank.dart';
 import '../../core/theme/flit_colors.dart';
 import '../../core/utils/web_download.dart';
 import '../../core/widgets/country_flag.dart';
@@ -24,33 +25,6 @@ import '../../data/services/leaderboard_service.dart';
 import '../../game/data/country_difficulty.dart';
 
 /// Aviation rank title and icon for player level.
-({String title, IconData icon}) _aviationRank(int level) {
-  if (level >= 50) {
-    return (title: 'Air Marshal', icon: Icons.stars);
-  }
-  if (level >= 40) {
-    return (title: 'Wing Commander', icon: Icons.military_tech);
-  }
-  if (level >= 30) {
-    return (title: 'Squadron Leader', icon: Icons.shield);
-  }
-  if (level >= 20) {
-    return (title: 'Flight Lieutenant', icon: Icons.workspace_premium);
-  }
-  if (level >= 15) {
-    return (title: 'Captain', icon: Icons.anchor);
-  }
-  if (level >= 10) {
-    return (title: 'First Officer', icon: Icons.flight);
-  }
-  if (level >= 5) {
-    return (title: 'Pilot Officer', icon: Icons.flight_takeoff);
-  }
-  if (level >= 3) {
-    return (title: 'Cadet', icon: Icons.school);
-  }
-  return (title: 'Trainee', icon: Icons.person);
-}
 
 /// Profile screen showing player stats and settings.
 class ProfileScreen extends ConsumerStatefulWidget {
@@ -852,13 +826,13 @@ class _LevelProgress extends StatelessWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Icon(
-                      _aviationRank(player.level).icon,
+                      aviationRank(player.level).icon,
                       color: FlitColors.gold,
                       size: 20,
                     ),
                     const SizedBox(width: 6),
                     Text(
-                      _aviationRank(player.level).title,
+                      aviationRank(player.level).title,
                       style: const TextStyle(
                         color: FlitColors.gold,
                         fontSize: 14,


### PR DESCRIPTION
## Summary
Tapping a friend in the friends menu now shows a real profile, not just your head-to-head record:

- **Real avatar** — `FriendsService` now batch-fetches `avatar_config` from `account_state` (same pattern the leaderboard uses). This also fixes a latent bug: friends *always* rendered as initial-letter placeholders because the config was never fetched. Both the list rows and the profile sheet now show composed avatars.
- **Rank + license** — chips under the name: aviation rank with level (shared `aviationRank` helper — previously duplicated across the profile and license screens, now single-sourced), pilot-license rarity badge in tier colour, and the license's nationality flag.
- **Career stats** — Flights (games played), Best Score, Best Streak from the public profile columns, plus per-mode **Daily Best / Training Best** via the existing `fetchBestScoresByMode` (which already accepted any user id).
- The H2H record, match history, and action buttons stay exactly where they were, below the new sections.

No schema or RLS changes — `profiles`, `account_state`, and `scores` are all publicly readable by design; this is purely wider selects.

## Verification
- 852/852 tests pass; analyzer 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_