### PR TITLE
Reveal map: session start dot + checkered finish flag

### DIFF
--- a/lib/core/widgets/reveal_map.dart
+++ b/lib/core/widgets/reveal_map.dart
@@ -44,8 +44,7 @@ class RevealPath {
   final Color color;
 
   /// Dashed rendering — used for the faint "optimal route" overlay so it
-  /// reads as a reference line, not a flown trail. Dashed paths also skip
-  /// the take-off dot.
+  /// reads as a reference line, not a flown trail.
   final bool dashed;
 }
 
@@ -67,6 +66,8 @@ class RevealMap extends StatefulWidget {
     this.stars = const [],
     this.dots = const [],
     this.paths = const [],
+    this.startLngLat,
+    this.finishLngLat,
     this.legendItems,
     this.showLegend = true,
   });
@@ -91,6 +92,10 @@ class RevealMap extends StatefulWidget {
   /// Polyline layers, drawn beneath the markers.
   final List<RevealPath> paths;
 
+  /// Session start (accent dot) and finish (checkered flag) markers.
+  final Vector2? startLngLat;
+  final Vector2? finishLngLat;
+
   /// Custom legend; when null the classic answer/clues/guesses legend is
   /// derived from whichever of the simple layers are present.
   final List<RevealLegendItem>? legendItems;
@@ -110,11 +115,15 @@ class RevealMapThumbnail extends StatelessWidget {
     this.stars = const [],
     this.dots = const [],
     this.paths = const [],
+    this.startLngLat,
+    this.finishLngLat,
   });
 
   final List<RevealStar> stars;
   final List<RevealDot> dots;
   final List<RevealPath> paths;
+  final Vector2? startLngLat;
+  final Vector2? finishLngLat;
 
   @override
   Widget build(BuildContext context) {
@@ -132,6 +141,8 @@ class RevealMapThumbnail extends StatelessWidget {
               stars: stars,
               dots: dots,
               paths: paths,
+              startLngLat: startLngLat,
+              finishLngLat: finishLngLat,
             ),
           ),
         ),
@@ -201,6 +212,8 @@ class _RevealMapState extends State<RevealMap> {
                     stars: widget.stars,
                     dots: widget.dots,
                     paths: widget.paths,
+                    startLngLat: widget.startLngLat,
+                    finishLngLat: widget.finishLngLat,
                     zoom: _zoom,
                   ),
                 ),
@@ -257,6 +270,8 @@ class _RevealMapPainter extends CustomPainter {
     required this.stars,
     required this.dots,
     required this.paths,
+    this.startLngLat,
+    this.finishLngLat,
     this.zoom = 1,
   });
 
@@ -266,6 +281,8 @@ class _RevealMapPainter extends CustomPainter {
   final List<RevealStar> stars;
   final List<RevealDot> dots;
   final List<RevealPath> paths;
+  final Vector2? startLngLat;
+  final Vector2? finishLngLat;
   final double zoom;
 
   @override
@@ -333,12 +350,21 @@ class _RevealMapPainter extends CustomPainter {
           ..strokeWidth = 1.2 / z
           ..strokeCap = StrokeCap.round,
       );
-      if (!path.dashed) {
-        // Take-off dot so the trail's direction reads at a glance.
-        final start =
-            project(normLng(path.points.first.x), path.points.first.y);
-        canvas.drawCircle(start, 2.5 / z, Paint()..color = path.color);
-      }
+    }
+
+    // Session start dot and checkered finish flag — one each, not per
+    // trail (per-trail take-off dots looked like duplicate target stars).
+    if (startLngLat != null) {
+      final pos = project(normLng(startLngLat!.x), startLngLat!.y);
+      canvas.drawCircle(pos, 4 / z, Paint()..color = Colors.white);
+      canvas.drawCircle(pos, 2.6 / z, Paint()..color = FlitColors.accent);
+    }
+    if (finishLngLat != null) {
+      _drawCheckeredFlag(
+        canvas,
+        project(normLng(finishLngLat!.x), finishLngLat!.y),
+        z,
+      );
     }
 
     final target =
@@ -408,6 +434,35 @@ class _RevealMapPainter extends CustomPainter {
     if (target != null) {
       _drawStar(canvas, target, 7 / z, Paint()..color = FlitColors.gold);
     }
+  }
+
+  /// Mini checkered flag: pole rising from the finish point with a 3×2
+  /// black/white checked banner.
+  void _drawCheckeredFlag(Canvas canvas, Offset pos, double z) {
+    final poleTop = pos - Offset(0, 10 / z);
+    canvas.drawLine(
+      pos,
+      poleTop,
+      Paint()
+        ..color = Colors.white
+        ..strokeWidth = 1.2 / z
+        ..strokeCap = StrokeCap.round,
+    );
+    final cell = 2.6 / z;
+    for (var col = 0; col < 3; col++) {
+      for (var row = 0; row < 2; row++) {
+        canvas.drawRect(
+          Rect.fromLTWH(
+            poleTop.dx + col * cell,
+            poleTop.dy + row * cell,
+            cell,
+            cell,
+          ),
+          Paint()..color = (col + row).isEven ? Colors.black : Colors.white,
+        );
+      }
+    }
+    canvas.drawCircle(pos, 1.6 / z, Paint()..color = Colors.white);
   }
 
   /// Converts [source] into a dashed copy by walking its metrics.

--- a/lib/features/play/play_screen.dart
+++ b/lib/features/play/play_screen.dart
@@ -2503,9 +2503,16 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
   /// Builds the star/path marker layers shared by the full [RevealMap]
   /// (with legend) and the [RevealMapThumbnail] embedded in the mission
   /// report card, so both stay in sync from one source of truth.
-  ({List<RevealStar> stars, List<RevealPath> paths}) _revealLayers() {
+  ({
+    List<RevealStar> stars,
+    List<RevealPath> paths,
+    Vector2? start,
+    Vector2? finish,
+  }) _revealLayers() {
     final stars = <RevealStar>[];
     final paths = <RevealPath>[];
+    Vector2? start;
+    Vector2? finish;
     for (final r in widget.roundResults) {
       final target = CountryData.getCapital(r.countryCode)?.location;
       if (target != null) {
@@ -2517,6 +2524,8 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
         );
       }
       if (r.path.length >= 2) {
+        start ??= r.path.first;
+        finish = r.path.last;
         paths.add(RevealPath(r.path));
         // Faint gold dashed reference line: the great-circle (shortest)
         // route from where this round started to its target, so the
@@ -2532,7 +2541,7 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
         }
       }
     }
-    return (stars: stars, paths: paths);
+    return (stars: stars, paths: paths, start: start, finish: finish);
   }
 
   /// World map of the whole run: a star per round's target (gold =
@@ -2546,6 +2555,8 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
       RevealMap(
         stars: layers.stars,
         paths: layers.paths,
+        startLngLat: layers.start,
+        finishLngLat: layers.finish,
         legendItems: [
           const RevealLegendItem(Icons.star, FlitColors.gold, 'found'),
           if (layers.stars.any((s) => s.color == FlitColors.error))
@@ -2560,6 +2571,16 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
               Icons.linear_scale,
               FlitColors.gold,
               'shortest route',
+            ),
+            const RevealLegendItem(
+              Icons.circle,
+              FlitColors.accent,
+              'start',
+            ),
+            const RevealLegendItem(
+              Icons.sports_score,
+              Colors.white,
+              'finish',
             ),
           ],
         ],
@@ -2667,7 +2688,12 @@ class _ResultDialogState extends ConsumerState<_ResultDialog> {
         // downloadable card never includes the answer map for it. Other
         // session types (training, free flight, dogfight) can show it.
         map: !widget.isDailyChallenge && layers.stars.isNotEmpty
-            ? RevealMapThumbnail(stars: layers.stars, paths: layers.paths)
+            ? RevealMapThumbnail(
+                stars: layers.stars,
+                paths: layers.paths,
+                startLngLat: layers.start,
+                finishLngLat: layers.finish,
+              )
             : null,
       ),
     );


### PR DESCRIPTION
## Summary
The per-trail take-off dots on the flight reveal map read as duplicate target stars — each round's start point sits exactly on the previous round's target, so dots and stars looked like the same thing.

Replaced with two unambiguous session markers:
- **Start**: a single white-ringed accent dot at the very first take-off
- **Finish**: a mini checkered flag (pole + 3×2 black/white banner) at the final touch-down

Both are zoom-compensated like every other marker, appear in the legend ("start" / "finish" with the checkered-flag icon), and carry through to the mission-report card thumbnail.

## Verification
- 852/852 tests pass; analyzer 0 errors / 0 warnings
- Flight-card golden regenerated and visually verified: start dot at Tokyo, checkered flag at Auckland, no more redundant dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_