### PR TITLE
Rework Daily Briefing: short, regional, achievable

### DIFF
--- a/lib/features/quiz/daily_briefing_screen.dart
+++ b/lib/features/quiz/daily_briefing_screen.dart
@@ -12,9 +12,10 @@ import 'quiz_game_screen.dart';
 
 /// Daily Flight Briefing screen.
 ///
-/// Shows today's deterministically generated quiz settings (level, category,
-/// difficulty, mode) and lets the player start the briefing. Players who have
-/// already completed today's briefing see a "CLEARED" badge and their score.
+/// Shows today's deterministically generated mission (region, curated
+/// six-question set, label rules) and lets the player start the briefing.
+/// Players who have already completed today's briefing see a "CLEARED" badge
+/// and their score.
 ///
 /// After completing the quiz, the score is submitted to the
 /// `daily_briefing_scores` table.
@@ -88,12 +89,13 @@ class _DailyBriefingScreenState extends State<DailyBriefingScreen>
       MaterialPageRoute<QuizSummary>(
         builder: (_) => QuizGameScreen(
           mode: _briefing.mode,
-          categories: {_briefing.category},
+          categories: _briefing.categories,
           region: _briefing.level.region,
           difficulty: _briefing.difficulty,
           seed: _briefing.seed,
           flightSchoolLevelId: _briefing.level.id,
           dailyBriefingDateKey: _briefing.dateKey,
+          presetQuestions: _briefing.questions,
         ),
       ),
     )
@@ -261,23 +263,25 @@ class _DailyBriefingScreenState extends State<DailyBriefingScreen>
           const SizedBox(height: 14),
           _buildParameter(
             'INTEL TYPE',
-            _briefing.category.displayName,
-            _briefing.category.description,
-            _categoryIcon(_briefing.category),
+            _briefing.intelTypeLabel,
+            'Tap the right area on the map',
+            _briefing.categories.length == 1
+                ? _categoryIcon(_briefing.categories.first)
+                : Icons.shuffle,
+          ),
+          const SizedBox(height: 14),
+          _buildParameter(
+            'TARGETS',
+            '${DailyBriefing.questionCount} targets',
+            _briefing.estimatedDuration,
+            Icons.checklist,
           ),
           const SizedBox(height: 14),
           _buildParameter(
             'ALTITUDE',
             _briefing.difficulty.displayName,
-            _briefing.difficulty.description,
+            _briefing.labelSummary,
             _difficultyIcon(_briefing.difficulty),
-          ),
-          const SizedBox(height: 14),
-          _buildParameter(
-            'MISSION TYPE',
-            _briefing.mode.displayName,
-            _briefing.estimatedDuration,
-            _modeIcon(_briefing.mode),
           ),
         ],
       ),
@@ -579,19 +583,6 @@ class _DailyBriefingScreenState extends State<DailyBriefingScreen>
         return Icons.cloud_queue;
       case QuizDifficulty.hard:
         return Icons.thunderstorm;
-    }
-  }
-
-  IconData _modeIcon(QuizMode mode) {
-    switch (mode) {
-      case QuizMode.allStates:
-        return Icons.checklist;
-      case QuizMode.timeTrial:
-        return Icons.timer;
-      case QuizMode.rapidFire:
-        return Icons.bolt;
-      case QuizMode.typeIn:
-        return Icons.keyboard;
     }
   }
 }

--- a/lib/features/quiz/quiz_game_screen.dart
+++ b/lib/features/quiz/quiz_game_screen.dart
@@ -36,6 +36,7 @@ class QuizGameScreen extends StatefulWidget {
     this.excludePercent = 0.0,
     this.h2hRoundIndex,
     this.dailyBriefingDateKey,
+    this.presetQuestions,
   });
 
   final QuizMode mode;
@@ -65,6 +66,10 @@ class QuizGameScreen extends StatefulWidget {
   /// When non-null, this quiz is a Daily Flight Briefing. The value is the
   /// date key (YYYY-MM-DD) used for score submission.
   final String? dailyBriefingDateKey;
+
+  /// Pre-built question list (Daily Briefing's curated set). When non-null,
+  /// the session uses it verbatim instead of generating a full-region sweep.
+  final List<QuizQuestion>? presetQuestions;
 
   @override
   State<QuizGameScreen> createState() => _QuizGameScreenState();
@@ -135,6 +140,7 @@ class _QuizGameScreenState extends State<QuizGameScreen>
       region: widget.region,
       difficulty: widget.difficulty,
       excludePercent: widget.excludePercent,
+      presetQuestions: widget.presetQuestions,
       seed: widget.seed,
     );
 
@@ -382,6 +388,10 @@ class _QuizGameScreenState extends State<QuizGameScreen>
   Widget build(BuildContext context) {
     final question = _session.currentQuestion;
     final remaining = _session.remainingMs;
+    // Per-question label blindness: labelFree "stretch" questions (Daily
+    // Briefing) hide labels even when the difficulty/user toggle shows them.
+    final labelFree = !_exploringMap && (question?.labelFree ?? false);
+    final showLabels = _exploringMap || (_showLabels && !labelFree);
 
     return Scaffold(
       backgroundColor: FlitColors.backgroundDark,
@@ -412,7 +422,7 @@ class _QuizGameScreenState extends State<QuizGameScreen>
                                 onStateTapped:
                                     _exploringMap ? (_) {} : _handleStateTapped,
                                 highlightCode: _highlightCode,
-                                showLabels: _exploringMap || _showLabels,
+                                showLabels: showLabels,
                                 eliminatedCodes: _exploringMap
                                     ? const {}
                                     : _session.eliminatedCodes,
@@ -429,7 +439,7 @@ class _QuizGameScreenState extends State<QuizGameScreen>
                                 onStateTapped:
                                     _exploringMap ? (_) {} : _handleStateTapped,
                                 highlightCode: _highlightCode,
-                                showLabels: _exploringMap || _showLabels,
+                                showLabels: showLabels,
                                 eliminatedCodes: _exploringMap
                                     ? const {}
                                     : _session.eliminatedCodes,
@@ -456,48 +466,50 @@ class _QuizGameScreenState extends State<QuizGameScreen>
                           child: _buildStrikesIndicator(),
                         ),
 
-                      // Label toggle button
-                      Positioned(
-                        bottom: 8,
-                        left: 8,
-                        child: GestureDetector(
-                          onTap: () =>
-                              setState(() => _showLabels = !_showLabels),
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 4,
-                            ),
-                            decoration: BoxDecoration(
-                              color: FlitColors.backgroundMid
-                                  .withValues(alpha: 0.85),
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                color: FlitColors.cardBorder,
-                                width: 0.5,
+                      // Label toggle button (hidden on label-free stretch
+                      // questions — the flag overrides the toggle).
+                      if (!labelFree)
+                        Positioned(
+                          bottom: 8,
+                          left: 8,
+                          child: GestureDetector(
+                            onTap: () =>
+                                setState(() => _showLabels = !_showLabels),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
                               ),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(
-                                  _showLabels ? Icons.label : Icons.label_off,
-                                  color: FlitColors.textSecondary,
-                                  size: 16,
+                              decoration: BoxDecoration(
+                                color: FlitColors.backgroundMid
+                                    .withValues(alpha: 0.85),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: FlitColors.cardBorder,
+                                  width: 0.5,
                                 ),
-                                const SizedBox(width: 4),
-                                Text(
-                                  _showLabels ? 'Names' : 'Names',
-                                  style: const TextStyle(
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(
+                                    _showLabels ? Icons.label : Icons.label_off,
                                     color: FlitColors.textSecondary,
-                                    fontSize: 11,
+                                    size: 16,
                                   ),
-                                ),
-                              ],
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    _showLabels ? 'Names' : 'Names',
+                                    style: const TextStyle(
+                                      color: FlitColors.textSecondary,
+                                      fontSize: 11,
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
                         ),
-                      ),
                     ],
                   ),
                 ),

--- a/lib/features/quiz/quiz_results_screen.dart
+++ b/lib/features/quiz/quiz_results_screen.dart
@@ -169,7 +169,11 @@ class _QuizResultsScreenState extends ConsumerState<QuizResultsScreen>
         'score': summary.totalScore,
         'time_ms': summary.elapsedMs,
         'level_id': widget.flightSchoolLevelId ?? '',
-        'category': summary.categories.map((c) => c.name).join(','),
+        // A curated daily set can mix categories (names + capitals +
+        // flavour); record it as 'mixed' rather than a joined list.
+        'category': summary.categories.length == 1
+            ? summary.categories.first.name
+            : 'mixed',
         'difficulty': summary.difficulty.name,
         'mode': summary.mode.name,
       }, onConflict: 'user_id,date_key');

--- a/lib/game/quiz/daily_briefing.dart
+++ b/lib/game/quiz/daily_briefing.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import '../map/region.dart';
 import 'flight_school_level.dart';
 import 'quiz_category.dart';
 import 'quiz_difficulty.dart';
@@ -9,46 +10,82 @@ import 'quiz_session.dart';
 /// generated from the current date.
 ///
 /// Every player who opens the briefing on the same calendar day (UTC) receives
-/// the same level, category, difficulty, mode, and question seed. This allows
-/// fair leaderboard competition: one attempt per day, same conditions for all.
+/// the same region, questions, order, and label rules. This allows fair
+/// leaderboard competition: one attempt per day, same conditions for all.
+///
+/// Selection policy (why the daily differs from Flight School practice):
+/// - The daily must be short, accessible, and achievable. It is always exactly
+///   [questionCount] tap-the-map questions — untimed, no strikes.
+/// - Regions rotate on a seeded weighted schedule: broadly-known regions
+///   (Europe, US States) dominate, a "world tour" tier (Africa, Asia, Latin
+///   America) fills most other days, and niche regions (UK, Ireland, Canada,
+///   Oceania, Caribbean) combined appear at most ~1 day in 7.
+/// - Questions use only the accessible categories: name and capital. On
+///   well-known regions (tier <= [_flavourMaxTier]) at most ONE question may
+///   instead be a nickname/landmark "flavour" clue. Obscure categories
+///   (stateFlower, stateBird, motto, sportsTeam, celebrity, filmSetting,
+///   flagDescription) never appear — they stay in Flight School practice.
+/// - Difficulty is always easy (labels on); challenge comes from per-question
+///   [QuizQuestion.labelFree] "stretch" questions at the end of the set —
+///   2 for easy regions, 1 for mid-tier, 0 for hard regions.
 class DailyBriefing {
   const DailyBriefing({
     required this.dateKey,
     required this.seed,
     required this.level,
-    required this.category,
+    required this.categories,
     required this.difficulty,
     required this.mode,
+    required this.questions,
   });
 
   /// Date string in YYYY-MM-DD format.
   final String dateKey;
 
-  /// Deterministic seed derived from the date (used for question order).
+  /// Deterministic seed derived from the date.
   final int seed;
 
-  /// The Flight School level selected for today's briefing.
+  /// The Flight School level (region) selected for today's briefing.
   final FlightSchoolLevel level;
 
-  /// The quiz category for today's briefing.
-  final QuizCategory category;
+  /// The categories used across today's question set.
+  final Set<QuizCategory> categories;
 
-  /// The difficulty setting for today's briefing.
+  /// The difficulty setting for today's briefing (always label-friendly;
+  /// label-blindness is applied per-question via [QuizQuestion.labelFree]).
   final QuizDifficulty difficulty;
 
-  /// The quiz mode for today's briefing.
+  /// The quiz mode for today's briefing (always untimed, no fail-out).
   final QuizMode mode;
 
-  /// Modes eligible for the daily briefing rotation.
+  /// Today's curated question list — exactly [questionCount] entries, no
+  /// duplicate answer areas, identical for every player.
+  final List<QuizQuestion> questions;
+
+  /// The daily is always exactly this many questions.
+  static const int questionCount = 6;
+
+  /// Highest level tier that may receive a nickname/landmark flavour question.
+  static const int _flavourMaxTier = 5;
+
+  /// Weighted region rotation, keyed by [FlightSchoolLevel.id].
   ///
-  /// [QuizMode.typeIn] is excluded because it requires a text input UX that
-  /// doesn't pair well with the "same conditions for everyone" philosophy
-  /// (autocomplete/keyboard differences across devices).
-  static const List<QuizMode> _eligibleModes = [
-    QuizMode.allStates,
-    QuizMode.timeTrial,
-    QuizMode.rapidFire,
-  ];
+  /// Europe and US States dominate; Africa/Asia/Latin America form the
+  /// "world tour" tier; the niche five (UK, Ireland, Canada, Oceania,
+  /// Caribbean) get weight 1 each — 5/33 of days, roughly 1 day in 7
+  /// combined.
+  static const Map<String, int> _levelWeights = {
+    'europe': 8,
+    'us_states': 8,
+    'africa': 4,
+    'asia': 4,
+    'latin_america': 4,
+    'uk_counties': 1,
+    'ireland': 1,
+    'canada': 1,
+    'oceania': 1,
+    'caribbean': 1,
+  };
 
   // ---------------------------------------------------------------------------
   // Factories
@@ -63,6 +100,8 @@ class DailyBriefing {
   /// Generate a briefing for a specific [date].
   ///
   /// Only the year/month/day components matter; the time portion is ignored.
+  /// Deterministic: the same date always yields the same region, questions,
+  /// order, and labelFree flags on every platform.
   factory DailyBriefing.forDate(DateTime date) {
     final normalised = DateTime.utc(date.year, date.month, date.day);
     final dateKey = '${normalised.year}-'
@@ -73,48 +112,117 @@ class DailyBriefing {
     final seed = _hashDateKey(dateKey);
     final rng = Random(seed);
 
-    // 1. Pick a level from all available flight school levels.
-    final level = flightSchoolLevels[rng.nextInt(flightSchoolLevels.length)];
+    // 1. Weighted region pick (draw order is load-bearing: level first, then
+    // the question plan — changing it changes every day's briefing).
+    final level = _pickLevel(rng);
 
-    // 2. Pick a difficulty, biased by the level's tier.
-    //
-    // Higher-tier levels (requiredLevel >= 13) shouldn't appear as "Easy" —
-    // it's nonsensical to label a Marshall Islands quiz as easy. We restrict
-    // the eligible difficulty pool based on the level's required player level.
-    final List<QuizDifficulty> difficultyPool;
-    if (level.requiredLevel >= 17) {
-      // Expert levels (Oceania, Caribbean, etc.) — medium or hard only.
-      difficultyPool = [QuizDifficulty.medium, QuizDifficulty.hard];
-    } else if (level.requiredLevel >= 9) {
-      // Mid-tier levels (Asia, Latin America, UK, Ireland) — all allowed but
-      // weighted away from easy by excluding it from the pool.
-      difficultyPool = [QuizDifficulty.medium, QuizDifficulty.hard];
-    } else {
-      // Starter levels (Europe, US, Africa) — any difficulty.
-      difficultyPool = QuizDifficulty.values;
-    }
-    final difficulty = difficultyPool[rng.nextInt(difficultyPool.length)];
-
-    // 3. Pick a category valid for this level (respecting difficulty filter).
-    final filteredCategories = difficulty.filterCategories(
-      level.availableCategories,
-    );
-    final categoryPool = filteredCategories.isNotEmpty
-        ? filteredCategories
-        : level.availableCategories;
-    final category = categoryPool[rng.nextInt(categoryPool.length)];
-
-    // 4. Pick a mode from the eligible set.
-    final mode = _eligibleModes[rng.nextInt(_eligibleModes.length)];
+    // 2. Build the curated question set.
+    final questions = _buildQuestions(level, rng, seed);
 
     return DailyBriefing(
       dateKey: dateKey,
       seed: seed,
       level: level,
-      category: category,
-      difficulty: difficulty,
-      mode: mode,
+      categories: questions.map((q) => q.category).toSet(),
+      // Always a labels-on difficulty: easy is the only tier with
+      // showLabels == true. Label-blindness is per-question (labelFree).
+      difficulty: QuizDifficulty.easy,
+      // Complete-the-set semantics: answer all six, untimed, no strikes.
+      mode: QuizMode.allStates,
+      questions: questions,
     );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Selection policy
+  // ---------------------------------------------------------------------------
+
+  /// Seeded weighted pick from the flight school levels.
+  static FlightSchoolLevel _pickLevel(Random rng) {
+    final totalWeight = flightSchoolLevels.fold<int>(
+      0,
+      (sum, l) => sum + (_levelWeights[l.id] ?? 1),
+    );
+    var roll = rng.nextInt(totalWeight);
+    for (final level in flightSchoolLevels) {
+      roll -= _levelWeights[level.id] ?? 1;
+      if (roll < 0) return level;
+    }
+    return flightSchoolLevels.first;
+  }
+
+  /// Number of label-free "stretch" questions for a region tier
+  /// ([FlightSchoolLevel.requiredLevel]). Hard regions stay fully labeled.
+  static int labelFreeCountForTier(int requiredLevel) {
+    if (requiredLevel >= 15) return 0;
+    if (requiredLevel >= 9) return 1;
+    return 2;
+  }
+
+  /// Build today's [questionCount] questions for [level].
+  ///
+  /// Seeded-samples distinct areas from the region (no duplicate answers),
+  /// mixes name and capital clues (2–4 capitals), optionally swaps one
+  /// question for a nickname/landmark flavour clue on well-known regions,
+  /// and marks the trailing stretch questions label-free.
+  static List<QuizQuestion> _buildQuestions(
+    FlightSchoolLevel level,
+    Random rng,
+    int seed,
+  ) {
+    // No difficulty filter: the country-difficulty ratings reuse ISO codes
+    // that collide with US state codes ('CA' state vs Canada), so the daily
+    // prefers straightforward seeded sampling.
+    final generator = QuizQuestionGenerator(region: level.region, seed: seed);
+    final remaining = List.of(RegionalData.getAreas(level.region))
+      ..shuffle(rng);
+
+    // Category plan: mostly names and capitals — 2 to 4 capital clues per day.
+    final capitalCount = 2 + rng.nextInt(3);
+    final plan = List<QuizCategory>.generate(
+      questionCount,
+      (i) => i < capitalCount ? QuizCategory.capital : QuizCategory.stateName,
+    )..shuffle(rng);
+
+    // Flavour: well-known regions may swap ONE question for a nickname or
+    // landmark clue (roughly every other day).
+    if (level.requiredLevel <= _flavourMaxTier && rng.nextBool()) {
+      final flavour =
+          rng.nextBool() ? QuizCategory.nickname : QuizCategory.landmark;
+      plan[rng.nextInt(questionCount)] = flavour;
+    }
+
+    final questions = <QuizQuestion>[];
+    for (final category in plan) {
+      QuizQuestion? question;
+      // Walk the shuffled areas until one supports this clue category
+      // (has a capital / nickname / landmark on record).
+      for (var i = 0; i < remaining.length; i++) {
+        final candidate = generator.generateForArea(remaining[i], category);
+        if (candidate != null) {
+          question = candidate;
+          remaining.removeAt(i);
+          break;
+        }
+      }
+      // Fallback: a plain name question always works for any area.
+      if (question == null && remaining.isNotEmpty) {
+        question = generator.generateForArea(
+          remaining.removeAt(0),
+          QuizCategory.stateName,
+        );
+      }
+      if (question != null) questions.add(question);
+    }
+
+    // Mark the trailing stretch questions label-free.
+    final blindCount = labelFreeCountForTier(level.requiredLevel);
+    for (var i = 0; i < questions.length; i++) {
+      if (i >= questions.length - blindCount) {
+        questions[i] = questions[i].copyWith(labelFree: true);
+      }
+    }
+    return questions;
   }
 
   // ---------------------------------------------------------------------------
@@ -131,24 +239,28 @@ class DailyBriefing {
     return hash.abs();
   }
 
+  /// Number of label-free stretch questions in today's set.
+  int get labelFreeCount => questions.where((q) => q.labelFree).length;
+
   /// Aviation-themed subtitle describing the mission parameters.
-  String get missionSubtitle {
-    final modeLabel = mode.displayName.toUpperCase();
-    final diffLabel = difficulty.displayName.toUpperCase();
-    return '$modeLabel / $diffLabel';
+  String get missionSubtitle =>
+      '${level.name.toUpperCase()} / $questionCount TARGETS';
+
+  /// Clue-type summary for the lobby card (e.g. "Names & Capitals").
+  String get intelTypeLabel {
+    final names = categories.map((c) => c.displayName).toList();
+    if (names.length == 1) return names.first;
+    if (names.length == 2) return '${names[0]} & ${names[1]}';
+    return names.join(' · ');
+  }
+
+  /// Label-visibility summary for the lobby card
+  /// (e.g. "Labels on · 2 blind").
+  String get labelSummary {
+    final blind = labelFreeCount;
+    return blind == 0 ? 'Labels on' : 'Labels on · $blind blind';
   }
 
   /// Estimated duration label for the briefing card.
-  String get estimatedDuration {
-    switch (mode) {
-      case QuizMode.allStates:
-        return '~${level.areaCount} questions';
-      case QuizMode.timeTrial:
-        return '60 seconds';
-      case QuizMode.rapidFire:
-        return '3 strikes';
-      case QuizMode.typeIn:
-        return '90 seconds';
-    }
-  }
+  String get estimatedDuration => '$questionCount targets · no timer';
 }

--- a/lib/game/quiz/quiz_category.dart
+++ b/lib/game/quiz/quiz_category.dart
@@ -136,6 +136,7 @@ class QuizQuestion {
     required this.clueText,
     required this.answerCode,
     required this.answerName,
+    this.labelFree = false,
   });
 
   /// The category this question belongs to.
@@ -149,6 +150,20 @@ class QuizQuestion {
 
   /// The correct state name for display (e.g. 'California').
   final String answerName;
+
+  /// When true, map labels are hidden for this question even if the
+  /// difficulty would normally show them. Used by the Daily Briefing's
+  /// "stretch" questions; defaults to false everywhere else (practice,
+  /// H2H, type-in, Uncharted are unaffected).
+  final bool labelFree;
+
+  QuizQuestion copyWith({bool? labelFree}) => QuizQuestion(
+        category: category,
+        clueText: clueText,
+        answerCode: answerCode,
+        answerName: answerName,
+        labelFree: labelFree ?? this.labelFree,
+      );
 }
 
 /// Non-mixed categories available for each region with rich clue data.
@@ -290,6 +305,14 @@ class QuizQuestionGenerator {
     questions.shuffle(_random);
     return questions;
   }
+
+  /// Generate a single question for [area] in the given [category].
+  ///
+  /// Returns null when the region lacks clue data for that category
+  /// (e.g. no capital recorded, no nickname). Used by the Daily Briefing
+  /// to build a small curated question list instead of a full-region sweep.
+  QuizQuestion? generateForArea(RegionalArea area, QuizCategory category) =>
+      _generateForArea(area, {category}, null);
 
   /// Generate a single question for an area from the given category set.
   QuizQuestion? _generateForArea(

--- a/lib/game/quiz/quiz_session.dart
+++ b/lib/game/quiz/quiz_session.dart
@@ -143,6 +143,7 @@ class QuizSession {
     required this.region,
     this.difficulty = QuizDifficulty.medium,
     this.excludePercent = 0.0,
+    this.presetQuestions,
     int? seed,
   })  : _generator = QuizQuestionGenerator(
             region: region, difficulty: difficulty, seed: seed),
@@ -169,6 +170,12 @@ class QuizSession {
   /// Fraction of areas to exclude (0.0 = none, 0.5 = 50%).
   /// Only effective in easy mode.
   final double excludePercent;
+
+  /// Pre-built question list (e.g. the Daily Briefing's curated six).
+  /// When non-null, [start] uses it verbatim — order, categories, and
+  /// labelFree flags are already deterministic — instead of generating a
+  /// full-region question sweep.
+  final List<QuizQuestion>? presetQuestions;
 
   final QuizQuestionGenerator _generator;
   final Random _random;
@@ -283,6 +290,14 @@ class QuizSession {
 
   /// Initialize and start the quiz.
   void start() {
+    if (presetQuestions != null) {
+      // Curated question list (Daily Briefing): use as-is. No exclusion —
+      // every player must face the identical set.
+      _questions = List.of(presetQuestions!);
+      _startTime = DateTime.now();
+      return;
+    }
+
     // When in mixed mode, pass the difficulty-filtered pool so easy mode
     // excludes hard categories (sportsTeam, celebrity, filmSetting, etc.).
     final allowedPool = categories.contains(QuizCategory.mixed)

--- a/test/unit/game/quiz/daily_briefing_test.dart
+++ b/test/unit/game/quiz/daily_briefing_test.dart
@@ -1,0 +1,246 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flit/game/quiz/daily_briefing.dart';
+import 'package:flit/game/quiz/quiz_category.dart';
+import 'package:flit/game/quiz/quiz_difficulty.dart';
+import 'package:flit/game/quiz/quiz_session.dart';
+
+void main() {
+  /// 60 consecutive dates starting 2026-01-01.
+  List<DateTime> dates(int count) => List.generate(
+        count,
+        (i) => DateTime.utc(2026, 1, 1).add(Duration(days: i)),
+      );
+
+  /// Categories the daily is allowed to use.
+  const accessible = {QuizCategory.stateName, QuizCategory.capital};
+  const flavour = {QuizCategory.nickname, QuizCategory.landmark};
+
+  group('DailyBriefing question set', () {
+    test('is always exactly ${DailyBriefing.questionCount} questions', () {
+      for (final date in dates(60)) {
+        final briefing = DailyBriefing.forDate(date);
+        expect(
+          briefing.questions.length,
+          DailyBriefing.questionCount,
+          reason: 'wrong question count on ${briefing.dateKey}',
+        );
+      }
+    });
+
+    test('has no duplicate answer areas', () {
+      for (final date in dates(60)) {
+        final briefing = DailyBriefing.forDate(date);
+        final codes = briefing.questions.map((q) => q.answerCode).toSet();
+        expect(
+          codes.length,
+          briefing.questions.length,
+          reason: 'duplicate answer area on ${briefing.dateKey}',
+        );
+      }
+    });
+
+    test('uses only name/capital plus at most one flavour question', () {
+      for (final date in dates(60)) {
+        final briefing = DailyBriefing.forDate(date);
+        final flavourCount = briefing.questions
+            .where((q) => flavour.contains(q.category))
+            .length;
+        expect(
+          flavourCount,
+          lessThanOrEqualTo(1),
+          reason: 'more than one flavour question on ${briefing.dateKey}',
+        );
+        if (flavourCount > 0) {
+          // Flavour clues only on well-known regions (tier <= 5).
+          expect(
+            briefing.level.requiredLevel,
+            lessThanOrEqualTo(5),
+            reason: 'flavour question on hard region ${briefing.level.id} '
+                '(${briefing.dateKey})',
+          );
+        }
+        for (final q in briefing.questions) {
+          expect(
+            accessible.contains(q.category) || flavour.contains(q.category),
+            isTrue,
+            reason: 'disallowed category ${q.category} on ${briefing.dateKey}',
+          );
+        }
+      }
+    });
+
+    test('obscure categories never appear across 60 consecutive dates', () {
+      const obscure = {
+        QuizCategory.stateFlower,
+        QuizCategory.stateBird,
+        QuizCategory.motto,
+        QuizCategory.sportsTeam,
+        QuizCategory.celebrity,
+        QuizCategory.filmSetting,
+        QuizCategory.flagDescription,
+        QuizCategory.mixed,
+      };
+      for (final date in dates(60)) {
+        final briefing = DailyBriefing.forDate(date);
+        for (final q in briefing.questions) {
+          expect(
+            obscure.contains(q.category),
+            isFalse,
+            reason: 'obscure category ${q.category} on ${briefing.dateKey}',
+          );
+        }
+      }
+    });
+
+    test('every question has clue text, answer code, and answer name', () {
+      for (final date in dates(60)) {
+        final briefing = DailyBriefing.forDate(date);
+        for (final q in briefing.questions) {
+          expect(q.clueText, isNotEmpty);
+          expect(q.answerCode, isNotEmpty);
+          expect(q.answerName, isNotEmpty);
+        }
+      }
+    });
+  });
+
+  group('DailyBriefing determinism', () {
+    test('two forDate calls yield identical briefings', () {
+      for (final date in dates(30)) {
+        final a = DailyBriefing.forDate(date);
+        final b = DailyBriefing.forDate(date);
+        expect(a.dateKey, b.dateKey);
+        expect(a.seed, b.seed);
+        expect(a.level.id, b.level.id);
+        expect(a.difficulty, b.difficulty);
+        expect(a.mode, b.mode);
+        expect(a.categories, b.categories);
+        expect(a.questions.length, b.questions.length);
+        for (var i = 0; i < a.questions.length; i++) {
+          expect(a.questions[i].category, b.questions[i].category);
+          expect(a.questions[i].clueText, b.questions[i].clueText);
+          expect(a.questions[i].answerCode, b.questions[i].answerCode);
+          expect(a.questions[i].labelFree, b.questions[i].labelFree);
+        }
+      }
+    });
+
+    test('time-of-day is ignored', () {
+      final morning = DailyBriefing.forDate(DateTime.utc(2026, 3, 14, 6, 30));
+      final night = DailyBriefing.forDate(DateTime.utc(2026, 3, 14, 23, 59));
+      expect(morning.seed, night.seed);
+      expect(morning.level.id, night.level.id);
+      expect(
+        morning.questions.map((q) => q.answerCode).toList(),
+        night.questions.map((q) => q.answerCode).toList(),
+      );
+    });
+  });
+
+  group('DailyBriefing label-free stretch questions', () {
+    test('counts match the region tier and sit at the end of the set', () {
+      for (final date in dates(120)) {
+        final briefing = DailyBriefing.forDate(date);
+        final expected = DailyBriefing.labelFreeCountForTier(
+          briefing.level.requiredLevel,
+        );
+        expect(
+          briefing.labelFreeCount,
+          expected,
+          reason: 'wrong blind count for ${briefing.level.id} '
+              '(${briefing.dateKey})',
+        );
+        // Only the trailing questions are label-free.
+        final total = briefing.questions.length;
+        for (var i = 0; i < total; i++) {
+          expect(
+            briefing.questions[i].labelFree,
+            i >= total - expected,
+            reason: 'labelFree misplaced at index $i on ${briefing.dateKey}',
+          );
+        }
+      }
+    });
+
+    test('tier thresholds: <9 gets 2, 9-14 gets 1, >=15 gets 0', () {
+      expect(DailyBriefing.labelFreeCountForTier(1), 2);
+      expect(DailyBriefing.labelFreeCountForTier(5), 2);
+      expect(DailyBriefing.labelFreeCountForTier(7), 2);
+      expect(DailyBriefing.labelFreeCountForTier(9), 1);
+      expect(DailyBriefing.labelFreeCountForTier(13), 1);
+      expect(DailyBriefing.labelFreeCountForTier(15), 0);
+      expect(DailyBriefing.labelFreeCountForTier(20), 0);
+    });
+  });
+
+  group('DailyBriefing conditions', () {
+    test('difficulty always shows labels; mode is untimed with no fail-out',
+        () {
+      for (final date in dates(60)) {
+        final briefing = DailyBriefing.forDate(date);
+        expect(briefing.difficulty.showLabels, isTrue);
+        expect(briefing.mode, QuizMode.allStates);
+        expect(briefing.mode.timeLimit, isNull);
+        expect(briefing.mode.maxWrong, isNull);
+      }
+    });
+
+    test('niche regions stay rare, well-known regions rotate', () {
+      const niche = {
+        'uk_counties',
+        'ireland',
+        'canada',
+        'oceania',
+        'caribbean'
+      };
+      var nicheDays = 0;
+      final seen = <String>{};
+      for (final date in dates(365)) {
+        final briefing = DailyBriefing.forDate(date);
+        seen.add(briefing.level.id);
+        if (niche.contains(briefing.level.id)) nicheDays++;
+      }
+      // Weighted at 5/33 (~15%); allow slack but stay near ~1 day in 7.
+      expect(nicheDays / 365, lessThan(0.25));
+      // The rotation genuinely varies regions.
+      expect(seen.length, greaterThanOrEqualTo(4));
+    });
+  });
+
+  group('QuizSession preset questions', () {
+    test('session uses the curated daily set verbatim', () {
+      final briefing = DailyBriefing.forDate(DateTime.utc(2026, 5, 1));
+      final session = QuizSession(
+        mode: briefing.mode,
+        categories: briefing.categories,
+        region: briefing.level.region,
+        difficulty: briefing.difficulty,
+        presetQuestions: briefing.questions,
+        seed: briefing.seed,
+      );
+      session.start();
+      expect(session.totalQuestions, DailyBriefing.questionCount);
+      expect(
+        session.currentQuestion?.answerCode,
+        briefing.questions.first.answerCode,
+      );
+      // Answering the first question correctly advances to the second.
+      final result = session.submitAnswer(briefing.questions.first.answerCode);
+      expect(result?.correct, isTrue);
+      expect(
+        session.currentQuestion?.answerCode,
+        briefing.questions[1].answerCode,
+      );
+    });
+
+    test('practice-mode questions default to labelFree false', () {
+      const question = QuizQuestion(
+        category: QuizCategory.stateName,
+        clueText: 'France',
+        answerCode: 'FR',
+        answerName: 'France',
+      );
+      expect(question.labelFree, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The daily briefing rolled level × category × mode uniformly, so days like "name all 50 state flowers" were legal — brutally hard and rarely completed. The tap-the-map mechanic was fine; the selection policy wasn't.

New deterministic daily policy (same for every player):
- **Region rotation with identity** — weighted seeded pick: Europe 8, US States 8, Africa/Asia/Latin America 4 each, niche regions (UK, Ireland, Canada, Oceania, Caribbean) 1 each ≈ one niche day per week combined. The lobby leads with the region.
- **Accessible categories only** — "Tap Tennessee" and "tap the state whose capital is Nashville"; well-known regions may swap in one nickname/landmark flavour question. Obscure categories (flowers, birds, mottos, celebrities, film, teams, flag descriptions) are structurally impossible in the daily — they remain in Flight School practice.
- **Exactly 6 questions**, untimed, no fail-out. `QuizSession` gains a `presetQuestions` path; the generator gains a public single-area builder. No country-difficulty filtering in daily sampling (avoids the `'CA'` state/Canada ISO collision).
- **Per-question label mixing** — new `QuizQuestion.labelFree`: easy regions end with 2 blind "stretch" questions, mid-tier regions 1, hard regions stay fully labeled. The map's label toggle hides on blind questions.
- **Lobby card** shows the real deal: region, intel type, "6 targets · no timer", "Labels on · N blind". Scoring, once-per-day gating, and the briefing leaderboard are unchanged (`category` column writes `mixed` for mixed sets).

Flight School practice, H2H, type-in, and Uncharted are untouched (preset path defaults off; `labelFree` defaults false).

## Verification
- 865/865 tests pass (13 new policy-pinning tests: count, category allowlist across 60 dates, determinism, labelFree tiers, niche-region rarity over 365 dates, preset session path)
- Analyzer 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiE4C1xWfrCFMKfbKQAgyi)_